### PR TITLE
Remove lazy side effect creation

### DIFF
--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -160,7 +160,10 @@ class Tracer:
             return self.variable_name_to_node[ptr.name].id
         # Handle external state case, by making a lookup node for it
         if isinstance(ptr, ExternalState):
-            return self.lookup_node(ptr.external_state).id
+            return (
+                self.executor.lookup_external_state(ptr)
+                or self.lookup_node(ptr.external_state).id
+            )
         raise ValueError(f"Unsupported pointer type: {type(ptr)}")
 
     def _process_implicit_dependency(


### PR DESCRIPTION
# Description

This PR removes the change added in #543 which made the side effects lazy. It shouldn't change any behavior, but just clean up the logic to make it more explicit what is happening. Previously, the behavior was relying on the fact that the generators were lazy, which was rather subtle.

## Type of change

Refactor.


# How Has This Been Tested?

Existing tests should cover it!