### PR TITLE
Add global logging config

### DIFF
--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -23,7 +23,10 @@ from lineapy.graph_reader.apis import LineaArtifact
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.plugins.airflow import sliced_airflow_dag
 from lineapy.transformer.node_transformer import transform
-from lineapy.utils.logging_config import configure_logging
+from lineapy.utils.logging_config import (
+    LOGGING_ENV_VARIABLE,
+    configure_logging,
+)
 from lineapy.utils.utils import prettify
 
 """
@@ -35,8 +38,16 @@ logger = logging.getLogger(__name__)
 
 
 @click.group()
-def linea_cli():
-    pass
+@click.option(
+    "--verbose",
+    help="Print out logging for graph creation and execution",
+    is_flag=True,
+)
+def linea_cli(verbose: bool):
+    # Set the logging env variable so its passed to subprocesses, like creating a jupyter kernel
+    if verbose:
+        os.environ[LOGGING_ENV_VARIABLE] = "DEBUG"
+    configure_logging()
 
 
 @linea_cli.command()
@@ -193,11 +204,6 @@ def generate_save_code(
     is_flag=True,
 )
 @click.option(
-    "--verbose",
-    help="Print out logging for graph creation and execution",
-    is_flag=True,
-)
-@click.option(
     "--visualize",
     help="Visualize the resulting graph with Graphviz",
     is_flag=True,
@@ -215,11 +221,9 @@ def python(
     airflow_task_dependencies: str,
     print_source: bool,
     print_graph: bool,
-    verbose: bool,
     visualize: bool,
 ):
     set_custom_excepthook()
-    configure_logging("INFO" if verbose else "WARNING")
     tree = rich.tree.Tree(f"📄 {file_name}")
 
     db = RelationalLineaDB.from_environment(db_url)

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -101,8 +101,7 @@ def input_transformer_post(lines: List[str]) -> List[str]:
     code = "".join(lines)
     # If we have just started, first start everything up
     if isinstance(STATE, StartedState):
-        # Configure logging so that we the linea db prints it has connected.
-        configure_logging("INFO")
+        configure_logging()
         db = RelationalLineaDB.from_environment(STATE.db_url)
         # pass in globals from ipython so that `get_ipthon()` works
         # and things like `!cat df.csv` work in the notebook

--- a/lineapy/utils/logging_config.py
+++ b/lineapy/utils/logging_config.py
@@ -6,6 +6,7 @@ want to mess up others logging configuration.
 """
 
 import logging
+import os
 
 from rich.logging import RichHandler
 
@@ -14,7 +15,13 @@ from rich.logging import RichHandler
 FORMAT = "%(message)s"
 
 
-def configure_logging(level="WARNING", LOG_SQL=False):
+LOGGING_ENV_VARIABLE = "LINEA_LOG_LEVEL"
+
+
+def configure_logging(level=None, LOG_SQL=False):
+    # Get the loglevel from `LOGGING_ENV_VARIABLE` or set to INFO
+    # if not defined
+    level = level or os.environ.get(LOGGING_ENV_VARIABLE, "INFO")
     # Disable black logging
     # https://github.com/psf/black/issues/2058
     logging.getLogger("blib2to3").setLevel(logging.ERROR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_logging():
-    configure_logging("INFO")
+    configure_logging()
 
 
 class PythonSnapshotExtension(SingleFileSnapshotExtension):


### PR DESCRIPTION
# Description

This change allows you to set the logging via the CLI and via an env variable. It makes the `--verbose` flag global to all commands.

For example:

```
lineapy --verbose file tmp.py x x
```

You can also set it by env variable to achieve the same thing:

```
env LINEA_LOG_LEVEL=DEBUG lineapy file tmp.py x x
```

## Type of change

Updates our CLI commands

# How Has This Been Tested?

Manually locally