### PR TITLE
LIN-244 fix warning on visualize

### DIFF
--- a/lineapy/visualizer/__init__.py
+++ b/lineapy/visualizer/__init__.py
@@ -36,12 +36,10 @@ class Visualizer:
         """
         Renders a PDF file for the graph and tries to open it.
         """
-        self.digraph.render(filename, view=True, format="pdf", quiet=True)
+        self.digraph.render(filename, view=True, format="pdf")
 
     def render_svg(self) -> str:
-        return optimize_svg(
-            self.digraph.pipe(format="svg", quiet=True).decode()
-        )
+        return optimize_svg(self.digraph.pipe(format="svg").decode())
 
     def ipython_display_object(self) -> DisplayObject:
         svg_text = self.render_svg()

--- a/lineapy/visualizer/graphviz.py
+++ b/lineapy/visualizer/graphviz.py
@@ -240,7 +240,7 @@ def node_type_to_kwargs(
 ) -> Dict[str, object]:
     if isinstance(node_type, SourceLineType):
         return {
-            "shape": "text",
+            "shape": "plaintext",
             "fontcolor": color(FONT_COLOR, highlighted),
         }
     return {


### PR DESCRIPTION
# Description

text isnt a supported shape. that is why we were getting the warning changed it to plaintext to hide it.

Fixes LIN-244

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
running notebooks in python 3.7 and python 3.9 and called visualize