### PR TITLE
Clean up graph printer

### DIFF
--- a/lineapy/data/graph.py
+++ b/lineapy/data/graph.py
@@ -142,7 +142,13 @@ class Graph(object):
         return Graph(nodes, self.session_context)
 
     def __str__(self):
-        return prettify(self.print())
+        return prettify(
+            self.print(
+                include_source_location=False,
+                include_id_field=True,
+                include_session=False,
+            )
+        )
 
     def __repr__(self):
         return prettify(self.print())

--- a/lineapy/graph_reader/graph_printer.py
+++ b/lineapy/graph_reader/graph_printer.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Iterable, cast
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST
 
-from lineapy.transformer.transformer_util import SYNTAX_KEY
-
 if TYPE_CHECKING:
     from lineapy.data.graph import Graph
 
@@ -105,10 +103,10 @@ class GraphPrinter:
                 )
 
             else:
-                self.id_to_attribute_name[node_id] = attr_name
                 yield f"{attr_name} = ("
                 yield from self.pretty_print_model(node)
                 yield ")"
+                self.id_to_attribute_name[node_id] = attr_name
 
     def pretty_print_model(self, model: BaseModel) -> Iterable[str]:
         yield f"{type(model).__name__}("
@@ -134,11 +132,13 @@ class GraphPrinter:
             v_str: str
             if k == "node_type":
                 continue
-            if k in SYNTAX_KEY and not self.include_source_location:
+            if k == "source_location" and not self.include_source_location:
                 continue
             if k == "id" and not self.include_id_field:
                 continue
             if k == "session_id" and not self.include_session:
+                continue
+            if (k == "positional_args" or k == "keyword_args") and not v:
                 continue
             if tp == LineaID and shape == SHAPE_LIST:
                 args = [self.lookup_id(id_) for id_ in v]

