### PR TITLE
Add additional inspect function unit tests

### DIFF
--- a/tests/unit/execution/test_inspect_function.py
+++ b/tests/unit/execution/test_inspect_function.py
@@ -1,16 +1,26 @@
 """
 Tests FunctionInspector().inspect to verify the right side effects are the same.
 """
+from operator import setitem
+
+import numpy
+import pandas
 from pandas import DataFrame
 from pytest import fixture, mark, param
+from sklearn.ensemble import RandomForestClassifier
+from sqlalchemy import create_engine
 
 from lineapy.execution.inspect_function import FunctionInspector
 from lineapy.instrumentation.annotation_spec import (
+    BoundSelfOfFunction,
     ExternalState,
+    ImplicitDependencyValue,
     MutatedValue,
     PositionalArg,
+    Result,
     ViewOfValues,
 )
+from lineapy.utils.lineabuiltins import l_list
 
 
 @mark.parametrize(
@@ -46,7 +56,7 @@ from lineapy.instrumentation.annotation_spec import (
         ),
         param(
             DataFrame.from_records([]).to_csv,
-            (["/dev/null"]),
+            ["/dev/null"],
             {},
             [
                 MutatedValue(
@@ -55,6 +65,103 @@ from lineapy.instrumentation.annotation_spec import (
             ],
             id="to_csv",
         ),
+        param(
+            set().add,
+            (1,),
+            {},
+            [
+                MutatedValue(
+                    mutated_value=BoundSelfOfFunction(self_ref="SELF_REF")
+                )
+            ],
+            id="set.add",
+        ),
+        param(
+            RandomForestClassifier().fit,
+            [[[1]], [2]],
+            {},
+            [
+                MutatedValue(
+                    mutated_value=BoundSelfOfFunction(self_ref="SELF_REF")
+                ),
+                ViewOfValues(
+                    views=[
+                        BoundSelfOfFunction(self_ref="SELF_REF"),
+                        Result(result="RESULT"),
+                    ]
+                ),
+            ],
+            id="clf.fit",
+        ),
+        param(
+            setitem,
+            [{}, 1, []],
+            {},
+            [
+                MutatedValue(
+                    mutated_value=PositionalArg(positional_argument_index=0),
+                ),
+                ViewOfValues(
+                    views=[
+                        PositionalArg(positional_argument_index=2),
+                        PositionalArg(positional_argument_index=0),
+                    ]
+                ),
+            ],
+            id="setitem",
+        ),
+        param(
+            pandas.read_csv,
+            ["tests/simple_data.csv"],
+            {},
+            [
+                ImplicitDependencyValue(
+                    dependency=ExternalState(external_state="file_system")
+                )
+            ],
+            id="read_csv",
+        ),
+        param(
+            pandas.read_csv("tests/simple_data.csv").drop,
+            [0],
+            {"inplace": True},
+            [
+                MutatedValue(
+                    mutated_value=BoundSelfOfFunction(self_ref="SELF_REF")
+                )
+            ],
+            id="inplace true",
+        ),
+        param(
+            pandas.read_csv("tests/simple_data.csv").drop,
+            [0],
+            {"inplace": False},
+            [],
+            id="inplace false",
+        ),
+        param(
+            l_list,
+            [[], []],
+            {},
+            [
+                ViewOfValues(
+                    views=[
+                        Result(result="RESULT"),
+                        PositionalArg(positional_argument_index=0),
+                        PositionalArg(positional_argument_index=1),
+                    ]
+                ),
+            ],
+            id="inplace false",
+        ),
+        param(
+            pandas.DataFrame({"name": ["User 1", "User 2", "User 3"]}).to_sql,
+            ["users"],
+            {"con": create_engine("sqlite://", echo=False)},
+            [MutatedValue(mutated_value=ExternalState(external_state="db"))],
+            id="to_sql",
+        ),
+        param(numpy.add, [1, 2], {}, [], id="ufunc"),
     ],
 )
 def test_inspect(


### PR DESCRIPTION

# Description

I have added some additional unit tests for inspect function, to assist
in refactoring it.

With these changes, the unit tests for inspect function now cover all the same lines
as the integration tests, 91% of the inspect_function.py file.

The uncovered lines are mainly warnings.


## Type of change

Adds tests

# How Has This Been Tested?

Adds tests
