### PR TITLE
Lin 184 test pandas examples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 	path = tests/integration/sources/xgboost
 	url = git@github.com:dmlc/xgboost.git
         ignore = all
+[submodule "tests/integration/sources/pandas_exercises"]
+	path = tests/integration/sources/pandas_exercises
+	url = git@github.com:guipsamora/pandas_exercises.git

--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -114,7 +114,8 @@ def notebook(
         name=artifact_name,
         date_created=artifact.date_created,  # type: ignore
     )
-    logger.info(api_artifact.get_code())
+    # logger.info(api_artifact.get_code())
+    print(api_artifact.get_code())
 
 
 @linea_cli.command()
@@ -164,7 +165,8 @@ def file(
         name=artifact_name,
         date_created=artifact.date_created,  # type:ignore
     )
-    logger.info(api_artifact.get_code())
+    # logger.info(api_artifact.get_code())
+    print(api_artifact.get_code())
 
 
 def generate_save_code(

--- a/lineapy/external.annotations.yaml
+++ b/lineapy/external.annotations.yaml
@@ -73,38 +73,6 @@
             - result: RESULT
 - module: pandas
   annotations:
-    - criteria:
-        class_method_names: 
-          - to_sql
-          - to_gbq
-        class_instance: DataFrame
-      side_effects:
-        - mutated_value:
-            external_state: db
-    - criteria:
-        class_method_names:
-          - to_csv
-          - to_json
-          - to_html
-          - to_xml
-          - to_excel
-          - to_hdf
-          - to_feather
-          - to_parquet
-          - to_stata
-          - to_pickle
-        class_instance: DataFrame
-      side_effects:
-        - mutated_value:
-            external_state: file_system
-    - criteria:
-        class_method_names:
-          - pop
-          - insert
-        class_instance: DataFrame
-      side_effects:
-        - mutated_value:
-            self_ref: SELF_REF
     - criteria: # I omitted pandas.io.sql, lets see if this works
         function_names:
           - read_sql
@@ -134,6 +102,38 @@
             external_state: file_system
 - module: pandas.core.generic
   annotations:
+    - criteria:
+        class_method_names:
+          - to_sql
+          - to_gbq
+        class_instance: NDFrame
+      side_effects:
+        - mutated_value:
+            external_state: db
+    - criteria:
+        class_method_names:
+          - to_csv
+          - to_json
+          - to_html
+          - to_xml
+          - to_excel
+          - to_hdf
+          - to_feather
+          - to_parquet
+          - to_stata
+          - to_pickle
+        class_instance: NDFrame
+      side_effects:
+        - mutated_value:
+            external_state: file_system
+    - criteria:
+        class_method_names:
+          - pop
+          - insert
+        class_instance: NDFrame
+      side_effects:
+        - mutated_value:
+            self_ref: SELF_REF
     - criteria:
         keyword_arg_name: inplace
         keyword_arg_value: 1

--- a/lineapy/external.annotations.yaml
+++ b/lineapy/external.annotations.yaml
@@ -74,7 +74,9 @@
 - module: pandas
   annotations:
     - criteria:
-        class_method_name: to_sql
+        class_method_names: 
+          - to_sql
+          - to_gbq
         class_instance: DataFrame
       side_effects:
         - mutated_value:
@@ -82,21 +84,51 @@
     - criteria:
         class_method_names:
           - to_csv
+          - to_json
+          - to_html
+          - to_xml
+          - to_excel
+          - to_hdf
+          - to_feather
           - to_parquet
+          - to_stata
+          - to_pickle
         class_instance: DataFrame
       side_effects:
         - mutated_value:
             external_state: file_system
+    - criteria:
+        class_method_names:
+          - pop
+          - insert
+        class_instance: DataFrame
+      side_effects:
+        - mutated_value:
+            self_ref: SELF_REF
     - criteria: # I omitted pandas.io.sql, lets see if this works
         function_names:
           - read_sql
+          - read_sql_query
+          - read_sql_table
       side_effects:
         - dependency:
             external_state: db
     - criteria:
         function_names:
           - read_csv
+          - read_fwf
+          - read_json
+          - read_html
+          - read_xml
+          - read_excel
+          - read_hdf
+          - read_feather
           - read_parquet
+          - read_orc
+          - read_stata
+          - read_sas
+          - read_spss
+          - read_pickle
       side_effects:
         - dependency:
             external_state: file_system
@@ -111,6 +143,37 @@
       side_effects:
         - mutated_value:
             self_ref: SELF_REF
+    # - criteria:
+    #     class_method_names:
+    #       - __setitem__
+    #       - _setitem_frame
+    #       - _setitem_array
+    #       - _setitem_slice
+    #       - _set_item_frame_value
+    #       - _set_item
+    #       - _iset_not_inplace
+    #       - _iset_item
+    #       - _set_item_mgr
+    #     class_instance: NDFrame
+    #   side_effects:
+    #     - mutated_value:
+    #         self_ref: SELF_REF
+    #     - views:
+    #         - self_ref: SELF_REF
+    #         - result: RESULT
+    #         - positional_argument_index: 1
+    # - criteria:
+    #     class_method_names:
+    #       - _set_value
+    #     class_instance: NDFrame
+    #   side_effects:
+    #     - mutated_value:
+    #         self_ref: SELF_REF
+    #     - views:
+    #         - self_ref: SELF_REF
+    #         - result: RESULT
+    #         - positional_argument_index: 2
+
 - module: boto3
   annotations:
     - criteria:

--- a/lineapy/external.annotations.yaml
+++ b/lineapy/external.annotations.yaml
@@ -143,37 +143,6 @@
       side_effects:
         - mutated_value:
             self_ref: SELF_REF
-    # - criteria:
-    #     class_method_names:
-    #       - __setitem__
-    #       - _setitem_frame
-    #       - _setitem_array
-    #       - _setitem_slice
-    #       - _set_item_frame_value
-    #       - _set_item
-    #       - _iset_not_inplace
-    #       - _iset_item
-    #       - _set_item_mgr
-    #     class_instance: NDFrame
-    #   side_effects:
-    #     - mutated_value:
-    #         self_ref: SELF_REF
-    #     - views:
-    #         - self_ref: SELF_REF
-    #         - result: RESULT
-    #         - positional_argument_index: 1
-    # - criteria:
-    #     class_method_names:
-    #       - _set_value
-    #     class_instance: NDFrame
-    #   side_effects:
-    #     - mutated_value:
-    #         self_ref: SELF_REF
-    #     - views:
-    #         - self_ref: SELF_REF
-    #         - result: RESULT
-    #         - positional_argument_index: 2
-
 - module: boto3
   annotations:
     - criteria:

--- a/tests/end_to_end/test_pandas.py
+++ b/tests/end_to_end/test_pandas.py
@@ -7,7 +7,6 @@ df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
 df["C"] = df["A"] + df["B"]
 """
     res = execute(code, artifacts=["df"])
-    # assert res.values["df"].to_csv(index=False) == "A,B,C\n1,4,5\n2,5,7\n3,6,9\n"
     assert res.artifacts["df"] == code
 
 
@@ -34,3 +33,23 @@ assert new_df.size == 2
 """
     res = execute(code, snapshot=False)
     assert res.values["new_df"].size == 2
+
+
+@pytest.mark.slow
+def test_pandas_pop(execute):
+    code = """from pandas import DataFrame
+df = DataFrame({"a": [0, 1], "b": [2, 3]})
+df.pop("b")
+"""
+    res = execute(code, snapshot=False, artifacts=["df"])
+    assert res.artifacts["df"] == code
+
+
+@pytest.mark.slow
+def test_pandas_insert(execute):
+    code = """from pandas import DataFrame
+df = DataFrame({"col1": [1, 2], "col2": [3, 4]})
+df.insert(1, "newcol", [99, 99])
+"""
+    res = execute(code, snapshot=False, artifacts=["df"])
+    assert res.artifacts["df"] == code

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_apply].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_apply].py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/04_Apply/US_Crime_Rates/US_Crime_Rates_1960_2014.csv"
+crime = pd.read_csv(url)
+crime.Year = pd.to_datetime(crime.Year, format="%Y")
+crime = crime.set_index("Year", drop=True)
+del crime["Total"]
+crimes = crime.resample("10AS").sum()
+population = crime["Population"].resample("10AS").max()
+crimes["Population"] = population
+linea_artifact_value = crimes

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_deleting].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_deleting].py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
+iris = pd.read_csv(url)
+iris.columns = ["sepal_length", "sepal_width", "petal_length", "petal_width", "class"]
+del iris["class"]
+iris = iris.dropna(how="any")
+iris = iris.reset_index(drop=True)
+linea_artifact_value = iris

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_filtering].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_filtering].py
@@ -1,0 +1,56 @@
+import pandas as pd
+
+raw_data = {
+    "regiment": [
+        "Nighthawks",
+        "Nighthawks",
+        "Nighthawks",
+        "Nighthawks",
+        "Dragoons",
+        "Dragoons",
+        "Dragoons",
+        "Dragoons",
+        "Scouts",
+        "Scouts",
+        "Scouts",
+        "Scouts",
+    ],
+    "company": [
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+    ],
+    "deaths": [523, 52, 25, 616, 43, 234, 523, 62, 62, 73, 37, 35],
+    "battles": [5, 42, 2, 2, 4, 7, 8, 3, 4, 7, 8, 9],
+    "size": [1045, 957, 1099, 1400, 1592, 1006, 987, 849, 973, 1005, 1099, 1523],
+    "veterans": [1, 5, 62, 26, 73, 37, 949, 48, 48, 435, 63, 345],
+    "readiness": [1, 2, 3, 3, 2, 1, 2, 3, 2, 1, 2, 3],
+    "armored": [1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1],
+    "deserters": [4, 24, 31, 2, 3, 4, 24, 31, 2, 3, 2, 3],
+    "origin": [
+        "Arizona",
+        "California",
+        "Texas",
+        "Florida",
+        "Maine",
+        "Iowa",
+        "Alaska",
+        "Washington",
+        "Oregon",
+        "Wyoming",
+        "Louisana",
+        "Georgia",
+    ],
+}
+army = pd.DataFrame(data=raw_data)
+army.set_index("origin", inplace=True)
+linea_artifact_value = army.loc[:, ["deaths"]].iloc[2]

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_merge].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_merge].py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+raw_data_1 = {
+    "subject_id": ["1", "2", "3", "4", "5"],
+    "first_name": ["Alex", "Amy", "Allen", "Alice", "Ayoung"],
+    "last_name": ["Anderson", "Ackerman", "Ali", "Aoni", "Atiches"],
+}
+raw_data_2 = {
+    "subject_id": ["4", "5", "6", "7", "8"],
+    "first_name": ["Billy", "Brian", "Bran", "Bryce", "Betty"],
+    "last_name": ["Bonder", "Black", "Balwner", "Brice", "Btisan"],
+}
+data1 = pd.DataFrame(raw_data_1, columns=["subject_id", "first_name", "last_name"])
+data2 = pd.DataFrame(raw_data_2, columns=["subject_id", "first_name", "last_name"])
+all_data_col = pd.concat([data1, data2], axis=1)
+linea_artifact_value = all_data_col

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_stats].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_stats].py
@@ -1,0 +1,18 @@
+import datetime
+
+import pandas as pd
+
+data_url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/06_Stats/Wind_Stats/wind.data"
+data = pd.read_csv(data_url, sep="\\s+", parse_dates=[[0, 1, 2]])
+
+
+def fix_century(x):
+    year = x.year - 100 if x.year > 1989 else x.year
+    return datetime.date(year, x.month, x.day)
+
+
+data["Yr_Mo_Dy"] = data["Yr_Mo_Dy"].apply(fix_century)
+data["Yr_Mo_Dy"] = pd.to_datetime(data["Yr_Mo_Dy"])
+data = data.set_index("Yr_Mo_Dy")
+weekly = data.resample("W").agg(["min", "max", "mean", "std"])
+linea_artifact_value = weekly

