### PR TITLE
test_inspect to_csv does not leave the csv file behind

### DIFF
--- a/tests/unit/execution/test_inspect_function.py
+++ b/tests/unit/execution/test_inspect_function.py
@@ -46,7 +46,7 @@ from lineapy.instrumentation.annotation_spec import (
         ),
         param(
             DataFrame.from_records([]).to_csv,
-            ("path"),
+            (["/dev/null"]),
             {},
             [
                 MutatedValue(


### PR DESCRIPTION
# Description

`https://github.com/LineaLabs/lineapy/blob/main/tests/unit/execution/test_inspect_function.py` is currently leaving a file named `p` after its run. The reason is because of `DataFrame.from_records([]).to_csv` call at line https://github.com/LineaLabs/lineapy/blob/a3a46441812d2254867e9aeee8c3f41204c55e1a/tests/unit/execution/test_inspect_function.py#L48

A bit annoying when running tests locally.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
