### PR TITLE
fix cli bug

### DIFF
--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -192,7 +192,7 @@ def generate_save_code(
 )
 @click.option(
     "--airflow-task-dependencies",
-    default=None,
+    default="",
     help="Optional flag for --airflow. Specifies tasks dependencies in Airflow format, i.e. 'p value' >> 'y' or 'p value', 'x' >> 'y'. Put slice names under single quotes.",
 )
 @click.option(


### PR DESCRIPTION
# Description

task dependencies default to null and are operated upon without a null check. defaulting to an empty string.

Fixes LIN-201

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
cli command mentioned in LIN-201 works.