### PR TITLE
Change docker build to only happen on main

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -4,8 +4,8 @@ name: Create, publish and test a Docker image
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: ["release"]
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
In order to save github action minutes, lets only run docker build on main, not on other branches. We could also only do it per tag: https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md