### PR TITLE
LIN-141 migrate non-code resources to manifest.in file instead of setup.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include lineapy *.jinja
+recursive-include lineapy *.annotations.yaml

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     license=LICENSE,
     classifiers=["Development Status :: 2 - Pre-Alpha"],
     packages=find_packages(),
-    package_data={"lineapy": ["*.yaml"]},
     # https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point
     entry_points={"console_scripts": ["lineapy=lineapy.cli.cli:linea_cli"]},
     install_requires=[


### PR DESCRIPTION
# Description

we currently have MANIFEST.IN that packages jinja files and setup.py that packages yaml files (in response to a bugfix). This PR merges the packaging directives for non-code files into the MANIFEST.IN

Fixes LIN-141

## Type of change

Please delete options that are not relevant.

N/A

# How Has This Been Tested?
Existing tests capture the scope of this PR.