### PR TITLE
Update page indexing in Sphinx to display renamed tutorial notebook

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ Welcome to LineaPy!
 
    tutorials/00_api_basics
    tutorials/01_refactor_code
-   tutorials/03_build_pipelines
+   tutorials/02_build_pipelines
 
 
 .. toctree::


### PR DESCRIPTION
# Description

Some notebooks had been renamed but the corresponding indexing has not, so they do not show up in Sphinx.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No testing needed for docs