### PR TITLE
LIN-357 rtd markdown link cleanup

### DIFF
--- a/docs/source/references/internals.rst
+++ b/docs/source/references/internals.rst
@@ -17,8 +17,8 @@ As well as the program graph, we also store some information about how things
 were executed and the source code the graph was derived from.
 
 We persist our graph structure to SQL (currently SQLite) using SQAlchemy,
-an ORM. The :class:`lineapy.data.types` file stores the graph nodes
-and the :class:`lineapy.db.relational` file stores the SQLAlchemy wrappers.
+an ORM. The :mod:`lineapy.data.types` file stores the graph nodes
+and the :mod:`lineapy.db.relational` file stores the SQLAlchemy wrappers.
 
 TODO: Visual of SQL table relationships
 
@@ -194,7 +194,7 @@ to a graph.
 CLI
 ++++
 
-In :class:`lineapy.cli.cli` we support running a Python file from the
+In :mod:`lineapy.cli.cli` we support running a Python file from the
 CLI. That can produce some output, such as (1) printing out sliced code/graph,
 and (2) optionally to airflow file.
 
@@ -211,7 +211,7 @@ Jupyter / IPython
 
 We also supporting tracing using IPython (and so by proxy, Jupyter).
 
-This is implemented in the :class:`lineapy.editors.ipython` file. That class
+This is implemented in the :mod:`lineapy.editors.ipython` file. That class
 provides three main entry points:
 
 #. `start()`: Starts tracing by adding a function to `input_transformers_post <https://ipython.readthedocs.io/en/stable/config/inputtransforms.html#string-based-transformations>`_ which takes in a list of strings of the cell contents, and returns a list of strings which are executed by IPython.
@@ -236,14 +236,14 @@ for handling exceptions in Jupyter. Instead, we set override the
 ~~~~~~~~~~~~~~~~~~
 
 Once we have initialized lineapy with the user's code, we traverse that through the
-python AST using a visitor defined in :class:`lineapy.transformer.node_transformer`.
+python AST using a visitor defined in :mod:`lineapy.transformer.node_transformer`.
 
 As we traverse the AST, we create nodes for each piece of it.
 
 3. Creating nodes
 ~~~~~~~~~~~~~~~~~
 
-This `NodeTransformer` relies on a tracer defined in :class:`lineapy.instrumentation.tracer`
+This `NodeTransformer` relies on an :class:`lineapy.instrumentation.tracer.Tracer`
 to actually create the nodes.
 
 The general process to create a node is:
@@ -259,7 +259,7 @@ We go into these side effects lower down, since they pertain to multiple layers.
 ~~~~~~~~~~~~~~~~~~
 
 As mentioned above, the `Tracer` passes on the responsibility of executing the
-node to the :class:`lineapy.execution.executor`. This is responsible
+node to the :class:`lineapy.execution.executor.Executor`. This is responsible
 for keeping a mapping of each node and its value after being executed.
 
 It returns a number of "side effects" which say things like "Node xxx was modified"
@@ -272,7 +272,7 @@ side effects that are described below.
 When we try to execute a `CallNode`, we need to know things like "does this
 modify any of its arguments?" to understand how it affects the graph.
 
-This reasoning is implemented in :class:`lineapy.execution.inspect_function`
+This reasoning is implemented in :mod:`lineapy.execution.inspect_function`
 which is basically one big switch statement, that understands certain
 Python functions. If some function is not being sliced properly,
 it is likely due to it being missing from this file.
@@ -291,7 +291,7 @@ Reading graphs
 
 After we have created a graph, we can perform a number of operations on it.
 
-Many of these use the :class:`lineapy.data.graph` object which represents
+Many of these use the :mod:`lineapy.data.graph` object which represents
 a collection of nodes. It can sort them topologically and by line number, meaning
 that any node will come after its parents, and all nodes with line numbers will
 be sorted by those as well.
