### PR TITLE
Lin 382 add annotations for sklearn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = tests/integration/sources/pandas_exercises
 	url = git@github.com:guipsamora/pandas_exercises.git
     ignore = all
+[submodule "tests/integration/sources/scikit-learn"]
+	path = tests/integration/sources/scikit-learn
+	url = https://github.com/scikit-learn/scikit-learn.git

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_compose_plot_feature_union].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_compose_plot_feature_union].py
@@ -1,0 +1,23 @@
+from sklearn.datasets import load_iris
+from sklearn.decomposition import PCA
+from sklearn.feature_selection import SelectKBest
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import FeatureUnion, Pipeline
+from sklearn.svm import SVC
+
+iris = load_iris()
+X, y = iris.data, iris.target
+pca = PCA(n_components=2)
+selection = SelectKBest(k=1)
+combined_features = FeatureUnion([("pca", pca), ("univ_select", selection)])
+X_features = combined_features.fit(X, y).transform(X)
+svm = SVC(kernel="linear")
+pipeline = Pipeline([("features", combined_features), ("svm", svm)])
+param_grid = dict(
+    features__pca__n_components=[1, 2, 3],
+    features__univ_select__k=[1, 2],
+    svm__C=[0.1, 1, 10],
+)
+grid_search = GridSearchCV(pipeline, param_grid=param_grid, verbose=10)
+grid_search.fit(X, y)
+linea_artifact_value = grid_search

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_mixture_plot_concentration_prior].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_mixture_plot_concentration_prior].py
@@ -1,0 +1,117 @@
+import matplotlib as mpl
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.mixture import BayesianGaussianMixture
+
+
+def plot_ellipses(ax, weights, means, covars):
+    for n in range(means.shape[0]):
+        eig_vals, eig_vecs = np.linalg.eigh(covars[n])
+        unit_eig_vec = eig_vecs[0] / np.linalg.norm(eig_vecs[0])
+        angle = np.arctan2(unit_eig_vec[1], unit_eig_vec[0])
+        angle = 180 * angle / np.pi
+        eig_vals = 2 * np.sqrt(2) * np.sqrt(eig_vals)
+        ell = mpl.patches.Ellipse(
+            means[n], eig_vals[0], eig_vals[1], 180 + angle, edgecolor="black"
+        )
+        ell.set_clip_box(ax.bbox)
+        ell.set_alpha(weights[n])
+        ell.set_facecolor("#56B4E9")
+        ax.add_artist(ell)
+
+
+def plot_results(ax1, ax2, estimator, X, y, title, plot_title=False):
+    ax1.set_title(title)
+    ax1.scatter(X[:, 0], X[:, 1], s=5, marker="o", color=colors[y], alpha=0.8)
+    ax1.set_xlim(-2.0, 2.0)
+    ax1.set_ylim(-3.0, 3.0)
+    ax1.set_xticks(())
+    ax1.set_yticks(())
+    plot_ellipses(ax1, estimator.weights_, estimator.means_, estimator.covariances_)
+    ax2.get_xaxis().set_tick_params(direction="out")
+    ax2.yaxis.grid(True, alpha=0.7)
+    for k, w in enumerate(estimator.weights_):
+        ax2.bar(
+            k,
+            w,
+            width=0.9,
+            color="#56B4E9",
+            zorder=3,
+            align="center",
+            edgecolor="black",
+        )
+        ax2.text(k, w + 0.007, "%.1f%%" % (w * 100.0), horizontalalignment="center")
+    ax2.set_xlim(-0.6, 2 * n_components - 0.4)
+    ax2.set_ylim(0.0, 1.1)
+    ax2.tick_params(axis="y", which="both", left=False, right=False, labelleft=False)
+    ax2.tick_params(axis="x", which="both", top=False)
+    if plot_title:
+        ax1.set_ylabel("Estimated Mixtures")
+        ax2.set_ylabel("Weight of each component")
+
+
+random_state, n_components, n_features = 2, 3, 2
+colors = np.array(["#0072B2", "#F0E442", "#D55E00"])
+covars = np.array(
+    [[[0.7, 0.0], [0.0, 0.1]], [[0.5, 0.0], [0.0, 0.1]], [[0.5, 0.0], [0.0, 0.1]]]
+)
+samples = np.array([200, 500, 200])
+means = np.array([[0.0, -0.7], [0.0, 0.0], [0.0, 0.7]])
+estimators = [
+    (
+        """Finite mixture with a Dirichlet distribution
+prior and $\\gamma_0=$""",
+        BayesianGaussianMixture(
+            weight_concentration_prior_type="dirichlet_distribution",
+            n_components=2 * n_components,
+            reg_covar=0,
+            init_params="random",
+            max_iter=1500,
+            mean_precision_prior=0.8,
+            random_state=random_state,
+        ),
+        [0.001, 1, 1000],
+    ),
+    (
+        """Infinite mixture with a Dirichlet process
+ prior and$\\gamma_0=$""",
+        BayesianGaussianMixture(
+            weight_concentration_prior_type="dirichlet_process",
+            n_components=2 * n_components,
+            reg_covar=0,
+            init_params="random",
+            max_iter=1500,
+            mean_precision_prior=0.8,
+            random_state=random_state,
+        ),
+        [1, 1000, 100000],
+    ),
+]
+rng = np.random.RandomState(random_state)
+X = np.vstack(
+    [
+        rng.multivariate_normal(means[j], covars[j], samples[j])
+        for j in range(n_components)
+    ]
+)
+y = np.concatenate([np.full(samples[j], j, dtype=int) for j in range(n_components)])
+for title, estimator, concentrations_prior in estimators:
+    plt.figure(figsize=(4.7 * 3, 8))
+    plt.subplots_adjust(
+        bottom=0.04, top=0.9, hspace=0.05, wspace=0.05, left=0.03, right=0.99
+    )
+    gs = gridspec.GridSpec(3, len(concentrations_prior))
+    for k, concentration in enumerate(concentrations_prior):
+        estimator.weight_concentration_prior = concentration
+        estimator.fit(X)
+        plot_results(
+            plt.subplot(gs[0:2, k]),
+            plt.subplot(gs[2, k]),
+            estimator,
+            X,
+            y,
+            "%s$%.1e$" % (title, concentration),
+            plot_title=k == 0,
+        )
+linea_artifact_value = estimators

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_model_selection_plot_randomized_search].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_model_selection_plot_randomized_search].py
@@ -1,0 +1,15 @@
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.linear_model import SGDClassifier
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+
+X, y = load_digits(return_X_y=True, n_class=3)
+clf = SGDClassifier(loss="hinge", penalty="elasticnet", fit_intercept=True)
+param_grid = {
+    "average": [True, False],
+    "l1_ratio": np.linspace(0, 1, num=10),
+    "alpha": np.power(10, np.arange(-2, 1, dtype=float)),
+}
+grid_search = GridSearchCV(clf, param_grid=param_grid)
+grid_search.fit(X, y)
+linea_artifact_value = grid_search

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_multioutput_plot_classifier_chain_yeast].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_multioutput_plot_classifier_chain_yeast].py
@@ -1,0 +1,13 @@
+from sklearn.datasets import fetch_openml
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.multioutput import ClassifierChain
+
+X, Y = fetch_openml("yeast", version=4, return_X_y=True)
+Y = Y == "TRUE"
+X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=0.2, random_state=0)
+base_lr = LogisticRegression()
+chains = [ClassifierChain(base_lr, order="random", random_state=i) for i in range(10)]
+for chain in chains:
+    chain.fit(X_train, Y_train)
+linea_artifact_value = chains

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_preprocessing_plot_scaling_importance].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_preprocessing_plot_scaling_importance].py
@@ -1,0 +1,17 @@
+from sklearn.datasets import load_wine
+from sklearn.decomposition import PCA
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import GaussianNB
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+RANDOM_STATE = 42
+features, target = load_wine(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    features, target, test_size=0.3, random_state=RANDOM_STATE
+)
+unscaled_clf = make_pipeline(PCA(n_components=2), GaussianNB())
+unscaled_clf.fit(X_train, y_train)
+std_clf = make_pipeline(StandardScaler(), PCA(n_components=2), GaussianNB())
+std_clf.fit(X_train, y_train)
+linea_artifact_value = unscaled_clf, std_clf

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_semi_supervised_plot_label_propagation_structure].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_semi_supervised_plot_label_propagation_structure].py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.datasets import make_circles
+from sklearn.semi_supervised import LabelSpreading
+
+n_samples = 200
+X, y = make_circles(n_samples=n_samples, shuffle=False)
+outer, inner = 0, 1
+labels = np.full(n_samples, -1.0)
+labels[0] = outer
+labels[-1] = inner
+label_spread = LabelSpreading(kernel="knn", alpha=0.8)
+label_spread.fit(X, labels)
+linea_artifact_value = label_spread

