### PR TITLE
Execution Time Field

### DIFF
--- a/lineapy/app/routes.py
+++ b/lineapy/app/routes.py
@@ -81,16 +81,18 @@ def execute(artifact_id):
         version = 0
     version += 1
 
-    # create row in exec table
-    exec_orm = ExecutionORM(artifact_id=artifact_id, version=version)
-    lineadb.session.add(exec_orm)
-    lineadb.session.commit()
-
     # get graph and re-execute
     executor = Executor()
     program = lineadb.get_graph_from_artifact_id(artifact_id)
     context = lineadb.get_context(artifact.context)
-    executor.execute_program(program, context)
+    execution_time = executor.execute_program(program, context)
+
+    # create row in exec table
+    exec_orm = ExecutionORM(
+        artifact_id=artifact_id, version=version, execution_time=execution_time
+    )
+    lineadb.session.add(exec_orm)
+    lineadb.session.commit()
 
     # run through Graph nodes and write values to NodeValueORM with new version
     lineadb.write_node_values(program.nodes, version)

--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -116,7 +116,7 @@ class Execution(BaseModel):
     artifact_id: LineaID
     version: str
     timestamp: Optional[datetime]
-    execution_time: Optional[int]
+    execution_time: float
 
     class Config:
         orm_mode = True

--- a/lineapy/db/relational/schema/relational.py
+++ b/lineapy/db/relational/schema/relational.py
@@ -50,6 +50,7 @@ from sqlalchemy import (
     Table,
     DateTime,
     PickleType,
+    Float,
     types,
 )
 from sqlalchemy.dialects.mysql.base import MSBinary
@@ -166,7 +167,7 @@ class ExecutionORM(Base):  # type: ignore
     artifact_id = Column(LineaIDORM, ForeignKey("artifact.id"), primary_key=True)
     version = Column(Integer, primary_key=True)
     timestamp = Column(DateTime, nullable=True, default=datetime.utcnow)
-    execution_time = Column(Integer, nullable=True)
+    execution_time = Column(Float)
 
 
 class NodeValueORM(Base):  # type: ignore

--- a/lineapy/execution/executor.py
+++ b/lineapy/execution/executor.py
@@ -99,14 +99,14 @@ class Executor(GraphReader):
         """
         ...
 
-    def execute_program(self, program: Graph, context: SessionContext) -> int:
+    def execute_program(self, program: Graph, context: SessionContext) -> float:
         if context is not None:
             self.setup(context)
 
         start = time.time()
         self.walk(program, context.code)
         end = time.time()
-        return int(end - start)
+        return end - start
 
     def setup_context_for_node(
         self,

--- a/tests/util.py
+++ b/tests/util.py
@@ -84,7 +84,7 @@ def setup_value_test(test_db: RelationalLineaDB, mode: ExecutionMode):
     executor = Executor()
 
     # execute stub graph and write to database
-    executor.execute_program(stub_graph, context)
+    execution_time = executor.execute_program(stub_graph, context)
     test_db.write_context(context)
     test_db.write_nodes(stub_graph.nodes)
 
@@ -96,7 +96,9 @@ def setup_value_test(test_db: RelationalLineaDB, mode: ExecutionMode):
         date_created="1372944000",
     )
 
-    exec_orm = ExecutionORM(artifact_id=artifact.id, version=1)
+    exec_orm = ExecutionORM(
+        artifact_id=artifact.id, version=1, execution_time=execution_time
+    )
     test_db.session.add(exec_orm)
     test_db.session.commit()
 
@@ -127,7 +129,7 @@ def setup_image_test(test_db: RelationalLineaDB, mode: ExecutionMode):
     executor = Executor()
 
     # execute stub graph and write to database
-    executor.execute_program(stub_graph, context)
+    execution_time = executor.execute_program(stub_graph, context)
     test_db.write_context(context)
     test_db.write_nodes(stub_graph.nodes)
 
@@ -139,6 +141,8 @@ def setup_image_test(test_db: RelationalLineaDB, mode: ExecutionMode):
         date_created="1372944000",
     )
 
-    exec_orm = ExecutionORM(artifact_id=resize_call.id, version=1)
+    exec_orm = ExecutionORM(
+        artifact_id=resize_call.id, version=1, execution_time=execution_time
+    )
     test_db.session.add(exec_orm)
     test_db.session.commit()


### PR DESCRIPTION
Summary
- ``execution time`` records the time it took to execute a graph
- Added ``execution time`` field to Executions data
- Added ``execution time`` column to Executions table

Closes #128 