### PR TITLE
fix issue with higher version of click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         name: black
         entry: black .
         language: python
-        additional_dependencies: ["black==21.10b0"]
+        additional_dependencies: ["black==21.10b0", "click<=8.0.4"]
         types: [python]
         pass_filenames: false
   - repo: local


### PR DESCRIPTION
# Description

ref: https://github.com/dask/distributed/issues/6013

alternate fix will be to update black to be above 22.3 as mentioned here: https://github.com/Clinical-Genomics/cgbeacon2/pull/221
but that will cause more issues in the immediate term.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
N/A