--- a/tests/integration/__snapshots__/test_slice/test_slice[pandas_timeseries].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[pandas_timeseries].py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/09_Time_Series/Apple_Stock/appl_1980_2014.csv"
+apple = pd.read_csv(url)
+apple.Date = pd.to_datetime(apple.Date)
+apple = apple.set_index("Date")
+apple_months = apple.resample("BM").mean()
+linea_artifact_value = apple_months

--- a/tests/integration/slices/pandas_apply.py
+++ b/tests/integration/slices/pandas_apply.py
@@ -1,0 +1,19 @@
+# This is the manual slice of:
+#  crimes
+# from file:
+#  sources/pandas_exercises/04_Apply/US_Crime_Rates/Exercises_with_solutions.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_apply]'
+
+import pandas as pd
+
+url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/04_Apply/US_Crime_Rates/US_Crime_Rates_1960_2014.csv"
+crime = pd.read_csv(url)
+crime.Year = pd.to_datetime(crime.Year, format="%Y")
+crime = crime.set_index("Year", drop=True)
+del crime["Total"]
+crimes = crime.resample("10AS").sum()
+population = crime["Population"].resample("10AS").max()
+crimes["Population"] = population
+linea_artifact_value = crimes

--- a/tests/integration/slices/pandas_deleting.py
+++ b/tests/integration/slices/pandas_deleting.py
@@ -1,0 +1,21 @@
+# This is the manual slice of:
+#  iris
+# from file:
+#  sources/pandas_exercises/10_Deleting/Iris/Exercises_with_solutions_and_code.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_deleting]'
+
+import numpy as np
+import pandas as pd
+
+url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
+iris = pd.read_csv(url)
+iris.columns = ["sepal_length", "sepal_width", "petal_length", "petal_width", "class"]
+iris.iloc[10:30, 2:3] = np.nan
+iris.petal_length.fillna(1, inplace=True)
+del iris["class"]
+iris.iloc[0:3, :] = np.nan
+iris = iris.dropna(how="any")
+iris = iris.reset_index(drop=True)
+linea_artifact_value = iris

