### PR TITLE
Move CI checks into separate jobs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,13 +17,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      # https://github.com/actions/cache/blob/main/examples.md#python---pip
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirement*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           pip install -e . -r requirements.txt -r dev-requirements.txt -r test-requirement.txt


### PR DESCRIPTION
This should speed up CI time, since they can run in parallel, and it will also be easier to see which parts fail.

Closes #215