### PR TITLE
fixed the [:,:] and [:,1] cases.

### DIFF
--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -465,3 +465,6 @@ class Tracer:
                 self.literal(len(output_variables), {}),
             )
         return None
+
+    def none(self) -> LiteralNode:
+        return self.literal(None, {})

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -410,17 +410,28 @@ class NodeTransformer(ast.NodeTransformer):
         return left
 
     def visit_Slice(self, node: ast.Slice) -> CallNode:
-        none_node = self.tracer.literal(None, {})
-        slice_arguments = [
-            self.visit(node.lower) if node.lower else none_node,
-            self.visit(node.upper) if node.upper else none_node,
-        ]
-        if node.step is not None:
-            slice_arguments.append(self.visit(node.step))
+        stop_node = (
+            self.visit(node.upper) if node.upper else self.tracer.none()
+        )
+        # From https://docs.python.org/3/library/functions.html?highlight=slice#slice
+        # slice can be called in two ways:
+        # 1. slice(stop) when the start and step are None
+        if node.lower is None and node.step is None:
+            args = [stop_node]
+        # 2. slice(start, stop, [step]) otherwise
+        else:
+            start_node = (
+                self.visit(node.lower) if node.lower else self.tracer.none()
+            )
+            args = [start_node, stop_node]
+            if node.step:
+                step_node = self.visit(node.step)
+                args.append(step_node)
+
         return self.tracer.call(
             self.tracer.lookup_node(slice.__name__),
             extract_concrete_syntax_from_node(node),
-            *slice_arguments,
+            *args,
         )
 
     def visit_Subscript(self, node: ast.Subscript) -> CallNode:

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_pandas.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_pandas.py
@@ -16,10 +16,6 @@ session = SessionContext(
         ),
     ],
 )
-literal_4 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_2 = VariableNode(
     id=get_new_id(),
     session_id=session.id,
@@ -476,14 +472,11 @@ call_18 = CallNode(
                                                                             id=get_new_id(),
                                                                             session_id=session.id,
                                                                             positional_order=0,
-                                                                            value_node_id=literal_4.id,
-                                                                        ).id,
-                                                                        ArgumentNode(
-                                                                            id=get_new_id(),
-                                                                            session_id=session.id,
-                                                                            positional_order=1,
-                                                                            value_node_id=literal_4.id,
-                                                                        ).id,
+                                                                            value_node_id=LiteralNode(
+                                                                                id=get_new_id(),
+                                                                                session_id=session.id,
+                                                                            ).id,
+                                                                        ).id
                                                                     ],
                                                                     function_id=LookupNode(
                                                                         id=get_new_id(),

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_empty_slice.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_empty_slice.py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_1 = VariableNode(
     id=get_new_id(),
     session_id=session.id,
@@ -104,14 +100,11 @@ variable_1 = VariableNode(
                             id=get_new_id(),
                             session_id=session.id,
                             positional_order=0,
-                            value_node_id=literal_1.id,
-                        ).id,
-                        ArgumentNode(
-                            id=get_new_id(),
-                            session_id=session.id,
-                            positional_order=1,
-                            value_node_id=literal_1.id,
-                        ).id,
+                            value_node_id=LiteralNode(
+                                id=get_new_id(),
+                                session_id=session.id,
+                            ).id,
+                        ).id
                     ],
                     function_id=LookupNode(
                         id=get_new_id(),

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step.py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_1 = VariableNode(
     id=get_new_id(),
     session_id=session.id,
@@ -104,13 +100,19 @@ variable_1 = VariableNode(
                             id=get_new_id(),
                             session_id=session.id,
                             positional_order=0,
-                            value_node_id=literal_1.id,
+                            value_node_id=LiteralNode(
+                                id=get_new_id(),
+                                session_id=session.id,
+                            ).id,
                         ).id,
                         ArgumentNode(
                             id=get_new_id(),
                             session_id=session.id,
                             positional_order=1,
-                            value_node_id=literal_1.id,
+                            value_node_id=LiteralNode(
+                                id=get_new_id(),
+                                session_id=session.id,
+                            ).id,
                         ).id,
                         ArgumentNode(
                             id=get_new_id(),

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start_and_stop.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start_and_stop.py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_1 = VariableNode(
     id=get_new_id(),
     session_id=session.id,

--- a/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_assign_subscript[ls[1:2] = [1]].py
+++ b/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_assign_subscript[ls[1:2] = [1]].py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_2 = VariableNode(
     id=get_new_id(),
     session_id=session.id,

--- a/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_assign_subscript[ls[1:a] = [b]].py
+++ b/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_assign_subscript[ls[1:a] = [b]].py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 call_4 = CallNode(
     id=get_new_id(),
     session_id=session.id,

--- a/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_subscript[ls[1:2]].py
+++ b/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_subscript[ls[1:2]].py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 variable_2 = VariableNode(
     id=get_new_id(),
     session_id=session.id,

--- a/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_subscript[ls[1:a]].py
+++ b/tests/__snapshots__/test_node_transformer/TestNodeTransformer.test_visit_subscript[ls[1:a]].py
@@ -11,10 +11,6 @@ session = SessionContext(
     working_directory="dummy_linea_repo/",
     libraries=[],
 )
-literal_1 = LiteralNode(
-    id=get_new_id(),
-    session_id=session.id,
-)
 call_3 = CallNode(
     id=get_new_id(),
     session_id=session.id,


### PR DESCRIPTION
Closes #207.

I had to do this weird thing of explicitly passing in a `None` to make slice happy

```bash
>>> slice()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: slice expected at least 1 argument, got 0
>>> slice(None)
slice(None, None, None)
```

And it created some weird None nodes for cases that I didn't expect, e.g., for the test case
```python
ls=[1,2,3]
a=1
b=4
ls[1:a] = [b]
```

It created 
```
literal_1 = LiteralNode(
    id=get_new_id(),
    session_id=session.id,
)
```

Maybe @saulshanabrook can help me with taking another look... I traced the execution and didn't even see the `None` case visited but there is no other explanation for how it's generated...