--- a/tests/integration/__snapshots__/test_slice/test_slice[sklearn_tree_plot_cost_complexity_pruning].py
+++ b/tests/integration/__snapshots__/test_slice/test_slice[sklearn_tree_plot_cost_complexity_pruning].py
@@ -1,0 +1,17 @@
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from sklearn.tree import DecisionTreeClassifier
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+clf = DecisionTreeClassifier(random_state=0)
+path = clf.cost_complexity_pruning_path(X_train, y_train)
+ccp_alphas, impurities = path.ccp_alphas, path.impurities
+clfs = []
+for ccp_alpha in ccp_alphas:
+    clf = DecisionTreeClassifier(random_state=0, ccp_alpha=ccp_alpha)
+    clf.fit(X_train, y_train)
+    clfs.append(clf)
+clfs = clfs[:-1]
+depth = [clf.tree_.max_depth for clf in clfs]
+linea_artifact_value = depth

--- a/tests/integration/slices/sklearn_compose_plot_feature_union.py
+++ b/tests/integration/slices/sklearn_compose_plot_feature_union.py
@@ -1,0 +1,31 @@
+# This is the manual slice of:
+#  grid_search
+# from file:
+#  sources/scikit-learn/examples/compose/plot_feature_union.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_compose_plot_feature_union]'
+
+from sklearn.datasets import load_iris
+from sklearn.decomposition import PCA
+from sklearn.feature_selection import SelectKBest
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import FeatureUnion, Pipeline
+from sklearn.svm import SVC
+
+iris = load_iris()
+X, y = iris.data, iris.target
+pca = PCA(n_components=2)
+selection = SelectKBest(k=1)
+combined_features = FeatureUnion([("pca", pca), ("univ_select", selection)])
+X_features = combined_features.fit(X, y).transform(X)
+svm = SVC(kernel="linear")
+pipeline = Pipeline([("features", combined_features), ("svm", svm)])
+param_grid = dict(
+    features__pca__n_components=[1, 2, 3],
+    features__univ_select__k=[1, 2],
+    svm__C=[0.1, 1, 10],
+)
+grid_search = GridSearchCV(pipeline, param_grid=param_grid, verbose=10)
+grid_search.fit(X, y)
+linea_artifact_value = grid_search

