### PR TITLE
Refactor a function to address warning (future error)

### DIFF
--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -481,14 +481,16 @@ class RelationalLineaDB:
         make it distinct on a subset of columns: session_id, name, and version.
         """
         return (
-            self.session.query(ImportNodeORM)
+            self.session.query(
+                ImportNodeORM.package_name, ImportNodeORM.version
+            )
             .filter(
                 and_(
                     ImportNodeORM.session_id == session_id,
                     ImportNodeORM.version is not None,
                 )
             )
-            .distinct(ImportNodeORM.package_name)
+            .distinct()
             .all()
         )
 

--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -487,7 +487,7 @@ class RelationalLineaDB:
             .filter(
                 and_(
                     ImportNodeORM.session_id == session_id,
-                    ImportNodeORM.version is not None,
+                    ImportNodeORM.version != "None",
                 )
             )
             .distinct()

--- a/lineapy/plugins/base.py
+++ b/lineapy/plugins/base.py
@@ -89,10 +89,10 @@ class BasePlugin:
         all_libs = self.db.get_libraries_for_session(self.session_id)
         lib_names_text = ""
         for lib in all_libs:
-            if lib.name in sys.modules:
-                text = get_lib_version_text(str(lib.package_name))
+            lib_name = str(lib.package_name)
+            if lib_name in sys.modules:
+                text = get_lib_version_text(lib_name)
                 lib_names_text += f"{text}\n"
-        # lib_names_text = "\n".join([str(lib.name) for lib in all_libs])
         (output_dir_path / (module_name + "_requirements.txt")).write_text(
             lib_names_text
         )

--- a/lineapy/utils/analytics/__init__.py
+++ b/lineapy/utils/analytics/__init__.py
@@ -35,9 +35,9 @@ def allow_do_not_track(fn: C) -> C:
 def send_lib_info_from_db(db: RelationalLineaDB, session_id: LineaID):
     import_nodes = db.get_libraries_for_session(session_id)
     [
-        track(LibImportEvent(str(n.name), str(n.version)))
+        track(LibImportEvent(str(n.package_name), str(n.version)))
         for n in import_nodes
-        if n.name != "lineapy"
+        if n.package_name != "lineapy"
     ]
     return
 


### PR DESCRIPTION
# Description

This change is to address the warning that `DISTINCT ON` query may not work in non-Postgres backends. So we just query the fields we need and then apply `DISTINCT` without `ON` params.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI will kick in.