### PR TITLE
Skip adding lineapy import to graph

### DIFF
--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -141,6 +141,8 @@ class NodeTransformer(ast.NodeTransformer):
         Similar to `visit_ImportFrom`, slightly different class syntax
         """
         for lib in node.names:
+            if lib.name == "lineapy":
+                continue
             self.tracer.trace_import(
                 lib.name,
                 self.get_source(node),

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_csv_import.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_csv_import.py
@@ -14,18 +14,6 @@ lineapy.linea_publish(s, "Graph With CSV Import")
 """,
     location=PosixPath("[source file path]"),
 )
-import_2 = ImportNode(
-    source_location=SourceLocation(
-        lineno=2,
-        col_offset=0,
-        end_lineno=2,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_5 = CallNode(
     source_location=SourceLocation(
         lineno=5,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_end_to_end_simple_graph.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_end_to_end_simple_graph.py
@@ -10,18 +10,6 @@ lineapy.linea_publish(a, \'testing artifact publish\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_graph_with_basic_image.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_graph_with_basic_image.py
@@ -19,18 +19,6 @@ lineapy.linea_publish(img, "Graph With Image")
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_5 = CallNode(
     source_location=SourceLocation(
         lineno=7,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_housing.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_housing.py
@@ -47,18 +47,6 @@ import_1 = ImportNode(
         name="altair",
     ),
 )
-import_5 = ImportNode(
-    source_location=SourceLocation(
-        lineno=6,
-        col_offset=0,
-        end_lineno=6,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_4 = CallNode(
     source_location=SourceLocation(
         lineno=8,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_loop_code.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_loop_code.py
@@ -16,18 +16,6 @@ lineapy.linea_publish(y, \'y\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,
@@ -84,7 +72,7 @@ call_2 = CallNode(
         ).id,
     },
 )
-call_3 = CallNode(
+call_4 = CallNode(
     function_id=LookupNode(
         name="getitem",
     ).id,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_messy_nodes.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_messy_nodes.py
@@ -19,18 +19,6 @@ lineapy.linea_publish(f, \'f\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 literal_1 = LiteralNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_publish.py
+++ b/tests/__snapshots__/test_end_to_end/TestEndToEnd.test_publish.py
@@ -10,18 +10,6 @@ lineapy.linea_publish(a, \'testing artifact publish\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_before_after_mutation.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_before_after_mutation.py
@@ -16,18 +16,6 @@ lineapy.linea_publish(after, \'after\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_delitem.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_delitem.py
@@ -12,18 +12,6 @@ lineapy.linea_publish(x, \'x\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_2 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_mutation.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_mutation.py
@@ -12,18 +12,6 @@ lineapy.linea_publish(x, \'x\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_mutation_of_view.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_mutation_of_view.py
@@ -14,18 +14,6 @@ lineapy.linea_publish(x, \'x\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_self_return_loop.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_self_return_loop.py
@@ -21,18 +21,6 @@ lineapy.linea_publish(clf, \'clf\')
 )
 import_1 = ImportNode(
     source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
-import_2 = ImportNode(
-    source_location=SourceLocation(
         lineno=2,
         col_offset=0,
         end_lineno=2,
@@ -63,7 +51,7 @@ call_5 = CallNode(
             name="getattr",
         ).id,
         positional_args=[
-            import_2.id,
+            import_1.id,
             LiteralNode(
                 value="array",
             ).id,
@@ -160,7 +148,7 @@ call_8 = CallNode(
             name="getattr",
         ).id,
         positional_args=[
-            import_2.id,
+            import_1.id,
             LiteralNode(
                 value="array",
             ).id,

--- a/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_view_of_view.py
+++ b/tests/__snapshots__/test_end_to_end/TestFunctionMutations.test_view_of_view.py
@@ -18,18 +18,6 @@ lineapy.linea_publish(z, \'z\')
 """,
     location=PosixPath("[source file path]"),
 )
-import_1 = ImportNode(
-    source_location=SourceLocation(
-        lineno=1,
-        col_offset=0,
-        end_lineno=1,
-        end_col_offset=14,
-        source_code=source_1.id,
-    ),
-    library=Library(
-        name="lineapy",
-    ),
-)
 call_1 = CallNode(
     source_location=SourceLocation(
         lineno=2,


### PR DESCRIPTION
We don't need to add the import of lineapy to the grpah, since
we are currently intercepting calls to publish before it gets
to the graph executor

Fixes #276 