--- a/tests/integration/slices/sklearn_mixture_plot_concentration_prior.py
+++ b/tests/integration/slices/sklearn_mixture_plot_concentration_prior.py
@@ -1,0 +1,59 @@
+# This is the manual slice of:
+#  estimators
+# from file:
+#  sources/scikit-learn/examples/mixture/plot_concentration_prior.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_mixture_plot_concentration_prior]'
+
+import numpy as np
+from sklearn.mixture import BayesianGaussianMixture
+
+random_state, n_components, n_features = 2, 3, 2
+covars = np.array(
+    [[[0.7, 0.0], [0.0, 0.1]], [[0.5, 0.0], [0.0, 0.1]], [[0.5, 0.0], [0.0, 0.1]]]
+)
+samples = np.array([200, 500, 200])
+means = np.array([[0.0, -0.7], [0.0, 0.0], [0.0, 0.7]])
+estimators = [
+    (
+        """Finite mixture with a Dirichlet distribution
+prior and $\\gamma_0=$""",
+        BayesianGaussianMixture(
+            weight_concentration_prior_type="dirichlet_distribution",
+            n_components=2 * n_components,
+            reg_covar=0,
+            init_params="random",
+            max_iter=1500,
+            mean_precision_prior=0.8,
+            random_state=random_state,
+        ),
+        [0.001, 1, 1000],
+    ),
+    (
+        """Infinite mixture with a Dirichlet process
+ prior and$\\gamma_0=$""",
+        BayesianGaussianMixture(
+            weight_concentration_prior_type="dirichlet_process",
+            n_components=2 * n_components,
+            reg_covar=0,
+            init_params="random",
+            max_iter=1500,
+            mean_precision_prior=0.8,
+            random_state=random_state,
+        ),
+        [1, 1000, 100000],
+    ),
+]
+rng = np.random.RandomState(random_state)
+X = np.vstack(
+    [
+        rng.multivariate_normal(means[j], covars[j], samples[j])
+        for j in range(n_components)
+    ]
+)
+y = np.concatenate([np.full(samples[j], j, dtype=int) for j in range(n_components)])
+for title, estimator, concentrations_prior in estimators:
+    for k, concentration in enumerate(concentrations_prior):
+        estimator.weight_concentration_prior = concentration
+        estimator.fit(X)

