### PR TITLE
Demo3 - Pipeline with several steps

### DIFF
--- a/examples/Demo_3_Multistep_pipeline.ipynb
+++ b/examples/Demo_3_Multistep_pipeline.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "from lineapy.plugins.airflow import to_airflow"
+    "import lineapy"
    ]
   },
   {
@@ -101,64 +101,31 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "from lineapy.db.relational import BaseNodeORM, SessionContextORM\n",
-    "node_orm = (\n",
-    "    preprocessing_art.db.session.query(BaseNodeORM)\n",
-    "    .filter(BaseNodeORM.id == preprocessing_art.node_id)\n",
-    "    .one()\n",
-    ")\n",
-    "session_orm = (\n",
-    "    preprocessing_art.db.session.query(SessionContextORM)\n",
-    "    .filter(SessionContextORM.id == node_orm.session_id)\n",
-    "    .one()\n",
-    ")\n",
-    "working_dir = Path(session_orm.working_directory)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added Airflow DAG named 'data_housing_pipeline'. Start a run from the Airflow UI or CLI.\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
-       "2609"
+       "PosixPath('/usr/src/airflow_home/dags/data_housing_pipeline.py')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from os import environ\n",
-    "\n",
-    "airflow_code = to_airflow(\n",
+    "lineapy.to_airflow(\n",
     "    {preprocessing_art.name: preprocessing_art.code, modeling_art.name: modeling_art.code}, \n",
-    "    \"data_housing_pipeline\", working_dir,\n",
+    "    \"data_housing_pipeline\",\n",
     "    \"data_housing_pipeline_cleaned_data_housing >> data_housing_pipeline_linea_model_housing\"\n",
-    ")\n",
-    "filename = None\n",
-    "if filename:\n",
-    "    path = Path(filename)\n",
-    "else:\n",
-    "    # Save dag to dags folder in airflow home\n",
-    "    # Otherwise default to default airflow home in home directory\n",
-    "    path = (\n",
-    "        (\n",
-    "            Path(environ[\"AIRFLOW_HOME\"])\n",
-    "            if \"AIRFLOW_HOME\" in environ\n",
-    "            else Path.home() / \"airflow\"\n",
-    "        )\n",
-    "        / \"dags\"\n",
-    "        / f\"data_housing_pipeline.py\"\n",
-    "    )\n",
-    "path.parent.mkdir(parents=True, exist_ok=True)\n",
-    "path.write_text(airflow_code)"
+    ")"
    ]
   },
   {

--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -1,6 +1,6 @@
 import atexit
 
-from lineapy.api.api import catalog, get, save
+from lineapy.api.api import catalog, get, save, to_airflow
 from lineapy.data.graph import Graph
 from lineapy.data.types import SessionType, ValueType
 from lineapy.editors.ipython import start, stop, visualize
@@ -14,6 +14,7 @@ __all__ = [
     "save",
     "get",
     "catalog",
+    "to_airflow",
     "SessionType",
     "ValueType",
     "_is_executing",

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -5,16 +5,21 @@ User facing APIs.
 import pickle
 import types
 from datetime import datetime
+from os import environ
+from pathlib import Path
+from typing import Dict
 
 from lineapy.data.types import Artifact, NodeValue
+from lineapy.db.relational import SessionContextORM
 from lineapy.exceptions.db_exceptions import ArtifactSaveException
 from lineapy.execution.context import get_context
 from lineapy.graph_reader.apis import LineaArtifact, LineaCatalog
+from lineapy.plugins import airflow as airflow_plugin
 from lineapy.utils.utils import get_value_type
 
 """
 Dev notes: We should keep these external APIs as small as possible, and unless
-there is a very compelling use case, not support more than 
+there is a very compelling use case, not support more than
 one way to access the same feature.
 """
 
@@ -165,3 +170,53 @@ def catalog() -> LineaCatalog:
     """
     execution_context = get_context()
     return LineaCatalog(execution_context.executor.db)
+
+
+def to_airflow(
+    artifacts_code: Dict[str, str],
+    dag_name: str,
+    task_dependencies: str = "",
+) -> Path:
+    """
+    Writes the airflow job to a path on disk.
+
+    :param artifacts_code: map of artifact names to be included in the DAG to their source code.
+    :param dag_name: name of the DAG and corresponding functions and task prefixes,
+    i.e. "sliced_housing_dag"
+    :param airflow_task_dependencies: task dependencies in Airflow format,
+    i.e. "'p value' >> 'y'" or "'p value', 'x' >> 'y'". Put slice names under single quotes.
+    This translates to "sliced_housing_dag_p >> sliced_housing_dag_y"
+    and "sliced_housing_dag_p,sliced_housing_dag_x >> sliced_housing_dag_y".
+    Here "sliced_housing_dag_p" and "sliced_housing_dag_x" are independent tasks
+    and "sliced_housing_dag_y" depends on them.
+    :return: string containing the path of the Airflow DAG file that was exported.
+    """
+    execution_context = get_context()
+    db = execution_context.executor.db
+    session_orm = db.session.query(SessionContextORM).all()
+    working_dir = (
+        Path(session_orm[0].working_directory)
+        if len(session_orm) > 0
+        else Path.home()
+    )
+
+    airflow_code = airflow_plugin.to_airflow(
+        artifacts_code, dag_name, working_dir, task_dependencies
+    )
+    # Save dag to dags folder in airflow home
+    # Otherwise default to default airflow home in home directory
+    path = (
+        (
+            Path(environ["AIRFLOW_HOME"])
+            if "AIRFLOW_HOME" in environ
+            else Path.home() / "airflow"
+        )
+        / "dags"
+        / f"{dag_name}.py"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(airflow_code)
+    print(
+        f"Added Airflow DAG named '{dag_name}'. Start a run from the Airflow UI or CLI."
+    )
+    return path


### PR DESCRIPTION
# Description

Adds Demo_3_Multistep_pipeline.ipynb demo notebook, which combines Demo_1_Preprocessing.ipynb and Demo_2_Modeling.ipynb in one multi (exactly 2) step ML Pipeline.

<img width="1786" alt="Screen Shot 2022-02-01 at 7 41 47 PM" src="https://user-images.githubusercontent.com/1968182/152089875-3ea43fc6-5383-4169-915e-38fed7ead9c7.png">

Had to create a new API call `lineapy.to_airflow()` under the "root" API (https://github.com/LineaLabs/lineapy/blob/main/lineapy/api/api.py).
The reason is https://github.com/LineaLabs/lineapy/blob/e4a74fd1b783250c341397cbb5a1aae13d98909f/lineapy/graph_reader/apis.py#L69 method is under the artifact class, but in this case we are building DAG from several artifacts.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