@@ -322,16 +322,16 @@ lines that are not required to reproduce some result are removed.
 What this means is that the graph structure needs to represent program
 dependence, which is why some of our more complicated analysis are required.
 
-This is implemented in :class:`lineapy.graph_reader.program_slice`.
+This is implemented in :mod:`lineapy.graph_reader.program_slice`.
 
 Visualizing
 ~~~~~~~~~~~
 
 We currently supporting visualizing a graph using Graphviz for debugging
 and teaching purposes. This is implemented in the
-:class:`lineapy.visualizer` directory with three main files:
+:mod:`lineapy.visualizer` directory with three main files:
 
-#. :class:`lineapy.visualizer`: Provides a `Visualizer` object which is the publicly exposed
+#. :mod:`lineapy.visualizer`: Provides a `Visualizer` object which is the publicly exposed
    interface for visualizing a graph. In supports creating it for a number of
    different scenarios, each with their own configurations set. For example,
    we want to show more detail in our testing than in our public API.
@@ -342,7 +342,7 @@ and teaching purposes. This is implemented in the
    during re-execution, so the tracer is unavailable.
    It also supports a number of ways to viewing the visualization, like
    as SVG, PDF, or as Jupyter Output.
-#. :class:`lineapy.visualizer.graphviz`: This files manages actually creating the graphviz source
+#. :mod:`lineapy.visualizer.graphviz`: This files manages actually creating the graphviz source
    using the `Graphviz <https://graphviz.readthedocs.io/en/stable/index.html>`_
    library. It renders each edge and node, and also renders a legend.
 #. :meth:`lineapy.visualizer.visual_graph.to_visual_graph`: This takes in the Graph and (optional) Tracer and returns
@@ -361,7 +361,7 @@ Outputting to airflow
 
 On top of just slicing the code, we also support creating an Airflow DAG out
 of the resulting code. This is currently implemented through string templating
-in :class:`lineapy.plugins.airflow` to create a file that airflow can understand.
+in :mod:`lineapy.plugins.airflow` to create a file that airflow can understand.
 
 All of the code is currently saved in one `PythonOperator`.
 
@@ -370,7 +370,7 @@ This is exposed to users in two ways:
 1. In the cli through the `--export-slice-to-airflow-dag` flag, which will
    save the resulting DAG to the current directory.
 2. In our API (usable in a script or in Jupyter) through the `to_airflow` method
-   on a saved artifact. This is implemented in :class:`lineapy.graph_reader.apis`.
+   on a saved artifact. This is implemented in :mod:`lineapy.graph_reader.apis`.
    Instead of saving to the current directory, this tries to find Airflow's
    DAGs folder, by looking at the `AIRFLOW_HOME` environment variable and saving it
    in there, so it is picked up by Airflow automatically.
@@ -485,7 +485,7 @@ when we see we have a `MutatedNode` side effect we know to make a new
 mutated, the other is a new node type that represents the result of this mutation).
 It also updates a mapping that points from each source node to its mutate node,
 so that when we then go to lookup a node, we point to the mutate node, instead
-of the source. This mapping and the logic to update it is kept in :class:`lineapy.instrumentation.mutation_tracker`.
+of the source. This mapping and the logic to update it is kept in :mod:`lineapy.instrumentation.mutation_tracker`.
 
 For #3, similar to #1, `inspect_function` returns a `ViewOfValues`, which is transformed
 into a `ViewOfNodes` in the `Executor`.
@@ -512,7 +512,7 @@ The life of a black box node goes through a number of stages:
    node for the string, and then a `CallNode` which execs the string.
    We differentiate between exec-ing a "statement" versus an "expression",
    since an expression will return some value, while a statement does not.
-#. The functions we use to do the `exec` are defined in :mod:`lineapy.lineabuiltins`, :func:`lineapy.lineabuiltins.l_exec_statement` and :func:`lineapy.lineabuiltins.l_exec_expr`. Along with
+#. The functions we use to do the `exec` are defined in :mod:`lineapy.utils.lineabuiltins`, :func:`lineapy.utils.lineabuiltins.l_exec_statement` and :func:`lineapy.utils.lineabuiltins.l_exec_expr`. Along with
    actually calling `exec`, they set up the source code context, so that
    exceptions raised in code that is `exec`ed has the proper traceback
    and also make sure to use it uses the correct globals.