--- a/tests/integration/slices/sklearn_model_selection_plot_randomized_search.py
+++ b/tests/integration/slices/sklearn_model_selection_plot_randomized_search.py
@@ -1,0 +1,23 @@
+# This is the manual slice of:
+#  grid_search
+# from file:
+#  sources/scikit-learn/examples/model_selection/plot_randomized_search.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_model_selection_plot_randomized_search]'
+
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.linear_model import SGDClassifier
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+
+X, y = load_digits(return_X_y=True, n_class=3)
+clf = SGDClassifier(loss="hinge", penalty="elasticnet", fit_intercept=True)
+param_grid = {
+    "average": [True, False],
+    "l1_ratio": np.linspace(0, 1, num=10),
+    "alpha": np.power(10, np.arange(-2, 1, dtype=float)),
+}
+grid_search = GridSearchCV(clf, param_grid=param_grid)
+grid_search.fit(X, y)
+linea_artifact_value = grid_search

--- a/tests/integration/slices/sklearn_multioutput_plot_classifier_chain_yeast.py
+++ b/tests/integration/slices/sklearn_multioutput_plot_classifier_chain_yeast.py
@@ -1,0 +1,21 @@
+# This is the manual slice of:
+#  chains
+# from file:
+#  sources/scikit-learn/examples/multioutput/plot_classifier_chain_yeast.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_multioutput_plot_classifier_chain_yeast]'
+
+from sklearn.datasets import fetch_openml
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.multioutput import ClassifierChain
+
+X, Y = fetch_openml("yeast", version=4, return_X_y=True)
+Y = Y == "TRUE"
+X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=0.2, random_state=0)
+base_lr = LogisticRegression()
+chains = [ClassifierChain(base_lr, order="random", random_state=i) for i in range(10)]
+for chain in chains:
+    chain.fit(X_train, Y_train)
+linea_artifact_value = chains

--- a/tests/integration/slices/sklearn_preprocessing_plot_scaling_importance.py
+++ b/tests/integration/slices/sklearn_preprocessing_plot_scaling_importance.py
@@ -1,0 +1,25 @@
+# This is the manual slice of:
+#  (unscaled_clf, std_clf)
+# from file:
+#  sources/scikit-learn/examples/preprocessing/plot_scaling_importance.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_preprocessing_plot_scaling_importance]'
+
+from sklearn.datasets import load_wine
+from sklearn.decomposition import PCA
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import GaussianNB
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+RANDOM_STATE = 42
+features, target = load_wine(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    features, target, test_size=0.3, random_state=RANDOM_STATE
+)
+unscaled_clf = make_pipeline(PCA(n_components=2), GaussianNB())
+unscaled_clf.fit(X_train, y_train)
+std_clf = make_pipeline(StandardScaler(), PCA(n_components=2), GaussianNB())
+std_clf.fit(X_train, y_train)
+linea_artifact_value = unscaled_clf, std_clf