--- a/lineapy/transformer/transformer_util.py
+++ b/lineapy/transformer/transformer_util.py
@@ -4,8 +4,6 @@ import ast
 AST synthesizers used by node_transformers
 """
 
-SYNTAX_KEY = ["lineno", "col_offset", "end_lineno", "end_col_offset"]
-
 
 def create_lib_attributes(names: list[ast.alias]) -> dict[str, str]:
     return {

--- a/tests/__snapshots__/test_end_to_end/TestDelete.test_del_attribute.py
+++ b/tests/__snapshots__/test_end_to_end/TestDelete.test_del_attribute.py
@@ -43,10 +43,7 @@ call_2 = CallNode(
                 value="SimpleNamespace",
             ).id,
         ],
-        keyword_args={},
     ).id,
-    positional_args=[],
-    keyword_args={},
 )
 call_3 = CallNode(
     source_location=SourceLocation(
@@ -75,7 +72,6 @@ call_3 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )
 call_4 = CallNode(
     source_location=SourceLocation(
@@ -94,5 +90,4 @@ call_4 = CallNode(
             value="hi",
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestDelete.test_del_subscript.py
+++ b/tests/__snapshots__/test_end_to_end/TestDelete.test_del_subscript.py
@@ -42,7 +42,6 @@ call_2 = CallNode(
                     value=1,
                 ).id
             ],
-            keyword_args={},
         ).id,
         LiteralNode(
             source_location=SourceLocation(
@@ -55,5 +54,4 @@ call_2 = CallNode(
             value=0,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestDelete.test_set_attr.py
+++ b/tests/__snapshots__/test_end_to_end/TestDelete.test_set_attr.py
@@ -55,10 +55,7 @@ call_3 = CallNode(
                         value="SimpleNamespace",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
-            positional_args=[],
-            keyword_args={},
         ).id,
         LiteralNode(
             value="hi",
@@ -74,5 +71,4 @@ call_3 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestDictionary.test_basic_dict.py
+++ b/tests/__snapshots__/test_end_to_end/TestDictionary.test_basic_dict.py
@@ -45,7 +45,6 @@ call_3 = CallNode(
                     value=1,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             function_id=LookupNode(
@@ -73,8 +72,6 @@ call_3 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestDictionary.test_splatting.py
+++ b/tests/__snapshots__/test_end_to_end/TestDictionary.test_splatting.py
@@ -45,7 +45,6 @@ call_9 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             function_id=LookupNode(
@@ -73,7 +72,6 @@ call_9 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             function_id=LookupNode(
@@ -84,8 +82,6 @@ call_9 = CallNode(
                     function_id=LookupNode(
                         name="__build_dict_kwargs_sentinel__",
                     ).id,
-                    positional_args=[],
-                    keyword_args={},
                 ).id,
                 CallNode(
                     source_location=SourceLocation(
@@ -125,7 +121,6 @@ call_9 = CallNode(
                                     value=3,
                                 ).id,
                             ],
-                            keyword_args={},
                         ).id,
                         CallNode(
                             function_id=LookupNode(
@@ -153,13 +148,10 @@ call_9 = CallNode(
                                     value=3,
                                 ).id,
                             ],
-                            keyword_args={},
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             function_id=LookupNode(
@@ -187,8 +179,6 @@ call_9 = CallNode(
                     value=4,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_alias_by_reference.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_alias_by_reference.py
@@ -57,7 +57,6 @@ call_1 = CallNode(
             value=3,
         ).id,
     ],
-    keyword_args={},
 )
 call_3 = CallNode(
     source_location=SourceLocation(
@@ -84,7 +83,6 @@ call_3 = CallNode(
                 value="append",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LiteralNode(
@@ -98,7 +96,6 @@ call_3 = CallNode(
             value=4,
         ).id
     ],
-    keyword_args={},
 )
 literal_6 = LiteralNode(
     source_location=SourceLocation(
@@ -122,7 +119,6 @@ call_4 = CallNode(
         name="contains",
     ).id,
     positional_args=[call_1.id, literal_6.id],
-    keyword_args={},
 )
 call_6 = CallNode(
     source_location=SourceLocation(
@@ -148,10 +144,8 @@ call_6 = CallNode(
                 name="contains",
             ).id,
             positional_args=[call_1.id, literal_6.id],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )
 call_7 = CallNode(
     source_location=SourceLocation(
@@ -165,5 +159,4 @@ call_7 = CallNode(
         name="sum",
     ).id,
     positional_args=[call_1.id],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_assignment_destructuring.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_assignment_destructuring.py
@@ -40,7 +40,6 @@ call_1 = CallNode(
             value=2,
         ).id,
     ],
-    keyword_args={},
 )
 call_2 = CallNode(
     function_id=LookupNode(
@@ -52,7 +51,6 @@ call_2 = CallNode(
             value=0,
         ).id,
     ],
-    keyword_args={},
 )
 call_3 = CallNode(
     function_id=LookupNode(
@@ -64,5 +62,4 @@ call_3 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_binops.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_binops.py
@@ -54,7 +54,6 @@ call_1 = CallNode(
         name="add",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_2 = CallNode(
     source_location=SourceLocation(
@@ -68,7 +67,6 @@ call_2 = CallNode(
         name="sub",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_3 = CallNode(
     source_location=SourceLocation(
@@ -82,7 +80,6 @@ call_3 = CallNode(
         name="mul",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_4 = CallNode(
     source_location=SourceLocation(
@@ -96,7 +93,6 @@ call_4 = CallNode(
         name="truediv",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_5 = CallNode(
     source_location=SourceLocation(
@@ -110,7 +106,6 @@ call_5 = CallNode(
         name="floordiv",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_6 = CallNode(
     source_location=SourceLocation(
@@ -124,7 +119,6 @@ call_6 = CallNode(
         name="mod",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_7 = CallNode(
     source_location=SourceLocation(
@@ -138,7 +132,6 @@ call_7 = CallNode(
         name="pow",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_8 = CallNode(
     source_location=SourceLocation(
@@ -152,7 +145,6 @@ call_8 = CallNode(
         name="lshift",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_9 = CallNode(
     source_location=SourceLocation(
@@ -166,7 +158,6 @@ call_9 = CallNode(
         name="rshift",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_10 = CallNode(
     source_location=SourceLocation(
@@ -180,7 +171,6 @@ call_10 = CallNode(
         name="or_",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_11 = CallNode(
     source_location=SourceLocation(
@@ -194,7 +184,6 @@ call_11 = CallNode(
         name="xor",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_12 = CallNode(
     source_location=SourceLocation(
@@ -208,5 +197,4 @@ call_12 = CallNode(
         name="and_",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_chained_attributes.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_chained_attributes.py
@@ -55,13 +55,11 @@ call_3 = CallNode(
                         value="data_transformers",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             LiteralNode(
                 value="enable",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LiteralNode(
@@ -75,5 +73,4 @@ call_3 = CallNode(
             value="json",
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_chained_ops.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_chained_ops.py
@@ -65,7 +65,6 @@ call_3 = CallNode(
                             value=2,
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -78,8 +77,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_compareops.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_compareops.py
@@ -65,7 +65,6 @@ call_3 = CallNode(
                             value=2,
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -78,8 +77,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_conditionals.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_conditionals.py
@@ -70,7 +70,6 @@ else:
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         "len": LookupNode(
             name="len",

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_csv_import.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_csv_import.py
@@ -94,7 +94,6 @@ call_5 = CallNode(
                                     value="read_csv",
                                 ).id,
                             ],
-                            keyword_args={},
                         ).id,
                         positional_args=[
                             LiteralNode(
@@ -108,7 +107,6 @@ call_5 = CallNode(
                                 value="tests/simple_data.csv",
                             ).id
                         ],
-                        keyword_args={},
                     ).id,
                     LiteralNode(
                         source_location=SourceLocation(
@@ -121,14 +119,10 @@ call_5 = CallNode(
                         value="a",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             LiteralNode(
                 value="sum",
             ).id,
         ],
-        keyword_args={},
     ).id,
-    positional_args=[],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_dictionary_support.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_dictionary_support.py
@@ -78,7 +78,6 @@ call_8 = CallNode(
                                     value="DataFrame",
                                 ).id,
                             ],
-                            keyword_args={},
                         ).id,
                         positional_args=[
                             CallNode(
@@ -141,16 +140,12 @@ call_8 = CallNode(
                                                         value=2,
                                                     ).id,
                                                 ],
-                                                keyword_args={},
                                             ).id,
                                         ],
-                                        keyword_args={},
                                     ).id
                                 ],
-                                keyword_args={},
                             ).id
                         ],
-                        keyword_args={},
                     ).id,
                     LiteralNode(
                         source_location=SourceLocation(
@@ -163,14 +158,10 @@ call_8 = CallNode(
                         value="id",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             LiteralNode(
                 value="sum",
             ).id,
         ],
-        keyword_args={},
     ).id,
-    positional_args=[],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_end_to_end_simple_graph.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_end_to_end_simple_graph.py
@@ -45,5 +45,4 @@ call_1 = CallNode(
             value=11,
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_fake_attribute.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_fake_attribute.py
@@ -46,7 +46,6 @@ call_2 = CallNode(
                     value="imag",
                 ).id,
             ],
-            keyword_args={},
         ).id,
         LiteralNode(
             source_location=SourceLocation(
@@ -59,5 +58,4 @@ call_2 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_function_definition_without_side_effect.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_function_definition_without_side_effect.py
@@ -39,13 +39,11 @@ call_2 = CallNode(
                     value="foo",
                 ).id,
             ],
-            keyword_args={},
         ).id,
         LiteralNode(
             value=0,
         ).id,
     ],
-    keyword_args={},
 )
 call_3 = CallNode(
     source_location=SourceLocation(
@@ -56,7 +54,6 @@ call_3 = CallNode(
         source_code=source_1.id,
     ),
     function_id=call_2.id,
-    positional_args=[],
     keyword_args={
         "a": LiteralNode(
             source_location=SourceLocation(
@@ -111,5 +108,4 @@ call_4 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_graph_with_basic_image.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_graph_with_basic_image.py
@@ -67,7 +67,6 @@ call_5 = CallNode(
                 value="imsave",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LiteralNode(
@@ -116,7 +115,6 @@ call_5 = CallNode(
                         value="read_csv",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             positional_args=[
                 LiteralNode(
@@ -130,10 +128,8 @@ call_5 = CallNode(
                     value="tests/simple_data.csv",
                 ).id
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )
 call_9 = CallNode(
     source_location=SourceLocation(
@@ -184,7 +180,6 @@ call_9 = CallNode(
                             value="open",
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 positional_args=[
                     LiteralNode(
@@ -198,13 +193,11 @@ call_9 = CallNode(
                         value="simple_data.png",
                     ).id
                 ],
-                keyword_args={},
             ).id,
             LiteralNode(
                 value="resize",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         CallNode(
@@ -240,8 +233,6 @@ call_9 = CallNode(
                     value=200,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_import.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_import.py
@@ -40,7 +40,6 @@ call_4 = CallNode(
                 value="sqrt",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         CallNode(
@@ -61,7 +60,6 @@ call_4 = CallNode(
                         value="pow",
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             positional_args=[
                 LiteralNode(
@@ -85,8 +83,6 @@ call_4 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_import_name.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_import_name.py
@@ -60,7 +60,6 @@ call_3 = CallNode(
                             value="__name__",
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -73,8 +72,6 @@ call_3 = CallNode(
                     value="pandas",
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_logical_binops.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_logical_binops.py
@@ -47,7 +47,6 @@ call_1 = CallNode(
         name="eq",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_2 = CallNode(
     source_location=SourceLocation(
@@ -61,7 +60,6 @@ call_2 = CallNode(
         name="ne",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_3 = CallNode(
     source_location=SourceLocation(
@@ -75,7 +73,6 @@ call_3 = CallNode(
         name="lt",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_4 = CallNode(
     source_location=SourceLocation(
@@ -89,7 +86,6 @@ call_4 = CallNode(
         name="le",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_5 = CallNode(
     source_location=SourceLocation(
@@ -103,7 +99,6 @@ call_5 = CallNode(
         name="gt",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )
 call_6 = CallNode(
     source_location=SourceLocation(
@@ -117,5 +112,4 @@ call_6 = CallNode(
         name="ge",
     ).id,
     positional_args=[literal_1.id, literal_2.id],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_loop_code.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_loop_code.py
@@ -39,8 +39,6 @@ call_1 = CallNode(
     function_id=LookupNode(
         name="__build_list__",
     ).id,
-    positional_args=[],
-    keyword_args={},
 )
 call_2 = CallNode(
     source_location=SourceLocation(
@@ -96,7 +94,6 @@ call_3 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )
 call_6 = CallNode(
     source_location=SourceLocation(
@@ -122,7 +119,6 @@ call_6 = CallNode(
                 name="sum",
             ).id,
             positional_args=[call_1.id],
-            keyword_args={},
         ).id,
         CallNode(
             function_id=LookupNode(
@@ -134,8 +130,6 @@ call_6 = CallNode(
                     value=0,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_messy_nodes.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_messy_nodes.py
@@ -65,7 +65,6 @@ call_2 = CallNode(
         ).id,
         literal_1.id,
     ],
-    keyword_args={},
 )
 call_4 = CallNode(
     source_location=SourceLocation(
@@ -116,10 +115,8 @@ call_4 = CallNode(
                             value=2,
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
             ],
-            keyword_args={},
         ).id,
         LiteralNode(
             source_location=SourceLocation(
@@ -132,7 +129,6 @@ call_4 = CallNode(
             value=2,
         ).id,
     ],
-    keyword_args={},
 )
 literal_5 = LiteralNode(
     source_location=SourceLocation(

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_nested_call_graph.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_nested_call_graph.py
@@ -42,7 +42,6 @@ call_2 = CallNode(
                     value=11,
                 ).id
             ],
-            keyword_args={},
         ).id,
         LiteralNode(
             source_location=SourceLocation(
@@ -55,5 +54,4 @@ call_2 = CallNode(
             value=10,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_pandas.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_pandas.py
@@ -43,7 +43,6 @@ call_5 = CallNode(
                 value="DataFrame",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         CallNode(
@@ -91,7 +90,6 @@ call_5 = CallNode(
                             value=2,
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 CallNode(
                     source_location=SourceLocation(
@@ -126,13 +124,10 @@ call_5 = CallNode(
                             value=4,
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )
 call_8 = CallNode(
     source_location=SourceLocation(
@@ -178,20 +173,17 @@ call_8 = CallNode(
                         value=0,
                     ).id,
                 ],
-                keyword_args={},
             ).id,
             LiteralNode(
                 value="astype",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LookupNode(
             name="str",
         ).id
     ],
-    keyword_args={},
 )
 call_11 = CallNode(
     source_location=SourceLocation(
@@ -234,7 +226,6 @@ call_11 = CallNode(
                             value="size",
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -247,10 +238,8 @@ call_11 = CallNode(
                     value=4,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )
 call_18 = CallNode(
     source_location=SourceLocation(
@@ -317,7 +306,6 @@ call_18 = CallNode(
                                             value="iloc",
                                         ).id,
                                     ],
-                                    keyword_args={},
                                 ).id,
                                 CallNode(
                                     source_location=SourceLocation(
@@ -343,7 +331,6 @@ call_18 = CallNode(
                                                 name="slice",
                                             ).id,
                                             positional_args=[LiteralNode().id],
-                                            keyword_args={},
                                         ).id,
                                         LiteralNode(
                                             source_location=SourceLocation(
@@ -356,16 +343,13 @@ call_18 = CallNode(
                                             value=1,
                                         ).id,
                                     ],
-                                    keyword_args={},
                                 ).id,
                             ],
-                            keyword_args={},
                         ).id,
                         LiteralNode(
                             value="size",
                         ).id,
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -378,8 +362,6 @@ call_18 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_print.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_print.py
@@ -57,7 +57,6 @@ call_3 = CallNode(
                             value=11,
                         ).id
                     ],
-                    keyword_args={},
                 ).id,
                 LiteralNode(
                     source_location=SourceLocation(
@@ -70,8 +69,6 @@ call_3 = CallNode(
                     value=10,
                 ).id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_publish.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_publish.py
@@ -45,5 +45,4 @@ call_1 = CallNode(
             value=11,
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_simple.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_simple.py
@@ -30,5 +30,4 @@ call_1 = CallNode(
             value=11,
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_string_format.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_string_format.py
@@ -41,7 +41,6 @@ call_2 = CallNode(
                 value="format",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LiteralNode(
@@ -55,5 +54,4 @@ call_2 = CallNode(
             value="foo",
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_subscript.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_subscript.py
@@ -67,7 +67,6 @@ call_1 = CallNode(
             value=4,
         ).id,
     ],
-    keyword_args={},
 )
 call_2 = CallNode(
     source_location=SourceLocation(
@@ -103,7 +102,6 @@ call_2 = CallNode(
             value=1,
         ).id,
     ],
-    keyword_args={},
 )
 literal_7 = LiteralNode(
     source_location=SourceLocation(
@@ -140,7 +138,6 @@ call_3 = CallNode(
         ).id,
         literal_7.id,
     ],
-    keyword_args={},
 )
 call_6 = CallNode(
     source_location=SourceLocation(
@@ -188,7 +185,6 @@ call_6 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -213,10 +209,8 @@ call_6 = CallNode(
                     value=30,
                 ).id
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )
 call_9 = CallNode(
     source_location=SourceLocation(
@@ -255,7 +249,6 @@ call_9 = CallNode(
                 ).id,
                 literal_7.id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -280,8 +273,6 @@ call_9 = CallNode(
                     value=40,
                 ).id
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_subscript_call.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_subscript_call.py
@@ -42,7 +42,6 @@ call_3 = CallNode(
                     value=0,
                 ).id
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -67,8 +66,6 @@ call_3 = CallNode(
                     value=0,
                 ).id
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestListComprehension.test_depends_on_prev_value.py
+++ b/tests/__snapshots__/test_end_to_end/TestListComprehension.test_depends_on_prev_value.py
@@ -57,7 +57,6 @@ call_3 = CallNode(
                             value=3,
                         ).id
                     ],
-                    keyword_args={},
                 ).id
             },
         ).id,
@@ -65,5 +64,4 @@ call_3 = CallNode(
             value=0,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestListComprehension.test_returns_value.py
+++ b/tests/__snapshots__/test_end_to_end/TestListComprehension.test_returns_value.py
@@ -41,5 +41,4 @@ call_2 = CallNode(
             value=0,
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_empty_slice.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_empty_slice.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -76,8 +75,6 @@ call_3 = CallNode(
                 name="slice",
             ).id,
             positional_args=[LiteralNode().id],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_start.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_start.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -88,8 +87,6 @@ call_3 = CallNode(
                 ).id,
                 LiteralNode().id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -89,8 +88,6 @@ call_3 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -98,8 +97,6 @@ call_3 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start_and_stop.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_start_and_stop.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -107,8 +106,6 @@ call_3 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_stop.py
+++ b/tests/__snapshots__/test_end_to_end/TestSlicing.test_slice_with_step_and_stop.py
@@ -62,7 +62,6 @@ call_3 = CallNode(
                     value=3,
                 ).id,
             ],
-            keyword_args={},
         ).id,
         CallNode(
             source_location=SourceLocation(
@@ -98,8 +97,6 @@ call_3 = CallNode(
                     value=2,
                 ).id,
             ],
-            keyword_args={},
         ).id,
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_add.py
+++ b/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_add.py
@@ -38,7 +38,6 @@ call_2 = CallNode(
                 value="Decimal",
             ).id,
         ],
-        keyword_args={},
     ).id,
     positional_args=[
         LiteralNode(
@@ -52,7 +51,6 @@ call_2 = CallNode(
             value="3.1415926535897932384626433832795028841971",
         ).id
     ],
-    keyword_args={},
 )
 call_5 = CallNode(
     source_location=SourceLocation(
@@ -90,12 +88,9 @@ call_5 = CallNode(
                         name="pos",
                     ).id,
                     positional_args=[call_2.id],
-                    keyword_args={},
                 ).id,
                 call_2.id,
             ],
-            keyword_args={},
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_invert.py
+++ b/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_invert.py
@@ -31,5 +31,4 @@ call_1 = CallNode(
             value=1,
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_not.py
+++ b/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_not.py
@@ -31,5 +31,4 @@ call_1 = CallNode(
             value=1,
         ).id
     ],
-    keyword_args={},
 )

--- a/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_sub.py
+++ b/tests/__snapshots__/test_end_to_end/TestUnaryOp.test_sub.py
@@ -31,5 +31,4 @@ call_1 = CallNode(
             value=1,
         ).id
     ],
-    keyword_args={},
 )


### PR DESCRIPTION
* Fix not printing source location to use new arg name
* Remove old SYNTAX_KEY which is now unused
* Don't write empty args/kwargs
* Move id storage, so that if we display IDs they show their actual string
  values