### PR TITLE
test fix

### DIFF
--- a/tests/simple.py
+++ b/tests/simple.py
@@ -1,4 +1,4 @@
 import pandas as pd
 
-assets = pd.read_csv("tests/ames_train_cleaned.csv")
+assets = pd.read_csv("ames_train_cleaned.csv")
 assets["is_new"] = assets["Year_Built"] > 1970


### PR DESCRIPTION
# Description

We changed the code so that we cd into directory of the file, and that broke the `simple.py` case.

@saulshanabrook and I discussed maybe making the relative path behavior more consistent with that of Python's, but TBD.