--- a/tests/integration/slices/sklearn_semi_supervised_plot_label_propagation_structure.py
+++ b/tests/integration/slices/sklearn_semi_supervised_plot_label_propagation_structure.py
@@ -1,0 +1,21 @@
+# This is the manual slice of:
+#  label_spread
+# from file:
+#  sources/scikit-learn/examples/semi_supervised/plot_label_propagation_structure.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_semi_supervised_plot_label_propagation_structure]'
+
+import numpy as np
+from sklearn.datasets import make_circles
+from sklearn.semi_supervised import LabelSpreading
+
+n_samples = 200
+X, y = make_circles(n_samples=n_samples, shuffle=False)
+outer, inner = 0, 1
+labels = np.full(n_samples, -1.0)
+labels[0] = outer
+labels[-1] = inner
+label_spread = LabelSpreading(kernel="knn", alpha=0.8)
+label_spread.fit(X, labels)
+linea_artifact_value = label_spread

--- a/tests/integration/slices/sklearn_tree_plot_cost_complexity_pruning.py
+++ b/tests/integration/slices/sklearn_tree_plot_cost_complexity_pruning.py
@@ -1,0 +1,25 @@
+# This is the manual slice of:
+#  depth
+# from file:
+#  sources/scikit-learn/examples/tree/plot_cost_complexity_pruning.py
+
+# To verify that linea produces the same slice, run:
+#  pytest -m integration --runxfail -vv 'tests/integration/test_slice.py::test_slice[sklearn_tree_plot_cost_complexity_pruning]'
+
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from sklearn.tree import DecisionTreeClassifier
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+clf = DecisionTreeClassifier(random_state=0)
+path = clf.cost_complexity_pruning_path(X_train, y_train)
+ccp_alphas, impurities = path.ccp_alphas, path.impurities
+clfs = []
+for ccp_alpha in ccp_alphas:
+    clf = DecisionTreeClassifier(random_state=0, ccp_alpha=ccp_alpha)
+    clf.fit(X_train, y_train)
+    clfs.append(clf)
+clfs = clfs[:-1]
+depth = [clf.tree_.max_depth for clf in clfs]
+linea_artifact_value = depth

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -84,6 +84,7 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
     "matplotlib": Environment(
         conda_deps=["matplotlib", "numpy"],
     ),
+    "sklearn" : Environment(conda_deps=["scikit-learn", "numpy"])
 }
 
 # A list of the params to test
@@ -305,6 +306,68 @@ PARAMS = [
             reason="Annotating a module as if a class does not work inside for loop (no attribute of __self__)",
         ),
     ),
