### PR TITLE
added boundary checking for stack access

### DIFF
--- a/lineapy/system_tracing/_op_stack.py
+++ b/lineapy/system_tracing/_op_stack.py
@@ -3,7 +3,7 @@ Modified from https://gist.github.com/crusaderky/cf0575cfeeee8faa1bb1b3480bc4a87
 to remove all feature besides getting items from the top of the stack.
 """
 import sys
-from ctypes import POINTER, Structure, c_ssize_t, c_void_p, py_object
+from ctypes import POINTER, Structure, c_ssize_t, c_void_p, py_object, sizeof
 from types import FrameType
 from typing import Any, Tuple
 
@@ -12,7 +12,7 @@ __all__ = ("OpStack",)
 
 class Frame(Structure):
     """
-    ctypes Structre (https://docs.python.org/3/library/ctypes.html#structures-and-unions) for a Python frame
+    ctypes Structure (https://docs.python.org/3/library/ctypes.html#structures-and-unions) for a Python frame
     object, so we can access the top of the stack.
     """
 
@@ -37,11 +37,28 @@ if sys.flags.debug:
         ("_ob_prev", POINTER(py_object)),
     ) + Frame._fields_
 
+PTR_SIZE = sizeof(POINTER(py_object))
+F_VALUESTACK_OFFSET = sizeof(Frame) - 2 * PTR_SIZE
+F_STACKTOP_OFFSET = sizeof(Frame) - PTR_SIZE
+
 
 class OpStack:
+    """
+    Only support negative access
+    """
+
     def __init__(self, frame: FrameType):
         self._frame = Frame.from_address(id(frame))
+        stack_start_addr = c_ssize_t.from_address(
+            id(frame) + F_VALUESTACK_OFFSET
+        ).value
+        stack_top_addr = c_ssize_t.from_address(
+            id(frame) + F_STACKTOP_OFFSET
+        ).value
+        self._len = (stack_top_addr - stack_start_addr) // PTR_SIZE
 
     def __getitem__(self, item: int) -> Any:
+        if item < -self._len or item >= 0:
+            raise IndexError(item)
         if item < 0:
             return self._frame.f_stacktop[item]

--- a/tests/system_tracing/test_op_stack.py
+++ b/tests/system_tracing/test_op_stack.py
@@ -1,0 +1,13 @@
+import inspect
+
+import pytest
+
+from lineapy.system_tracing._op_stack import OpStack
+
+
+def test_stack_access():
+    f = inspect.currentframe()
+    assert f
+    op_stack = OpStack(f)
+    with pytest.raises(IndexError):
+        op_stack[-1000]


### PR DESCRIPTION
# Description

Add stack de-reference check to prevent segfaults.

Fixes LIN-248

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added one unit test.