### PR TITLE
fixes #377

### DIFF
--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -446,7 +446,7 @@ class NodeTransformer(ast.NodeTransformer):
             )
         else:
             raise ValueError(
-                "Subscript with ctx=ast.Load() should have been handled by"
+                "Subscript with ctx=ast.Store() should have been handled by"
                 " visit_Assign."
             )
 


### PR DESCRIPTION

# Description

Typo in the error message for visit_Subscript. `ast.Store()` is handled by `visit_Assign`, not `ast.Load()`.

Spotted while doing a quick walkthrough with Shardul.

Fixes #377 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

no test needed since it's just in the error message.