### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Report a bug in Linea
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Your code**:
+*What code did you try to trace with Linea?*
+
+```python
+...
+```
+
+**Issue:
+*What went wrong when trying to run this code?*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new feature for Linea
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.


### PR DESCRIPTION
Closes https://github.com/LineaLabs/lineapy/issues/315 by adding bug and feature issue templates for easier reporting.