### PR TITLE
Lin 397 docs add documentation on the flavors of notebooks linea py works with

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,26 +120,25 @@ to different sessions; you will need to repeat it for each new session.
 
 #### Hosted Jupyter Environment
 
-In hosted Jupyter notebook environments such as JupyterHub, Google Colab, Kaggle or other environments that you do not start your notebook from CLI(such as Jupyter extension within VS Code), you need to install `lineapy` directly within your notebook first via:
+In hosted Jupyter notebook environments such as JupyterHub, Google Colab, Kaggle or other environments that you do not start your notebook from CLI (such as Jupyter extension within VS Code), you need to install `lineapy` directly within your notebook first via:
 
 ```ipython
 !pip install lineapy
 ```
 
-then you can manually load `lineapy` with :
+then you can manually load `lineapy` extension with :
 
 ```python
 %load_ext lineapy
 ```
 
-For environments with older versions `IPython` like Google Colab, we need to upgrade the `IPython` module before the above steps, we can upgrade `IPython` via:
+For environments with older versions `IPython<7.0` like Google Colab, we need to upgrade the `IPython>=7.0` module before the above steps, we can upgrade `IPython` via:
 
 ```ipython
-%%capture
 !pip install --upgrade ipython
 ```
 
-and elegantly restart the notebook runtime with:
+and restart the notebook runtime:
 
 ```ipython
 exit()

--- a/README.md
+++ b/README.md
@@ -118,6 +118,35 @@ in the middle of a session will lead to erroneous behaviors by LineaPy.
 - This loads the extension to the current session only, i.e., it does not carry over
 to different sessions; you will need to repeat it for each new session.
 
+#### Hosted Jupyter Environment
+
+In hosted Jupyter notebook environments such as JupyterHub, Google Colab, Kaggle or other environments that you do not start your notebook from CLI(such as Jupyter extension within VS Code), you need to install `lineapy` directly within your notebook first via:
+
+```ipython
+!pip install lineapy
+```
+
+then you can manually load `lineapy` with :
+
+```python
+%load_ext lineapy
+```
+
+For environments with older versions `IPython` like Google Colab, we need to upgrade the `IPython` module before the above steps, we can upgrade `IPython` via:
+
+```ipython
+%%capture
+!pip install --upgrade ipython
+```
+
+and elegantly restart the notebook runtime with:
+
+```ipython
+exit()
+```
+
+then we can start setting up LineaPy as described previously.
+
 #### CLI
 
 We can also use LineaPy as a CLI command. Run:

--- a/docs/source/fundamentals/interfaces.rst
+++ b/docs/source/fundamentals/interfaces.rst
@@ -37,6 +37,39 @@ executed at the top of your session. Please note:
 
 - This loads the extension to the current session only, i.e., it does not carry over to different sessions; you will need to repeat it for each new session.
 
+
+Hosted Jupyter Environment
+-------------------
+
+In hosted Jupyter notebook environments such as JupyterHub, Google Colab, Kaggle or other environments
+that you do not start your notebook from CLI(such as Jupyter extension within VS Code), you need to
+install `lineapy` directly within your notebook first via:
+
+.. code:: python
+
+    !pip install lineapy
+
+Then you can manually load `lineapy` extension with :
+
+.. code:: python
+
+    %load_ext lineapy
+
+For environments with older versions `IPython` like Google Colab, we need to upgrade the `IPython` module before the above steps, we can upgrade `IPython` via:
+
+.. code:: python
+
+    %%capture
+    !pip install --upgrade ipython
+
+and elegantly restart the notebook runtime with:
+
+.. code:: python
+
+    exit()
+
+Finally, we can start setting up LineaPy as described previously.
+
 CLI
 ---
 

--- a/docs/source/fundamentals/interfaces.rst
+++ b/docs/source/fundamentals/interfaces.rst
@@ -39,30 +39,29 @@ executed at the top of your session. Please note:
 
 
 Hosted Jupyter Environment
--------------------
+--------------------------
 
 In hosted Jupyter notebook environments such as JupyterHub, Google Colab, Kaggle or other environments
-that you do not start your notebook from CLI(such as Jupyter extension within VS Code), you need to
-install `lineapy` directly within your notebook first via:
+that you do not start your notebook from CLI (such as Jupyter extension within VS Code), you need to
+install ``lineapy`` directly within your notebook first via:
 
 .. code:: python
 
     !pip install lineapy
 
-Then you can manually load `lineapy` extension with :
+Then you can manually load ``lineapy`` extension with :
 
 .. code:: python
 
     %load_ext lineapy
 
-For environments with older versions `IPython` like Google Colab, we need to upgrade the `IPython` module before the above steps, we can upgrade `IPython` via:
+For environments with older versions ``IPython<7.0`` like Google Colab, we need to upgrade the ``IPython>=7.0`` module before the above steps, we can upgrade ``IPython`` via:
 
 .. code:: python
 
-    %%capture
     !pip install --upgrade ipython
 
-and elegantly restart the notebook runtime with:
+and restart the notebook runtime:
 
 .. code:: python
 


### PR DESCRIPTION
# Description

Update docs for usage in different flavors of notebooks. Add a section `Hosted Jupyter Environment` for that.

Fixes # (issue)

LIN-397

## Type of change

Docs

# How Has This Been Tested?

Sphinx docs have been tested locally.