### PR TITLE
LIN-390 - rename the .linea folder to .lineapy

### DIFF
--- a/docs/source/guide/build_pipelines/index.rst
+++ b/docs/source/guide/build_pipelines/index.rst
@@ -184,6 +184,8 @@ Finally, we have the automatically generated Dockerfile (``demo_airflow_pipeline
 
    CMD [ "standalone" ]
 
+.. _testingairflow:
+
 Testing Locally
 ---------------
 

--- a/docs/source/guide/manage_artifacts/database/postgres.rst
+++ b/docs/source/guide/manage_artifacts/database/postgres.rst
@@ -90,7 +90,7 @@ if successful. Otherwise, it will default back to SQLite and print:
 
 .. code:: none
 
-    sqlite:///.linea/db.sqlite
+    sqlite:///.lineapy/db.sqlite
 
 Known Issues
 ------------

--- a/docs/source/support/faq.rst
+++ b/docs/source/support/faq.rst
@@ -1,8 +1,6 @@
 FAQ
 ===
 
------
-
 Why do I get an error for database lock?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -15,13 +13,13 @@ navigate to your home directory and run:
 
 .. code:: bash
 
-    $ fuser .linea/db.sqlite
+    $ fuser .lineapy/db.sqlite
 
 which will list process ID(s) connecting to the database, like so:
 
 .. code:: none
 
-    .linea/db.sqlite: 78638
+    .lineapy/db.sqlite: 78638
 
 You can then terminate the troublesome process(es) with:
 

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-FOLDER_NAME = ".linea"
+FOLDER_NAME = ".lineapy"
 
 LOG_FILE_NAME = "linea.log"
 


### PR DESCRIPTION
# Description

We made our package public using the name lineapy. Making sure the reference to the .linea folder gets updated to reflect the name.

Fixes LIN-390

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
