### PR TITLE
Add integration tests docs

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -21,6 +21,9 @@ The tests have the `integration` mark so that they are not run by default. So to
 
 Also, all the tests which have failing slices, are currently marked as xfailed, so will not raise errors by default. If you do want to see the errors, you can use `--runxfail` and use `-vv` to print out the full diff.
 
+Most tests do succeed in producing a slice, but the slice just happens to be wrong, so they are marked with `raises=AssertionError`. This is so that pytest knows they should only fail there, not at an earlier step. However,
+some tests don't succeed in even producing a slice, and those are just marked `xfail` without a reason.
+
 So if you wanted to say run the `numpy-mnist` test to see how the written slice
 differs from the generated slice, you could do:
 


### PR DESCRIPTION
# Description

This PR adds a README to the integration tests, to explain more how they work, how to run them, and how to add to them.

I was originally going to also go through and cleanup each sliced file to make it more succinct, but I wasn't sure if made sense, in case we later wanted to go back and uncomment parts that we later on thought are necessary? Like assert statements or prints. But open to doing that in a follow up if you think it would be worth it!

I also had a few minor changes that I could do, but I didn't want to do them and conflict with any tests @yifanwu might be working on, so I held off for now and documented them at the bottom of the file. 

## Type of change

Documentation.

# How Has This Been Tested?

No code changes, I tested the commands I put in the README manually.