### PR TITLE
airflow unit tests

### DIFF
--- a/tests/unit/plugins/test_airflow.py
+++ b/tests/unit/plugins/test_airflow.py
@@ -1,0 +1,57 @@
+import pytest
+
+from lineapy.plugins.airflow import split_code_blocks
+
+
+@pytest.mark.parametrize(
+    "code, func_name, import_block, code_block, main_block",
+    [
+        (
+            """import numpy\na = 1""",
+            "abc",
+            "import numpy",
+            "def abc():\n\ta = 1",
+            'if __name__ == "__main__":\n\tprint(abc())',
+        ),
+        (
+            """from typing import (
+    Callable,
+    Dict,
+    Hashable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+a = 1
+""",
+            "abc",
+            """from typing import (
+    Callable,
+    Dict,
+    Hashable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)""",
+            "def abc():\n\ta = 1\n\t",
+            'if __name__ == "__main__":\n\tprint(abc())',
+        ),
+    ],
+    ids=[
+        "single_import",
+        "multi_line_import",
+    ],
+)
+def test_split_code_blocks(
+    code, func_name, import_block, code_block, main_block
+):
+    _import_block, _code_block, _main_block = split_code_blocks(
+        code, func_name
+    )
+    assert _import_block == import_block
+    assert _code_block == code_block
+    assert _main_block == main_block


### PR DESCRIPTION
# Description

```
root@a00bfa142b0d:/workspaces/lineapy# pytest --cov=lineapy.plugins --cov-report=term-missing tests/test_airflow.py tests/unit/plugins/test_airflow.py 
======================================================================= test session starts ========================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /workspaces/lineapy, configfile: pytest.ini
plugins: syrupy-1.4.5, cov-3.0.0, nbval-0.9.6, virtualenv-1.7.0, anyio-3.4.0, forked-1.4.0, shutil-1.7.0, xdist-2.5.0
collected 6 items / 1 deselected / 5 selected                                                                                                                      

tests/test_airflow.py ...                                                                                                                                    [ 60%]
tests/unit/plugins/test_airflow.py ..                                                                                                                        [100%]

========================================================================= warnings summary =========================================================================
tests/test_airflow.py::test_slice_airflow
tests/test_airflow.py::test_slice_airflow
tests/test_airflow.py::test_multiple_slices_airflow
tests/test_airflow.py::test_multiple_slices_airflow
tests/test_airflow.py::test_multiple_slices_airflow_with_task_dependencies
tests/test_airflow.py::test_multiple_slices_airflow_with_task_dependencies
  /usr/local/lib/python3.9/site-packages/sklearn/base.py:450: UserWarning: X does not have valid feature names, but RandomForestClassifier was fitted with feature names
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform linux, python 3.9.9-final-0 -----------
Name    Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------
---------------------------------------------------
TOTAL      49      0     10      0   100%

2 files skipped due to complete coverage.
Coverage HTML written to dir htmlcov

--------------------------------------------------------------------- snapshot report summary ----------------------------------------------------------------------
3 snapshots passed.
=========================================================== 5 passed, 1 deselected, 6 warnings in 8.06s ============================================================
````

Fixes https://linea.atlassian.net/browse/LIN-165

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
