### PR TITLE
Display code coverage during tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,22 @@ black --line-length 79 --check .
 pytest
 ```
 
+### Snapshots
+
 Some tests use use [`syrupy`](https://github.com/tophat/syrupy) for snapshot test, to make it easier to update generate code and graphs.
 If you mean to change the tracing or graph spec, or added a new test that uses it, then run `pytest --snapshot-update` to update the saved snapshots.
 
+### Code Coverage
+
+The code coverage statistics are printed after the tests finish. It also generates
+an HTML file which can be used to look line by line, what is covered and what is not.
+Open this with `open htmlcov/index.html` after the tests finish.
+
+### XFail
+
 Also we use [pytest's xfail](https://docs.pytest.org/en/latest/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail) to mark tests that are expected to fail, because of a known bug. To have them run anyway, run `--run-xfail`.
+
+### Inpsecting AST
 
 If you want to inspect the AST of some Python code for debugging, you can run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,10 @@ exclude = '__snapshots__'
 
 [tool.isort]
 profile = "black"
+
+[tool.coverage.run]
+# Trace which side of branches were taken
+# https://coverage.readthedocs.io/en/latest/branch.html#branch
+branch = true
+# Ignore coverage on app, since we are letting it rot
+omit = ["lineapy/app/*"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 norecursedirs = __snapshots__
 filterwarnings =
     ignore:A private pytest class or function was used.:pytest.PytestDeprecationWarning
+addopts = 
+    --cov-report html
+    --cov-report term:skip-covered
+    --cov=lineapy

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setup(
             "mypy",
             "pytest",
             "matplotlib",
+            "coverage[toml]",
+            "pytest-cov",
         ],
         "server": [
             "flask",


### PR DESCRIPTION
This PR adds support for including code coverage during the tests. It closes #214. 

It uses the [coverage](https://coverage.readthedocs.io/en/6.0/) and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) packages to generate the coverage information. 

It now displays this in the CLI output:

```
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/saul/p/lineapy, configfile: pytest.ini
plugins: subtests-0.5.0, mock-3.6.1, syrupy-1.4.5, anyio-3.3.2, cov-3.0.0
collected 115 items                                                                                                                                                               

tests/test_analyze_ast_scope.py ..........                                                                                                                                  [  8%]
tests/test_end_to_end.py ............x................xxxxx.......x...........                                                                                              [ 54%]
tests/test_flask_app.py .                                                                                                                                                   [ 55%]
tests/test_node_transformer.py ........XX............xXXXXXXXXxxx....x....x.....                                              [ 98%]
tests/test_script.py ..                                                                                                       [100%]

---------- coverage: platform darwin, python 3.9.7-final-0 -----------
Name                                               Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------------
lineapy/__init__.py                                   10      1      0      0    90%
lineapy/bytecode/__init__.py                          12     12      2      0     0%
lineapy/cli/cli.py                                    47      8     10      4    79%
lineapy/data/graph.py                                140     20     72      9    82%
lineapy/data/types.py                                171      1      4      1    99%
lineapy/db/asset_manager/base.py                      15      2      2      0    88%
lineapy/db/asset_manager/local.py                     32      3      8      1    90%
lineapy/db/asset_manager/s3.py                         7      7      0      0     0%
lineapy/db/base.py                                    53     10     10      2    81%
lineapy/db/relational/db.py                          228     53     96     16    73%
lineapy/execution/executor.py                        115     32     48      6    67%
lineapy/execution/scheduler.py                        15     15      0      0     0%
lineapy/graph_reader/graph_helper.py                   6      6      2      0     0%
lineapy/graph_reader/graph_printer.py                109      3     46      4    95%
lineapy/graph_reader/graph_util.py                    91     51     58      3    41%
lineapy/graph_reader/program_slice.py                 49      4     18      1    90%
lineapy/graph_writer/base.py                           3      3      0      0     0%
lineapy/instrumentation/tracer.py                    136     17     30      4    85%
lineapy/kernel/kernel.py                              24     24      2      0     0%
lineapy/lineabuiltins.py                              20      1      8      3    86%
lineapy/metadata_extractor/metadata_extractor.py      11     11      0      0     0%
lineapy/transformer/analyze_ast_scope.py              66      2     22      1    97%
lineapy/transformer/node_transformer.py              168     11     62     10    90%
lineapy/transformer/transformer.py                    20      2      4      2    83%
lineapy/utils.py                                     117     26     42      6    74%
------------------------------------------------------------------------------------
TOTAL                                               1931    325    558     73    80%

18 files skipped due to complete coverage.
Coverage HTML written to dir htmlcov


------------------------------------------------------ snapshot report summary ------------------------------------------------------
88 snapshots passed.
============================================ 92 passed, 13 xfailed, 10 xpassed in 24.74s ============================================
```

It also generates HTML files which can be used to browse line by line:

![Screen Shot 2021-10-04 at 2 32 10 PM](https://user-images.githubusercontent.com/1186124/135927689-7d403165-c647-4522-bd40-261fee0ae179.png)

This PR, unfortunately, doesn't display the coverage in the PR in anyway, instead relying on the author to test coverage and compare themselves locally.

I did find one plugin that could comment on your PR based on the test coverage (https://github.com/coroo/pytest-coverage-commentator), but I didn't really trust it and didn't want it to comment a ton of times. 

The more standard approach is to use some cloud SASS service (ala https://coveralls.io/ https://about.codecov.io/product/feature/source-code-coverage/ https://codeclimate.com/quality/ https://www.codacy.com/) but they seem to be charging money for non open source projects.

