### PR TITLE
make graphviz import optional

### DIFF
--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -16,7 +16,6 @@ from lineapy.logging import configure_logging
 from lineapy.plugins.airflow import sliced_aiflow_dag
 from lineapy.transformer.node_transformer import transform
 from lineapy.utils import prettify
-from lineapy.visualizer import Visualizer
 
 """
 We are using click because our package will likely already have a dependency on
@@ -99,6 +98,8 @@ def linea_cli(
     transform(code, file_name, tracer)
 
     if visualize:
+        from lineapy.visualizer import Visualizer
+
         Visualizer.for_public(tracer).render_pdf_file()
 
     if slice and not export_slice and not export_slice_to_airflow_dag:

--- a/lineapy/graph_reader/apis.py
+++ b/lineapy/graph_reader/apis.py
@@ -19,7 +19,6 @@ from lineapy.db.db import RelationalLineaDB
 from lineapy.db.relational import BaseNodeORM, SessionContextORM
 from lineapy.graph_reader.program_slice import get_program_slice
 from lineapy.plugins.airflow import slice_to_airflow
-from lineapy.visualizer import Visualizer
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +115,8 @@ class LineaArtifact:
         """
         Displays the graph for this artifact.
         """
+        from lineapy.visualizer import Visualizer
+
         display(
             Visualizer.for_public_node(
                 self._graph, self.node_id

--- a/lineapy/ipython.py
+++ b/lineapy/ipython.py
@@ -19,7 +19,6 @@ from lineapy.instrumentation.tracer import Tracer
 from lineapy.ipython_cell_storage import cleanup_cells, get_cell_path
 from lineapy.logging import configure_logging
 from lineapy.transformer.node_transformer import transform
-from lineapy.visualizer import Visualizer
 
 __all__ = ["_end_cell", "start", "stop", "visualize"]
 
@@ -64,6 +63,8 @@ class CellsExecutedState:
         """
         Returns a jupyter display object for the visualization
         """
+        from lineapy.visualizer import Visualizer
+
         return Visualizer.for_public(self.tracer).ipython_display_object()
 
 

--- a/lineapy/visualizer/__init__.py
+++ b/lineapy/visualizer/__init__.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
 
-import graphviz
+try:
+    import graphviz
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "graphviz is not installed, please install graphviz in your local environment to visualize artifacts"
+    ) from None
+
 from IPython.display import HTML, DisplayObject
 
 from lineapy.data.graph import Graph

--- a/lineapy/visualizer/graphviz.py
+++ b/lineapy/visualizer/graphviz.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Optional, Union
 
-import graphviz
+try:
+    import graphviz
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "graphviz is not installed, please install graphviz in your local environment to visualize artifacts"
+    ) from None
 
 from lineapy.data.types import NodeType
 from lineapy.visualizer.visual_graph import (


### PR DESCRIPTION
# Description

Currently when lineapy is imported in a project, it complains that graphviz is not installed (graphviz is a noted as an extra dependency and should not be _required_ to run lineapy in production). This PR makes it so that lineapy can be imported without graphviz installed in the env. ONLY when lineapy.visualize() or artifact.visualize() is called will it look for graphviz and raise an error if it is not found.

Fixes #416 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tested by importing lineapy in design partners repo.