### PR TITLE
Refactor inspect function slightly

### DIFF
--- a/lineapy/execution/inspect_function.py
+++ b/lineapy/execution/inspect_function.py
@@ -4,7 +4,7 @@ import operator
 import sys
 import types
 from dataclasses import dataclass
-from typing import Callable, Iterable, Union
+from typing import Any, Callable, Iterable, Union
 
 import joblib
 
@@ -23,101 +23,89 @@ def inspect_function(
     """
     if function == open:
         yield ImplicitDependencyValue(file_system)
-        return
-
-    if function == joblib.dump:
+    elif function == joblib.dump:
         yield MutatedValue(file_system)
-        return
-    if imported_module("pandas"):
-        import pandas
+    ##
+    # Pandas
+    ##
+    elif (
+        (pandas := try_import("pandas"))
+        and isinstance(function, types.MethodType)
+        and function.__name__ == "to_sql"
+        and isinstance(function.__self__, pandas.DataFrame)
+    ):
+        yield MutatedValue(db)
 
-        if (
-            isinstance(function, types.MethodType)
-            and function.__name__ == "to_sql"
-            and isinstance(function.__self__, pandas.DataFrame)
-        ):
-            yield MutatedValue(db)
-            return
+    elif (
+        isinstance(function, types.FunctionType)
+        and function.__name__ == "read_sql"
+        and function.__module__ == "pandas.io.sql"
+    ):
+        yield ImplicitDependencyValue(db)
 
-        if (
-            isinstance(function, types.FunctionType)
-            and function.__name__ == "read_sql"
-            and function.__module__ == "pandas.io.sql"
-        ):
-            yield ImplicitDependencyValue(db)
-            return
+    elif (
+        pandas
+        and isinstance(function, types.MethodType)
+        and function.__name__ == "to_csv"
+        and isinstance(function.__self__, pandas.DataFrame)
+    ):
+        yield MutatedValue(file_system)
 
-        if (
-            isinstance(function, types.MethodType)
-            and function.__name__ == "to_csv"
-            and isinstance(function.__self__, pandas.DataFrame)
-        ):
-            yield MutatedValue(file_system)
-            return
+    elif (
+        isinstance(function, types.FunctionType)
+        and function.__name__ == "read_csv"
+        and function.__module__ == "pandas.io.parsers.readers"
+    ):
+        yield ImplicitDependencyValue(file_system)
 
-        if (
-            isinstance(function, types.FunctionType)
-            and function.__name__ == "read_csv"
-            and function.__module__ == "pandas.io.parsers.readers"
-        ):
-            yield ImplicitDependencyValue(file_system)
-            return
+    ##
+    # PIL
+    ##
 
-    if imported_module("PIL.Image"):
-        from PIL.Image import Image
-
-        if (
-            isinstance(function, types.MethodType)
-            and function.__name__ == "save"
-            and isinstance(function.__self__, Image)
-        ):
-            yield MutatedValue(file_system)
-            return
-        if (
-            isinstance(function, types.FunctionType)
-            and (function.__name__ == "open")
-            and (function.__module__ == "PIL.Image")
-        ):
-            yield ImplicitDependencyValue(file_system)
-            return
-
-    if function == setattr:
+    elif (
+        (pil_image := try_import("PIL.Image"))
+        and isinstance(function, types.MethodType)
+        and function.__name__ == "save"
+        and isinstance(function.__self__, pil_image.Image)
+    ):
+        yield MutatedValue(file_system)
+    elif (
+        isinstance(function, types.FunctionType)
+        and (function.__name__ == "open")
+        and (function.__module__ == "PIL.Image")
+    ):
+        yield ImplicitDependencyValue(file_system)
+    elif function == setattr:
         # setattr(o, attr, value)
         yield MutatedValue(PositionalArg(0))
         if is_mutable(args[2]):
             yield ViewOfValues(PositionalArg(2), PositionalArg(0))
-        return
-    if function == getattr:
+    elif function == getattr:
         # getattr(o, attr)
         if is_mutable(args[0]) and is_mutable(result):
             yield ViewOfValues(PositionalArg(0), Result())
     # TODO: We should probably not use use setitem, but instead get particular
     # __setitem__ for class so we can differentiate based on type more easily?
-    if function == operator.setitem:
+    elif function == operator.setitem:
         # setitem(dict, key, value)
         yield MutatedValue(PositionalArg(0))
         if is_mutable(args[2]):
             yield ViewOfValues(PositionalArg(2), PositionalArg(0))
-        return
-
-    if function == operator.getitem:
+    elif function == operator.getitem:
         # getitem(dict, key)
         # If both are mutable, they are now views of one another!
         if is_mutable(args[0]) and is_mutable(result):
             yield ViewOfValues(PositionalArg(0), Result())
-            return
     if function == operator.delitem:
         # delitem(dict, key)
         yield MutatedValue(PositionalArg(0))
-        return
     if function == l_list:
         # l_build_list(x1, x2, ...)
         yield ViewOfValues(
             Result(),
             *(PositionalArg(i) for i, a in enumerate(args) if is_mutable(a)),
         )
-        return
-    if (
+    elif (
         isinstance(function, types.BuiltinMethodType)
         and function.__name__ == "append"
         and isinstance(function.__self__, list)
@@ -126,33 +114,29 @@ def inspect_function(
         yield MutatedValue(BoundSelfOfFunction())
         if is_mutable(args[0]):
             yield ViewOfValues(BoundSelfOfFunction(), PositionalArg(0))
-        return
-
-    if imported_module("sklearn"):
-        from sklearn.base import BaseEstimator
-
-        if (
-            isinstance(function, types.MethodType)
-            and function.__name__ == "fit"
-            and isinstance(function.__self__, BaseEstimator)
-        ):
-            # In res = clf.fit(x, y)
-            # cff is mutated, and we say that the res and the clf
-            # are views of each other, since mutating one will mutate the other
-            # since they are the same object.
-            yield MutatedValue(BoundSelfOfFunction())
-            yield ViewOfValues(BoundSelfOfFunction(), Result())
-            return
+    elif (
+        (sklearn_base := try_import("sklearn.base"))
+        and isinstance(function, types.MethodType)
+        and function.__name__ == "fit"
+        and isinstance(function.__self__, sklearn_base.BaseEstimator)
+    ):
+        # In res = clf.fit(x, y)
+        # cff is mutated, and we say that the res and the clf
+        # are views of each other, since mutating one will mutate the other
+        # since they are the same object.
+        yield MutatedValue(BoundSelfOfFunction())
+        yield ViewOfValues(BoundSelfOfFunction(), Result())
     # Note: Future functions might require normalizing the args/kwargs with
     # inspect.signature.bind(args, kwargs) first
-    return []
+    else:
+        return []
 
 
-def imported_module(name: str) -> bool:
+def try_import(name: str) -> Any:
     """
-    Returns true if we have imported this module before.
+    Returns the modules, if it has been imported already.
     """
-    return name in sys.modules
+    return sys.modules.get(name, None)
 
 
 def is_mutable(obj: object) -> bool:


### PR DESCRIPTION
# Description

This slightly refactor inspect function. It removes the nested conditionals, so that we can remove the return statements, by making our import logic an expression.

## Type of change

Cleanup

# How Has This Been Tested?

Existing tests should cover it!