--- a/tests/integration/slices/pandas_filtering.py
+++ b/tests/integration/slices/pandas_filtering.py
@@ -1,0 +1,64 @@
+# This is the manual slice of:
+#  army.loc[:, ["deaths"]].iloc[2]
+# from file:
+#  sources/pandas_exercises/02_Filtering_&_Sorting/Fictional Army/Exercise_with_solutions.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_filtering]'
+
+import pandas as pd
+
+raw_data = {
+    "regiment": [
+        "Nighthawks",
+        "Nighthawks",
+        "Nighthawks",
+        "Nighthawks",
+        "Dragoons",
+        "Dragoons",
+        "Dragoons",
+        "Dragoons",
+        "Scouts",
+        "Scouts",
+        "Scouts",
+        "Scouts",
+    ],
+    "company": [
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+        "1st",
+        "1st",
+        "2nd",
+        "2nd",
+    ],
+    "deaths": [523, 52, 25, 616, 43, 234, 523, 62, 62, 73, 37, 35],
+    "battles": [5, 42, 2, 2, 4, 7, 8, 3, 4, 7, 8, 9],
+    "size": [1045, 957, 1099, 1400, 1592, 1006, 987, 849, 973, 1005, 1099, 1523],
+    "veterans": [1, 5, 62, 26, 73, 37, 949, 48, 48, 435, 63, 345],
+    "readiness": [1, 2, 3, 3, 2, 1, 2, 3, 2, 1, 2, 3],
+    "armored": [1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1],
+    "deserters": [4, 24, 31, 2, 3, 4, 24, 31, 2, 3, 2, 3],
+    "origin": [
+        "Arizona",
+        "California",
+        "Texas",
+        "Florida",
+        "Maine",
+        "Iowa",
+        "Alaska",
+        "Washington",
+        "Oregon",
+        "Wyoming",
+        "Louisana",
+        "Georgia",
+    ],
+}
+army = pd.DataFrame(data=raw_data)
+army.set_index("origin", inplace=True)
+linea_artifact_value = army.loc[:, ["deaths"]].iloc[2]

