### PR TITLE
revert to 3.9 python for demos etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.2
 # Pin syntax as Docker reccomens
 # https://docs.docker.com/language/python/build-images/#create-a-dockerfile-for-python
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 RUN apt-get update && apt-get -y install git graphviz make && \
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \


### PR DESCRIPTION
# Description

Had an issue where codespaces (airflow) would not start properly. this was due to flask app not behaving nicely with python 3.7. temp fix is to go back to 3.9 since we have figure out the dependency set for that.

Fixes N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
local dev container.