@@ -612,7 +612,7 @@ We can think about these use cases under this framework:
    node for that implicitly defined node.
 #. Whenever we have a node that depends on the state of that side effect,
    we add that node as an implicit dependency.
-#. Whenever we manually refer to that implicit node, as in :class:`lineapy.file_system`
+#. Whenever we manually refer to that implicit node, as in :class:`lineapy.utils.lineabuiltins.file_system`
    we have this also have an implicit dependency on the most recent version of that node.
 
 Currently we only support the broad categories of side effects, but we can
@@ -621,7 +621,7 @@ particular file.
 
 We implement the following framework by:
 
-#. We create a global for `file_system` and `db` in :mod:`lineapy.lineabuiltins`. Both of these
+#. We create a global for `file_system` and `db` in :mod:`lineapy.utils.lineabuiltins`. Both of these
    are instances of `ExternalState`, a class defined in that file.
    This lets them be accessed through a `LookupNode`.
 #. We can bubble this up from the `inspect_function.py` by passing an instance of `ExternalState` in as
@@ -698,8 +698,8 @@ LineaPy API (step 4)
 
 Although LineaPy does not require any annotations to trace your code, we do provide
 some functions that you can use to annotate it to tell us what is important
-and also to interact with LineaPy. These are defined in :class:`lineapy.api` and returns
-objects defined in :class:`lineapy.graph_reader.apis`.
+and also to interact with LineaPy. These are defined in :mod:`lineapy.api` and returns
+objects defined in :mod:`lineapy.graph_reader.apis`.
 
 Implementing these functions require us to break a key abstraction we have which is that
 executing code while tracing LineaPy should perform the same as while not tracing with LineaPy.
@@ -715,7 +715,7 @@ _Writing this, I realize that we might not need the context for the `l_exec` fun
 
 We break this abstraction by having the executor set up a global context, using `set_context`
 before it calls any nodes, and providing the `get_context` function to retrieve it. These
-are both defined in :class:`lineapy.execution.context`.
+are both defined in :mod:`lineapy.execution.context`.
 
 This lets our API functions access the current node being executed, as well as the current DB.
 
@@ -735,5 +735,5 @@ We do two special things to change how exceptions are handled:
    source code which originated it.
    We do this by removing the top frame, and adding back a fake frame with the proper
    source code position. Then when python prints the exception, it will look the same.
-   This is done in :class:`lineapy.exceptions.user_exception` and
-   the fake frame creation in :class:`lineapy.exceptions.create_frame`.
+   This is done in :mod:`lineapy.exceptions.user_exception` and
+   the fake frame creation in :mod:`lineapy.exceptions.create_frame`.

--- a/docs/source/references/internals.rst
+++ b/docs/source/references/internals.rst
@@ -17,8 +17,8 @@ As well as the program graph, we also store some information about how things
 were executed and the source code the graph was derived from.
 
 We persist our graph structure to SQL (currently SQLite) using SQAlchemy,
-an ORM. The [`types.py`](./lineapy/data/types.py) file stores the graph nodes
-and the `relational.py` file stores the SQLAlchemy wrappers.
+an ORM. The :class:`lineapy.data.types` file stores the graph nodes
+and the :class:`lineapy.db.relational` file stores the SQLAlchemy wrappers.
 
 TODO: Visual of SQL table relationships
 
@@ -194,7 +194,7 @@ to a graph.
 CLI
 ++++
 
-In [`cli.py`](lineapy/cli/cli.py) we support running a Python file from the
+In :class:`lineapy.cli.cli` we support running a Python file from the
 CLI. That can produce some output, such as (1) printing out sliced code/graph,
 and (2) optionally to airflow file.
 