--- a/tests/integration/slices/pandas_merge.py
+++ b/tests/integration/slices/pandas_merge.py
@@ -1,0 +1,24 @@
+# This is the manual slice of:
+#  all_data_col
+# from file:
+#  sources/pandas_exercises/05_Merge/Fictitous Names/Exercises_with_solutions.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_merge]'
+
+import pandas as pd
+
+raw_data_1 = {
+    "subject_id": ["1", "2", "3", "4", "5"],
+    "first_name": ["Alex", "Amy", "Allen", "Alice", "Ayoung"],
+    "last_name": ["Anderson", "Ackerman", "Ali", "Aoni", "Atiches"],
+}
+raw_data_2 = {
+    "subject_id": ["4", "5", "6", "7", "8"],
+    "first_name": ["Billy", "Brian", "Bran", "Bryce", "Betty"],
+    "last_name": ["Bonder", "Black", "Balwner", "Brice", "Btisan"],
+}
+data1 = pd.DataFrame(raw_data_1, columns=["subject_id", "first_name", "last_name"])
+data2 = pd.DataFrame(raw_data_2, columns=["subject_id", "first_name", "last_name"])
+all_data_col = pd.concat([data1, data2], axis=1)
+linea_artifact_value = all_data_col

--- a/tests/integration/slices/pandas_stats.py
+++ b/tests/integration/slices/pandas_stats.py
@@ -1,0 +1,26 @@
+# This is the manual slice of:
+#  weekly
+# from file:
+#  sources/pandas_exercises/06_Stats/Wind_Stats/Exercises_with_solutions.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_stats]'
+
+import datetime
+
+import pandas as pd
+
+data_url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/06_Stats/Wind_Stats/wind.data"
+data = pd.read_csv(data_url, sep="\\s+", parse_dates=[[0, 1, 2]])
+
+
+def fix_century(x):
+    year = x.year - 100 if x.year > 1989 else x.year
+    return datetime.date(year, x.month, x.day)
+
+
+data["Yr_Mo_Dy"] = data["Yr_Mo_Dy"].apply(fix_century)
+data["Yr_Mo_Dy"] = pd.to_datetime(data["Yr_Mo_Dy"])
+data = data.set_index("Yr_Mo_Dy")
+weekly = data.resample("W").agg(["min", "max", "mean", "std"])
+linea_artifact_value = weekly

