### PR TITLE
version bump

### DIFF
--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 # Create an ipython extension that starts and stops tracing
 # https://ipython.readthedocs.io/en/stable/config/extensions/index.html#writing-extensions

--- a/tests/outputs/expected/sliced_housing_multiple_requirements.txt
+++ b/tests/outputs/expected/sliced_housing_multiple_requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn==1.0.2
 altair==4.2.0
-lineapy==0.0.4
+lineapy==0.0.5
 pandas==1.3.5
 seaborn==0.11.2

--- a/tests/outputs/expected/sliced_housing_multiple_w_dependencies_requirements.txt
+++ b/tests/outputs/expected/sliced_housing_multiple_w_dependencies_requirements.txt
@@ -1,4 +1,4 @@
-lineapy==0.0.4
+lineapy==0.0.5
 altair==4.2.0
 pandas==1.3.5
 seaborn==0.11.2

--- a/tests/outputs/expected/sliced_housing_simple_requirements.txt
+++ b/tests/outputs/expected/sliced_housing_simple_requirements.txt
@@ -2,4 +2,4 @@ altair==4.2.0
 seaborn==0.11.2
 pandas==1.3.5
 scikit-learn==1.0.2
-lineapy==0.0.4
+lineapy==0.0.5


### PR DESCRIPTION
# Description

Bumps to 0.0.5 to release the `.get_value()` API.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

PyPi tested in prod.