@@ -211,7 +211,7 @@ Jupyter / IPython
 
 We also supporting tracing using IPython (and so by proxy, Jupyter).
 
-This is implemented in the [`ipython.py`](lineapy/ipython.py) file. That file
+This is implemented in the :class:`lineapy.editors.ipython` file. That class
 provides three main entry points:
 
 #. `start()`: Starts tracing by adding a function to `input_transformers_post <https://ipython.readthedocs.io/en/stable/config/inputtransforms.html#string-based-transformations>`_ which takes in a list of strings of the cell contents, and returns a list of strings which are executed by IPython.
@@ -236,14 +236,14 @@ for handling exceptions in Jupyter. Instead, we set override the
 ~~~~~~~~~~~~~~~~~~
 
 Once we have initialized lineapy with the user's code, we traverse that through the
-python AST using a visitor defined in [`node_transformer.py`](lineapy/transformer/node_transformer.py).
+python AST using a visitor defined in :class:`lineapy.transformer.node_transformer`.
 
 As we traverse the AST, we create nodes for each piece of it.
 
 3. Creating nodes
 ~~~~~~~~~~~~~~~~~
 
-This `NodeTransformer` relies on an [`Tracer`](lineapy/instrumentation/tracer.py)
+This `NodeTransformer` relies on a tracer defined in :class:`lineapy.instrumentation.tracer`
 to actually create the nodes.
 
 The general process to create a node is:
@@ -259,7 +259,7 @@ We go into these side effects lower down, since they pertain to multiple layers.
 ~~~~~~~~~~~~~~~~~~
 
 As mentioned above, the `Tracer` passes on the responsibility of executing the
-node to the [`Executor`](lineapy/execution/executor.py). This is responsible
+node to the :class:`lineapy.execution.executor`. This is responsible
 for keeping a mapping of each node and its value after being executed.
 
 It returns a number of "side effects" which say things like "Node xxx was modified"
@@ -272,7 +272,7 @@ side effects that are described below.
 When we try to execute a `CallNode`, we need to know things like "does this
 modify any of its arguments?" to understand how it affects the graph.
 
-This reasoning is implemented in [`inspect_function`](lineapy/execution/inspect_function.py)
+This reasoning is implemented in :class:`lineapy.execution.inspect_function`
 which is basically one big switch statement, that understands certain
 Python functions. If some function is not being sliced properly,
 it is likely due to it being missing from this file.
@@ -291,7 +291,7 @@ Reading graphs
 
 After we have created a graph, we can perform a number of operations on it.
 
-Many of these use the [`Graph`](lineapy/data/graph.py) object which represents
+Many of these use the :class:`lineapy.data.graph` object which represents
 a collection of nodes. It can sort them topologically and by line number, meaning
 that any node will come after its parents, and all nodes with line numbers will
 be sorted by those as well.
@@ -322,14 +322,14 @@ lines that are not required to reproduce some result are removed.
 What this means is that the graph structure needs to represent program
 dependence, which is why some of our more complicated analysis are required.
 
-This is implemented in [`program_slice`](lineapy/graph_reader/program_slice.py).
+This is implemented in :class:`lineapy.graph_reader.program_slice`.
 
 Visualizing
 ~~~~~~~~~~~
 
 We currently supporting visualizing a graph using Graphviz for debugging
 and teaching purposes. This is implemented in the
-[`visualizer`](lineapy/visualizer) directory with three main files:
+:class:`lineapy.visualizer` directory with three main files:
 
 #. :class:`lineapy.visualizer`: Provides a `Visualizer` object which is the publicly exposed
    interface for visualizing a graph. In supports creating it for a number of
@@ -361,7 +361,7 @@ Outputting to airflow
 
 On top of just slicing the code, we also support creating an Airflow DAG out
 of the resulting code. This is currently implemented through string templating
