### PR TITLE
Separate templates of dag and task

### DIFF
--- a/lineapy/plugins/airflow.py
+++ b/lineapy/plugins/airflow.py
@@ -16,7 +16,7 @@ from airflow.utils.dates import days_ago
 from airflow.operators.python_operator import PythonOperator
 """
 
-AIRFLOW_MAIN_TEMPLATE = """
+AIRFLOW_DAG_TEMPLATE = """
 default_dag_args = {"owner": "airflow", "retries": 2, "start_date": days_ago(1)}
 
 dag = DAG(
@@ -26,9 +26,11 @@ dag = DAG(
     catchup=False,
     default_args=default_dag_args,
 )
+"""
 
-DAG_NAME = PythonOperator(
-    dag=dag, task_id=f"DAG_NAME_task", python_callable=DAG_NAME,
+AIRFLOW_TASK_TEMPLATE = """
+TASK_NAME = PythonOperator(
+    dag=dag, task_id=f"TASK_NAME_task", python_callable=TASK_NAME,
 )
 """
 
@@ -87,7 +89,8 @@ def slice_to_airflow(
             f"\n\tprint({variable})" if variable else ""
         )  # TODO What to do with artifact_var in a DAG?
         + "\n\n"
-        + AIRFLOW_MAIN_TEMPLATE.replace("DAG_NAME", func_name)
+        + AIRFLOW_DAG_TEMPLATE.replace("DAG_NAME", func_name)
+        + AIRFLOW_TASK_TEMPLATE.replace("TASK_NAME", func_name)
     )
     # Black lint
     black_mode = FileMode()


### PR DESCRIPTION

# Description

As a first step to #387 this separates `AIRFLOW_MAIN_TEMPLATE` to `AIRFLOW_DAG_TEMPLATE` and `AIRFLOW_TASK_TEMPLATE`.

This still uses string templates and not dicts and only one TASK, but as the task string is separate, we can make a list of them in a loop as a next step.

This would depend on actually producing multiple slices/artifacts (see #307)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
