### PR TITLE
LIN-346 fix the very narrow case of removing "import lineapy"

### DIFF
--- a/lineapy/graph_reader/apis.py
+++ b/lineapy/graph_reader/apis.py
@@ -159,7 +159,19 @@ class LineaArtifact:
 
             swapped, replaces = lineapy_pattern.subn(replace_fun, code)
             if replaces > 0:
+                # If we replaced something, pickle was used so add import pickle on top
+                # Conversely, if lineapy reference was removed, potentially the import lineapy line is not needed anymore.
+                remove_pattern = re.compile(r"import lineapy\n")
+                match_pattern = re.compile(r"lineapy\.(.*)")
                 swapped = "import pickle\n" + swapped
+                if match_pattern.search(swapped):
+                    # we still are using lineapy.xxx functions
+                    # so do nothing
+                    pass
+                else:
+                    swapped, lineareplaces = remove_pattern.subn("", swapped)
+                    logger.debug(f"Removed lineapy {lineareplaces} times")
+
             logger.debug("replaces made: %s", replaces)
 
             return swapped

--- a/tests/unit/graph_reader/test_artifact_get_code.py
+++ b/tests/unit/graph_reader/test_artifact_get_code.py
@@ -10,21 +10,23 @@ FAKE_PATH = "/tmp/path/to/value/file/xey"
 @pytest.mark.parametrize(
     "code, expected",
     [
-        ("", ""),
-        ("x = 1", "x = 1"),
-        (
+        pytest.param("", "", id="blank"),
+        pytest.param("x = 1", "x = 1", id="nolinea"),
+        pytest.param(
             """import lineapy
 lineapy.save(x,"xey")""",
             f"""import pickle
 pickle.dump(x,open("{FAKE_PATH}","wb"))""",
+            id="lineapy_save",
         ),
-        (
+        pytest.param(
             """import lineapy
 x = lineapy.get('x').value""",
             f"""import pickle
 x = pickle.load(open("{FAKE_PATH}","rb"))""",
+            id="lineapy_get",
         ),
-        (
+        pytest.param(
             """import lineapy
 x = lineapy.get('x').value
 y = lineapy.get('y')""",
@@ -32,14 +34,8 @@ y = lineapy.get('y')""",
 import lineapy
 x = pickle.load(open("{FAKE_PATH}","rb"))
 y = lineapy.get('y')""",
+            id="lineapy_get_partial_replace",
         ),
-    ],
-    ids=[
-        "blank",
-        "nolinea",
-        "lineapy_save",
-        "lineapy_get",
-        "lineapy_get_partial_replace",
     ],
 )
 def test__de_linealize_code(code, expected):

--- a/tests/unit/graph_reader/test_artifact_get_code.py
+++ b/tests/unit/graph_reader/test_artifact_get_code.py
@@ -13,17 +13,34 @@ FAKE_PATH = "/tmp/path/to/value/file/xey"
         ("", ""),
         ("x = 1", "x = 1"),
         (
-            'lineapy.save(x,"xey")',
+            """import lineapy
+lineapy.save(x,"xey")""",
             f"""import pickle
 pickle.dump(x,open("{FAKE_PATH}","wb"))""",
         ),
         (
-            "x = lineapy.get('x').value",
+            """import lineapy
+x = lineapy.get('x').value""",
             f"""import pickle
 x = pickle.load(open("{FAKE_PATH}","rb"))""",
         ),
+        (
+            """import lineapy
+x = lineapy.get('x').value
+y = lineapy.get('y')""",
+            f"""import pickle
+import lineapy
+x = pickle.load(open("{FAKE_PATH}","rb"))
+y = lineapy.get('y')""",
+        ),
     ],
-    ids=["blank", "nolinea", "lineapy_save", "lineapy_get"],
+    ids=[
+        "blank",
+        "nolinea",
+        "lineapy_save",
+        "lineapy_get",
+        "lineapy_get_partial_replace",
+    ],
 )
 def test__de_linealize_code(code, expected):
     artifact = LineaArtifact(


### PR DESCRIPTION
# Description

only removes the line if all references to lineapy.xxxx were removed. We do not currently handle any other cases but lineapy.save(xxx) and lineapy.get(xxx).value

Fixes LIN-346

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
extended existing unit tests