### PR TITLE
LIN-349 Add renew_session for sqlite connection

### DIFF
--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -301,6 +301,8 @@ class RelationalLineaDB:
             timestamp=execution.timestamp,
         )
         self.session.add(execution_orm)
+        if not self.url.startswith(DB_SQLITE_PREFIX):
+            self.session.flush()
         self.renew_session()
 
     """


### PR DESCRIPTION
# Description

Fix sqlite locked while multiple notebook running at same time by adding a `renew_session` after writing to sqlite(only).

Fixes # (issue)

LIN-349

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Locally spin up two jupyter notebooks (one endless writing and one reading) with sqlite backend, without locking.

