### PR TITLE
Try fixing `KeyError: 'IPYTHONDIR'`

### DIFF
--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -196,24 +196,25 @@ def use_virtualenv(name: str):
     # Remove ipythondir set for all tests, so that they are not run with linea by default
     old_ipython_dir = os.environ["IPYTHONDIR"]
     del os.environ["IPYTHONDIR"]
-
-    if not virtualenv_dir.exists():
-        subprocess.run(
-            [
-                "python",
-                "-m",
-                "venv",
-                virtualenv_dir,
-            ],
-            check=True,
-        )
-        subprocess.run(
-            ["pip", "install", "-e", LINEAPY_DIR, *VIRTUAL_ENVS[name]],
-            check=True,
-        )
-    yield
-    os.environ["PATH"] = old_path
-    os.environ["IPYTHONDIR"] = old_ipython_dir
+    try:
+        if not virtualenv_dir.exists():
+            subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "venv",
+                    virtualenv_dir,
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["pip", "install", "-e", LINEAPY_DIR, *VIRTUAL_ENVS[name]],
+                check=True,
+            )
+        yield
+    finally:
+        os.environ["PATH"] = old_path
+        os.environ["IPYTHONDIR"] = old_ipython_dir
 
 
 def normalize_source(code: str) -> str:


### PR DESCRIPTION
# Description

This is an attempt to resolve this error @yifanwu had when running the new integration tests:

```
self = environ({'LANG': 'C.UTF-8', 'USER': 'ubuntu', 'LOGNAME': 'ubuntu', 'HOME': '/home/ubuntu', 'PATH': '/home/ubuntu/linea...LSE', 'PYTEST_CURRENT_TEST': 'tests/integration/test_slice.py::test_slice[pytorch-tutorial-intro-torchscript] (call)'})
key = 'IPYTHONDIR'

    def __getitem__(self, key):
        try:
            value = self._data[self.encodekey(key)]
        except KeyError:
            # raise KeyError with the original key value
>           raise KeyError(key) from None
E           KeyError: 'IPYTHONDIR'

../../anaconda3/envs/lineapy/lib/python3.9/os.py:679: KeyError
--------------------------------------------------------------------------------------------- snapshot report summary ----------------------------------------------------------------------------------------------

============================================================================================= short test summary info ==============================================================================================
FAILED tests/integration/test_slice.py::test_slice[xgboost_basic_walkthrough] - subprocess.CalledProcessError: Command '['lineapy', 'file', 'basic_walkthrough.py', "xgboost/demo/guide-python/basic_walkthrough....
FAILED tests/integration/test_slice.py::test_slice[numpy-mooreslaw] - KeyError: 'IPYTHONDIR'
FAILED tests/integration/test_slice.py::test_slice[numpy-mnist] - KeyError: 'IPYTHONDIR'
FAILED tests/integration/test_slice.py::test_slice[numpy-pong] - KeyError: 'IPYTHONDIR'
FAILED tests/integration/test_slice.py::test_slice[pytorch-vision-tensor-transform] - KeyError: 'IPYTHONDIR'
FAILED tests/integration/test_slice.py::test_slice[pytorch-tutorial-intro-torchscript] - KeyError: 'IPYTHONDIR'
```

I believe the problem was that the first test, `tests/integration/test_slice.py::test_slice[xgboost_basic_walkthrough]`, failed when trying to create the virtualenv, and the context manager didn't clean up properly. So then, when the next tests are run, the `IPYTHONDIR` was not set (it was supposed to be set on the contextmanager cleanup), so they also fail.  I folllowed the [`contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager) to properly cleanup.

@yifanwu can you test running this locally and see if this fixes the `IPTYHONDIR` problem?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The existing tests should make sure it does not degrade current behavior. Waiting for @yifanwu to test manually locally.