+    ##
+    # sklearn
+    ##
+
+    # template
+    # param(
+    #     "sklearn",
+    #     "scikit-learn/",
+    #     "",
+    #     id="sklearn_"
+    # ),
+    # sklearn.pipeline
+    param(
+        "sklearn",
+        "scikit-learn/examples/compose/plot_feature_union.py",
+        "grid_search",
+        id="sklearn_compose_plot_feature_union"
+    ),
+    # mixture
+    param(
+        "sklearn",
+        "scikit-learn/examples/mixture/plot_concentration_prior.py",
+        "estimators",
+        id="sklearn_mixture_plot_concentration_prior",
+        marks=mark.xfail(reason="Need to improve slicing within for loop"),
+    ),
+    # model_selection
+    param(
+        "sklearn",
+        "scikit-learn/examples/model_selection/plot_randomized_search.py",
+        "grid_search",
+        id="sklearn_model_selection_plot_randomized_search"
+    ),
+    # multioutput
+    param(
+        "sklearn",
+        "scikit-learn/examples/multioutput/plot_classifier_chain_yeast.py",
+        "chains",
+        id="sklearn_multioutput_plot_classifier_chain_yeast"
+    ),
+    # preprocessing
+    param(
+        "sklearn",
+        "scikit-learn/examples/preprocessing/plot_scaling_importance.py",
+        "(unscaled_clf, std_clf)",
+        id="sklearn_preprocessing_plot_scaling_importance"
+    ),
+    # semi_supervised
+    param(
+        "sklearn",
+        "scikit-learn/examples/semi_supervised/plot_label_propagation_structure.py",
+        "label_spread",
+        id="sklearn_semi_supervised_plot_label_propagation_structure"
+    ),
+    # list of clf to train
+    param(
+        "sklearn",
+        "scikit-learn/examples/tree/plot_cost_complexity_pruning.py",
+        "depth",
+        id = "sklearn_tree_plot_cost_complexity_pruning"
+    )
+
 ]
 
 

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -84,7 +84,7 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
     "matplotlib": Environment(
         conda_deps=["matplotlib", "numpy"],
     ),
-    "sklearn" : Environment(conda_deps=["scikit-learn", "numpy"])
+    "sklearn": Environment(conda_deps=["scikit-learn", "numpy"]),
 }
 
 # A list of the params to test
@@ -309,20 +309,11 @@ PARAMS = [
     ##
     # sklearn
     ##
-
-    # template
-    # param(
-    #     "sklearn",
-    #     "scikit-learn/",
-    #     "",
-    #     id="sklearn_"
-    # ),
-    # sklearn.pipeline
     param(
         "sklearn",
         "scikit-learn/examples/compose/plot_feature_union.py",
         "grid_search",
-        id="sklearn_compose_plot_feature_union"
+        id="sklearn_compose_plot_feature_union",
     ),
     # mixture
     param(
@@ -337,37 +328,36 @@ PARAMS = [
         "sklearn",
         "scikit-learn/examples/model_selection/plot_randomized_search.py",
         "grid_search",
-        id="sklearn_model_selection_plot_randomized_search"
+        id="sklearn_model_selection_plot_randomized_search",
     ),
     # multioutput
     param(
         "sklearn",
         "scikit-learn/examples/multioutput/plot_classifier_chain_yeast.py",
         "chains",
-        id="sklearn_multioutput_plot_classifier_chain_yeast"
+        id="sklearn_multioutput_plot_classifier_chain_yeast",
     ),
     # preprocessing
     param(
         "sklearn",
         "scikit-learn/examples/preprocessing/plot_scaling_importance.py",
         "(unscaled_clf, std_clf)",
-        id="sklearn_preprocessing_plot_scaling_importance"
+        id="sklearn_preprocessing_plot_scaling_importance",
     ),
     # semi_supervised
     param(
         "sklearn",
         "scikit-learn/examples/semi_supervised/plot_label_propagation_structure.py",
         "label_spread",
-        id="sklearn_semi_supervised_plot_label_propagation_structure"
+        id="sklearn_semi_supervised_plot_label_propagation_structure",
     ),
     # list of clf to train
     param(
         "sklearn",
         "scikit-learn/examples/tree/plot_cost_complexity_pruning.py",
         "depth",
-        id = "sklearn_tree_plot_cost_complexity_pruning"
-    )
-
+        id="sklearn_tree_plot_cost_complexity_pruning",
+    ),
 ]
 
 


### PR DESCRIPTION
# Description

Add integration test for `scikit-learn`. 

For `sklearn.base.BaseEstimator.fit_transform` method and classes within `sklearn.model_selection`. The original estimator does not mutate. `sklearn` is actually only copying the parameters. Thus, no need for new annotations. 

Fixes # (issue)

LIN-382

## Type of change

- [x] New tests

# How Has This Been Tested?

Local integration tests.