--- a/tests/integration/slices/pandas_timeseries.py
+++ b/tests/integration/slices/pandas_timeseries.py
@@ -1,0 +1,16 @@
+# This is the manual slice of:
+#  apple_months
+# from file:
+#  sources/pandas_exercises/09_Time_Series/Apple_Stock/Exercises-with-solutions-code.ipynb
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[pandas_timeseries]'
+
+import pandas as pd
+
+url = "https://raw.githubusercontent.com/guipsamora/pandas_exercises/master/09_Time_Series/Apple_Stock/appl_1980_2014.csv"
+apple = pd.read_csv(url)
+apple.Date = pd.to_datetime(apple.Date)
+apple = apple.set_index("Date")
+apple_months = apple.resample("BM").mean()
+linea_artifact_value = apple_months

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -80,6 +80,7 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
     "xgboost": Environment(
         conda_deps=["xgboost", "scikit-learn", "numpy", "scipy"]
     ),
+    "pandas": Environment(),
 }
 
 # A list of the params to test
@@ -222,6 +223,60 @@ PARAMS = [
         "lineapy.file_system",
         id="xgboost_basic_walkthrough",
         marks=mark.xfail(reason="import error"),
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/01_Getting_&_Knowing_Your_Data/Occupation/Exercises_with_solutions.ipynb",
+        "users",
+        id="pandas_intro",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/02_Filtering_&_Sorting/Fictional Army/Exercise_with_solutions.ipynb",
+        'army.loc[:, ["deaths"]].iloc[2]',
+        id="pandas_filtering",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/03_Grouping/Regiment/Exercises_solutions.ipynb",
+        "regiment ",
+        id="pandas_grouping",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/04_Apply/US_Crime_Rates/Exercises_with_solutions.ipynb",
+        "crimes",
+        id="pandas_apply",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/06_Stats/Wind_Stats/Exercises_with_solutions.ipynb",
+        "weekly",
+        id="pandas_stats",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/07_Visualization/Scores/Exercises_code_with_solutions.ipynb",
+        "df",
+        id="pandas_vis",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/08_Creating_Series_and_DataFrames/Pokemon/Exercises_with_solutions.ipynb",
+        "pokemon",
+        id="pandas_creating",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/09_Time_Series/Investor_Flow_of_Funds_US/Exercises_with_solutions.ipynb",
+        "(monthly, yearly)",
+        id="pandas_timeseries",
+    ),
+    param(
+        "pandas",
+        "pandas_exercises/10_Deleting/Wine/Exercises_with_solutions.ipynb",
+        "wine",
+        id="pandas_deleting",
     ),
 ]
 

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -274,9 +274,10 @@ PARAMS = [
     ),
     param(
         "pandas",
-        "pandas_exercises/10_Deleting/Wine/Exercises_with_solutions.ipynb",
-        "wine",
+        "pandas_exercises/10_Deleting/Iris/Exercises_with_solutions_and_code.ipynb",
+        "iris",
         id="pandas_deleting",
+        marks=mark.xfail(reason="need annotation"),
     ),
 ]
 

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -224,23 +224,17 @@ PARAMS = [
         id="xgboost_basic_walkthrough",
         marks=mark.xfail(reason="import error"),
     ),