-in [`airflow.py`](lineapy/plugins/airflow.py) to create a file that airflow can understand.
+in :class:`lineapy.plugins.airflow` to create a file that airflow can understand.
 
 All of the code is currently saved in one `PythonOperator`.
 
@@ -370,7 +370,7 @@ This is exposed to users in two ways:
 1. In the cli through the `--export-slice-to-airflow-dag` flag, which will
    save the resulting DAG to the current directory.
 2. In our API (usable in a script or in Jupyter) through the `to_airflow` method
-   on a saved artifact. This is implemented in [`apis.py`](lineapy/graph_reader/apis.py).
+   on a saved artifact. This is implemented in :class:`lineapy.graph_reader.apis`.
    Instead of saving to the current directory, this tries to find Airflow's
    DAGs folder, by looking at the `AIRFLOW_HOME` environment variable and saving it
    in there, so it is picked up by Airflow automatically.
@@ -485,7 +485,7 @@ when we see we have a `MutatedNode` side effect we know to make a new
 mutated, the other is a new node type that represents the result of this mutation).
 It also updates a mapping that points from each source node to its mutate node,
 so that when we then go to lookup a node, we point to the mutate node, instead
-of the source. This mapping and the logic to update it is kept in [`mutation_tracker.py`](lineapy/instrumentation/mutation_tracker.py).
+of the source. This mapping and the logic to update it is kept in :class:`lineapy.instrumentation.mutation_tracker`.
 
 For #3, similar to #1, `inspect_function` returns a `ViewOfValues`, which is transformed
 into a `ViewOfNodes` in the `Executor`.
@@ -698,8 +698,8 @@ LineaPy API (step 4)
 
 Although LineaPy does not require any annotations to trace your code, we do provide
 some functions that you can use to annotate it to tell us what is important
-and also to interact with LineaPy. These are defined in [`api.py`](lineapy/api.py) and returns
-objects defined in [`apis.py`](lineapy/graph_reader/apis.py).
+and also to interact with LineaPy. These are defined in :class:`lineapy.api` and returns
+objects defined in :class:`lineapy.graph_reader.apis`.
 
 Implementing these functions require us to break a key abstraction we have which is that
 executing code while tracing LineaPy should perform the same as while not tracing with LineaPy.
@@ -715,7 +715,7 @@ _Writing this, I realize that we might not need the context for the `l_exec` fun
 
 We break this abstraction by having the executor set up a global context, using `set_context`
 before it calls any nodes, and providing the `get_context` function to retrieve it. These
-are both defined in [`context.py`](lineapy/execution/context.py).
+are both defined in :class:`lineapy.execution.context`.
 
 This lets our API functions access the current node being executed, as well as the current DB.
 
@@ -725,7 +725,7 @@ Exception handling (steps 1 and 4)
 We do two special things to change how exceptions are handled:
 
 #. In step 1: Remove the frames we add in LineaPy off of the stack to show a user their
-   original exception. We do this by raising a [`lineapy.exceptions.user_exception.UserException`](lineapy/exceptions/user_exception.py)
+   original exception. We do this by raising a :class:`lineapy.exceptions.user_exception.UserException`
    which contains the original exception that was raised. Then in Step 1 above
    (either in the CLI or Jupyter), we see if the exception raised was a `UserException`
    and if so we just use the inner exception.
@@ -735,5 +735,5 @@ We do two special things to change how exceptions are handled:
    source code which originated it.
    We do this by removing the top frame, and adding back a fake frame with the proper
    source code position. Then when python prints the exception, it will look the same.
-   This is done in [`user_exception.py`](lineapy/exceptions/user_exception.py) and
-   the fake frame creation in [`create_frame.py`](lineapy/exceptions/create_frame.py).
+   This is done in :class:`lineapy.exceptions.user_exception` and
+   the fake frame creation in :class:`lineapy.exceptions.create_frame`.


### PR DESCRIPTION
# Description

Fix broken existing links in RTD and clean up markdown style broken links.

Fixes # (issue)

LIN-357

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local doc build, verify no '](' exists and verify links are working.