### PR TITLE
Mini PR: Deprecate state_change_nodes

### DIFF
--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -167,7 +167,7 @@ class LoopEnterNode(Node):
     # keeping a list of state_change_nodes that we probably have to re-construct from the sql db.
     # Yifan's note: deprecating these state_change_nodes to instead have the StateChangeNode point to the LoopEnterNodes instead
     # this is cleaner for other StateChangeNodes use cases such as FunctionDefinition nodes.
-    state_change_nodes: List[StateChangeNode]
+    # state_change_nodes: List[StateChangeNode]
 
 
 # Not sure if we need the exit node, commenting out for now

--- a/tests/stub_data/graph_with_loops.py
+++ b/tests/stub_data/graph_with_loops.py
@@ -68,7 +68,6 @@ le = LoopEnterNode(
     session_id=session.uuid,
     # @Dhruv, please watch out for indentation oddities when you run into errors
     code="for x in range(9):\n\ta.append(x)\n\tb+=x",
-    state_change_nodes=[a_state_change, b_state_change]
 )
 
 x_id = get_new_id()


### PR DESCRIPTION
Deprecate state_change_nodes property of LoopEnterNode in favor of associating through the associated_node_id property (in StateChangeNode)