-    param(
-        "pandas",
-        "pandas_exercises/01_Getting_&_Knowing_Your_Data/Occupation/Exercises_with_solutions.ipynb",
-        "users",
-        id="pandas_intro",
-    ),
+    # param(
+    #     "pandas",
+    #     "pandas_exercises/01_Getting_&_Knowing_Your_Data/Occupation/Exercises_with_solutions.ipynb",
+    #     "users",
+    #     id="pandas_intro",
+    # ),
     param(
         "pandas",
         "pandas_exercises/02_Filtering_&_Sorting/Fictional Army/Exercise_with_solutions.ipynb",
         'army.loc[:, ["deaths"]].iloc[2]',
         id="pandas_filtering",
-    ),
-    param(
-        "pandas",
-        "pandas_exercises/03_Grouping/Regiment/Exercises_solutions.ipynb",
-        "regiment ",
-        id="pandas_grouping",
     ),
     param(
         "pandas",
@@ -254,22 +248,22 @@ PARAMS = [
         "weekly",
         id="pandas_stats",
     ),
+    # param(
+    #     "pandas",
+    #     "pandas_exercises/07_Visualization/Scores/Exercises_code_with_solutions.ipynb",
+    #     "df",
+    #     id="pandas_vis",
+    # ),
+    # param(
+    #     "pandas",
+    #     "pandas_exercises/08_Creating_Series_and_DataFrames/Pokemon/Exercises_with_solutions.ipynb",
+    #     "pokemon",
+    #     id="pandas_creating",
+    # ),
     param(
         "pandas",
-        "pandas_exercises/07_Visualization/Scores/Exercises_code_with_solutions.ipynb",
-        "df",
-        id="pandas_vis",
-    ),
-    param(
-        "pandas",
-        "pandas_exercises/08_Creating_Series_and_DataFrames/Pokemon/Exercises_with_solutions.ipynb",
-        "pokemon",
-        id="pandas_creating",
-    ),
-    param(
-        "pandas",
-        "pandas_exercises/09_Time_Series/Investor_Flow_of_Funds_US/Exercises_with_solutions.ipynb",
-        "(monthly, yearly)",
+        "pandas_exercises/09_Time_Series/Apple_Stock/Exercises-with-solutions-code.ipynb",
+        "apple_months",
         id="pandas_timeseries",
     ),
     param(

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -244,6 +244,12 @@ PARAMS = [
     ),
     param(
         "pandas",
+        "pandas_exercises/05_Merge/Fictitous Names/Exercises_with_solutions.ipynb",
+        "all_data_col",
+        id="pandas_merge",
+    ),
+    param(
+        "pandas",
         "pandas_exercises/06_Stats/Wind_Stats/Exercises_with_solutions.ipynb",
         "weekly",
         id="pandas_stats",

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -224,12 +224,6 @@ PARAMS = [
         id="xgboost_basic_walkthrough",
         marks=mark.xfail(reason="import error"),
     ),
-    # param(
-    #     "pandas",
-    #     "pandas_exercises/01_Getting_&_Knowing_Your_Data/Occupation/Exercises_with_solutions.ipynb",
-    #     "users",
-    #     id="pandas_intro",
-    # ),
     param(
         "pandas",
         "pandas_exercises/02_Filtering_&_Sorting/Fictional Army/Exercise_with_solutions.ipynb",
@@ -254,18 +248,6 @@ PARAMS = [
         "weekly",
         id="pandas_stats",
     ),
-    # param(
-    #     "pandas",
-    #     "pandas_exercises/07_Visualization/Scores/Exercises_code_with_solutions.ipynb",
-    #     "df",
-    #     id="pandas_vis",
-    # ),
-    # param(
-    #     "pandas",
-    #     "pandas_exercises/08_Creating_Series_and_DataFrames/Pokemon/Exercises_with_solutions.ipynb",
-    #     "pokemon",
-    #     id="pandas_creating",
-    # ),
     param(
         "pandas",
         "pandas_exercises/09_Time_Series/Apple_Stock/Exercises-with-solutions-code.ipynb",


### PR DESCRIPTION
# Description

Add integration tests with pandas examples, and annotations.

Fixes # (issue)

LIN-184

## Type of change

- [x] New feature (non-breaking change which adds functionality)

* Add integration tests for `pandas`.
  Using notebooks in [pandas_exerciese](https://github.com/guipsamora/pandas_exercises). (BSD-3) as source. We are not using in official pandas repository because they are in `.rst` format.
* New annotations.

Found lineapy works in following assign pattern
```
iris1['petal_length'].fillna(1, inplace=True)
```
but not works in following
```
iris2.petal_length.fillna(1, inplace=True)
iris3.iloc[10:30,2:3] = 1
iris4.loc[iris4.petal_length.isnull(),['petal_length']]=1
iris5.at[10:29,'petal_length']=1
```
Need another ticket for this.

# How Has This Been Tested?

* Integration tests for examples
* New end_to_end tests for new annotations.