### PR TITLE
Write transformed code to temporary file

### DIFF
--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -57,7 +57,7 @@ def linea_cli(mode, session, file_name):
         report_error_to_user("Error: File does not appear to exist.")
     else:
         # Remove the file if we have no errors
-        os.unlink(transformed_code_file)
+        os.unlink(transformed_code_file.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, when running linea from the CLI, if there is an exception raised while executing the trace, then it can be hard to know where it came from. By writing to a temporary file, and compiling to bytecode first, then we can see a proper traceback, like:

```
Traceback (most recent call last):
  File "/usr/local/Caskroom/miniconda/base/envs/lineapy/bin/lineapy", line 33, in <module>
    sys.exit(load_entry_point('lineapy', 'console_scripts', 'lineapy')())
  File "/usr/local/Caskroom/miniconda/base/envs/lineapy/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Caskroom/miniconda/base/envs/lineapy/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/Caskroom/miniconda/base/envs/lineapy/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Caskroom/miniconda/base/envs/lineapy/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/Users/saul/p/lineapy/lineapy/cli/cli.py", line 51, in linea_cli
    exec(bytecode)
  File "/var/folders/xn/05ktz3056kqd9n8frgd6236h0000gn/T/tmp8869tov3", line 85, in <module>
    lineapy_tracer.call(function_name='load_private_data',
  File "/Users/saul/p/lineapy/lineapy/instrumentation/tracer.py", line 322, in call
    argument_nodes = create_argument_nodes(
  File "/Users/saul/p/lineapy/lineapy/instrumentation/tracer_util.py", line 39, in create_argument_nodes
    var_id = look_up_node_id_by_variable_name(a.name)
  File "/Users/saul/p/lineapy/lineapy/instrumentation/tracer.py", line 142, in look_up_node_id_by_variable_name
    raise UserError(
lineapy.utils.UserError: Trying to lookup variable cfg_data, which is not found. Note that this could be that you are trying to publish a variable assigned to a literal value.
```