### PR TITLE
Reload annotations

### DIFF
--- a/docs/source/tutorials/04a_adding_library_annotations.ipynb
+++ b/docs/source/tutorials/04a_adding_library_annotations.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "91401518-703c-4bfe-bfc1-add0eca794b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: http://localhost:4040/linea/dev/+simple/\n",
+      "Requirement already satisfied: pyperclip in /Users/simba/opt/miniconda3/envs/py39/lib/python3.9/site-packages (1.8.2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!pip install pyperclip\n",
+    "# NBVAL_SKIP\n",
+    "import pyperclip\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a0673d80-d287-47fb-bc2e-45cb2d4c6629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "with open(\"lib_annotation_sample.yaml\", \"w\") as f:\n",
+    "    f.write(\"\"\"\n",
+    "- module: pyperclip\n",
+    "  annotations:\n",
+    "    - criteria:\n",
+    "        function_names:\n",
+    "          - copy\n",
+    "          - paste\n",
+    "      side_effects:\n",
+    "        - mutated_value:\n",
+    "            self_ref: SELF_REF\n",
+    "\n",
+    "    \"\"\")\n",
+    "    f.flush()\n",
+    "    f.close()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9c8f1953-1e81-4bcc-bc34-994b424363b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/simba/Projects/lineapy/examples/tutorials'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "import os\n",
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "62c5da93-a171-4b4c-9b9b-8cbf108c36c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Module specification: {\n",
+      "    \"module\": \"pyperclip\",\n",
+      "    \"annotations\": [\n",
+      "        {\n",
+      "            \"criteria\": {\n",
+      "                \"function_names\": [\n",
+      "                    \"copy\",\n",
+      "                    \"paste\"\n",
+      "                ]\n",
+      "            },\n",
+      "            \"side_effects\": [\n",
+      "                {\n",
+      "                    \"mutated_value\": {\n",
+      "                        \"self_ref\": \"SELF_REF\"\n",
+      "                    }\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n",
+      "\n",
+      "Creating annotation source custom at /Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!lineapy annotate add --name \"lib_annotation_sample\" \"./lib_annotation_sample.yaml\"\n",
+    "lineapy.reload()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "acb7efbe-bd55-403c-8a5d-b5e5690ed014",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "custom\t/Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!lineapy annotate list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3c45849d-ce52-4590-879e-6c9f3675de3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "  \n",
+    "pyperclip.copy(\"This wont show up without annotations\")\n",
+    "tmp_var = pyperclip.paste()\n",
+    "\n",
+    "art_annot = lineapy.save(tmp_var, \"annotated_text\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d4d40cd5-a24f-4335-b375-bc2db1003038",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "import pyperclip\n",
+      "\n",
+      "pyperclip.copy(\"This wont show up without annotations\")\n",
+      "tmp_var = pyperclip.paste()\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# The output here will NOT display the line pyperclip.copy\n",
+    "# New annotations are reloaded at the start of a session. \n",
+    "# Try restarting the kernel and rerun to see the updated output.\n",
+    "\n",
+    "print(art_annot.get_code())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "af881176-279b-4530-8a00-8d9ee2ad7697",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
+    "\n",
+    "!lineapy annotate delete --name \"lib_annotation_sample\"\n",
+    "os.unlink(\"lib_annotation_sample.yaml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/tutorials/04b_adding_custom_annotations.ipynb
+++ b/docs/source/tutorials/04b_adding_custom_annotations.ipynb
@@ -33,7 +33,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "from .myclass import MyClass\n",
+      "from .sample_user_class import MyClass\n",
       "\n",
       "a = MyClass()\n",
       "\n"
@@ -54,7 +54,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "myclass\n"
+      "sample_user_class\n"
      ]
     }
    ],
@@ -79,7 +79,7 @@
    "source": [
     "with open(\"usercode_annotation_sample.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
-    "- module: myclass\n",
+    "- module: sample_user_class\n",
     "  annotations:\n",
     "    - criteria:\n",
     "          class_instance: MyClass\n",
@@ -127,7 +127,7 @@
      "output_type": "stream",
      "text": [
       "Module specification: {\n",
-      "    \"module\": \"myclass\",\n",
+      "    \"module\": \"sample_user_class\",\n",
       "    \"annotations\": [\n",
       "        {\n",
       "            \"criteria\": {\n",
@@ -145,7 +145,8 @@
       "    ]\n",
       "}\n",
       "\n",
-      "Creating annotation source custom2 at /Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "Creating annotation source usercode_annotation_sample at \u001b[35m/Users/simba/.lineapy/c\u001b[0m\n",
+      "\u001b[35mustom-annotations/\u001b[0m\u001b[95musercode_annotation_sample.annotations.yaml\u001b[0m                   \n",
       "\u001b[0m"
      ]
     }
@@ -166,7 +167,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "custom2\t/Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "usercode_annotation_sample\t/Users/simba/.lineapy/custom-annotations/usercode_annotation_sample.annotations.yaml\n",
+      "custom\t/Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
@@ -199,7 +201,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "from .myclass import MyClass\n",
+      "from .sample_user_class import MyClass\n",
       "\n",
       "b = MyClass()\n",
       "b.update_counter()\n",

--- a/docs/source/tutorials/04b_adding_custom_annotations.ipynb
+++ b/docs/source/tutorials/04b_adding_custom_annotations.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "91401518-703c-4bfe-bfc1-add0eca794b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from .sample_user_class import MyClass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6f2f01af-d2e5-4644-814a-f235d604b348",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MyClass()\n",
+    "a.update_counter()\n",
+    "\n",
+    "art_no_annot = lineapy.save(a, \"notannotated\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f0fcc7c0-742b-496f-aa11-29a01441a3fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from .myclass import MyClass\n",
+      "\n",
+      "a = MyClass()\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(art_no_annot.get_code())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "15149d1d-92e5-46b2-bb7c-c9f39a98d80a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "myclass\n"
+     ]
+    }
+   ],
+   "source": [
+    "# first, lets understand the module of the function you want to add\n",
+    "# in this case the module is straightforward since it is being imported from our myclass.py\n",
+    "\n",
+    "print(a.update_counter.__self__.__module__)\n",
+    "\n",
+    "# This module name should be the first line of the annotation: \"module: myclass\"\n",
+    "# Next is the list of annotations that we want to add. Refer to TODO:<annotation_specs link> in the docs\n",
+    "# In this case, we want to annotate the update_counter class method that modifies the class attribute \"counter\"\n",
+    "# Instead of fine tuning it to the attribute level, we say that the instance itself has been modified "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a0673d80-d287-47fb-bc2e-45cb2d4c6629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"usercode_annotation_sample.yaml\", \"w\") as f:\n",
+    "    f.write(\"\"\"\n",
+    "- module: myclass\n",
+    "  annotations:\n",
+    "    - criteria:\n",
+    "          class_instance: MyClass\n",
+    "          class_method_name: update_counter\n",
+    "      side_effects:\n",
+    "        - mutated_value:\n",
+    "            self_ref: SELF_REF\n",
+    "\n",
+    "    \"\"\")\n",
+    "    f.flush()\n",
+    "    f.close()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9c8f1953-1e81-4bcc-bc34-994b424363b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/simba/Projects/lineapy/examples/tutorials'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "import os\n",
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "62c5da93-a171-4b4c-9b9b-8cbf108c36c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Module specification: {\n",
+      "    \"module\": \"myclass\",\n",
+      "    \"annotations\": [\n",
+      "        {\n",
+      "            \"criteria\": {\n",
+      "                \"class_instance\": \"MyClass\",\n",
+      "                \"class_method_name\": \"update_counter\"\n",
+      "            },\n",
+      "            \"side_effects\": [\n",
+      "                {\n",
+      "                    \"mutated_value\": {\n",
+      "                        \"self_ref\": \"SELF_REF\"\n",
+      "                    }\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n",
+      "\n",
+      "Creating annotation source custom2 at /Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "!lineapy annotate add --name \"usercode_annotation_sample\" \"./usercode_annotation_sample.yaml\"\n",
+    "lineapy.reload()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "acb7efbe-bd55-403c-8a5d-b5e5690ed014",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "custom2\t/Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "!lineapy annotate list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3c45849d-ce52-4590-879e-6c9f3675de3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = MyClass()\n",
+    "b.update_counter()\n",
+    "\n",
+    "art_annot = lineapy.save(b, \"annotated\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d4d40cd5-a24f-4335-b375-bc2db1003038",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from .myclass import MyClass\n",
+      "\n",
+      "b = MyClass()\n",
+      "b.update_counter()\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The output here will NOT display the line pyperclip.copy\n",
+    "# New annotations are reloaded at the start of a session. \n",
+    "# Try restarting the kernel and rerun to see the updated output.\n",
+    "\n",
+    "print(art_annot.get_code())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "af881176-279b-4530-8a00-8d9ee2ad7697",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
+    "\n",
+    "!lineapy annotate delete --name \"usercode_annotation_sample\"\n",
+    "os.unlink(\"usercode_annotation_sample.yaml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/tutorials/custom_annotations-usercode.ipynb
+++ b/docs/source/tutorials/custom_annotations-usercode.ipynb
@@ -5,26 +5,75 @@
    "execution_count": 1,
    "id": "91401518-703c-4bfe-bfc1-add0eca794b5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Looking in indexes: http://localhost:4040/linea/dev/+simple/\n",
-      "Requirement already satisfied: pyperclip in /Users/simba/opt/miniconda3/envs/py39/lib/python3.9/site-packages (1.8.2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# NBVAL_SKIP\n",
-    "!pip install pyperclip\n",
-    "# NBVAL_SKIP\n",
-    "import pyperclip\n"
+    "from .myclass import MyClass\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "6f2f01af-d2e5-4644-814a-f235d604b348",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MyClass()\n",
+    "a.update_counter()\n",
+    "\n",
+    "art_no_annot = lineapy.save(a, \"notannotated\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f0fcc7c0-742b-496f-aa11-29a01441a3fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from .myclass import MyClass\n",
+      "\n",
+      "a = MyClass()\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(art_no_annot.get_code())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "15149d1d-92e5-46b2-bb7c-c9f39a98d80a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "myclass\n"
+     ]
+    }
+   ],
+   "source": [
+    "# first understand the module of the function you want to add\n",
+    "# in this case the module is straightforward since it is being imported from our myclass.py\n",
+    "\n",
+    "print(a.update_counter.__self__.__module__)\n",
+    "\n",
+    "# This module name should be the first line of the annotation: \"module: myclass\"\n",
+    "# Next is the list of annotations that we want to add. Refer to TODO:<annotation_specs link> in the docs\n",
+    "# In this case, we want to annotate the update_counter class method that modifies the class attribute \"counter\"\n",
+    "# Instead of fine tuning it to the attribute level, we say that the instance itself has been modified "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "a0673d80-d287-47fb-bc2e-45cb2d4c6629",
    "metadata": {},
    "outputs": [],
@@ -32,12 +81,11 @@
     "# NBVAL_SKIP\n",
     "with open(\"custom_annotation.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
-    "- module: pyperclip\n",
+    "- module: myclass\n",
     "  annotations:\n",
     "    - criteria:\n",
-    "        function_names:\n",
-    "          - copy\n",
-    "          - paste\n",
+    "          class_instance: MyClass\n",
+    "          class_method_name: update_counter\n",
     "      side_effects:\n",
     "        - mutated_value:\n",
     "            self_ref: SELF_REF\n",
@@ -49,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "9c8f1953-1e81-4bcc-bc34-994b424363b9",
    "metadata": {},
    "outputs": [
@@ -59,7 +107,7 @@
        "'/Users/simba/Projects/lineapy/examples/tutorials'"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "62c5da93-a171-4b4c-9b9b-8cbf108c36c9",
    "metadata": {},
    "outputs": [
@@ -81,14 +129,12 @@
      "output_type": "stream",
      "text": [
       "Module specification: {\n",
-      "    \"module\": \"pyperclip\",\n",
+      "    \"module\": \"myclass\",\n",
       "    \"annotations\": [\n",
       "        {\n",
       "            \"criteria\": {\n",
-      "                \"function_names\": [\n",
-      "                    \"copy\",\n",
-      "                    \"paste\"\n",
-      "                ]\n",
+      "                \"class_instance\": \"MyClass\",\n",
+      "                \"class_method_name\": \"update_counter\"\n",
       "            },\n",
       "            \"side_effects\": [\n",
       "                {\n",
@@ -101,20 +147,20 @@
       "    ]\n",
       "}\n",
       "\n",
-      "Creating annotation source custom at /Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "Creating annotation source custom2 at /Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
    ],
    "source": [
     "# NBVAL_SKIP\n",
-    "!lineapy annotate add --name \"custom\" \"./custom_annotation.yaml\"\n",
+    "!lineapy annotate add --name \"custom2\" \"./custom_annotation.yaml\"\n",
     "lineapy.reload()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "acb7efbe-bd55-403c-8a5d-b5e5690ed014",
    "metadata": {},
    "outputs": [
@@ -122,7 +168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "custom\t/Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "custom2\t/Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
@@ -134,21 +180,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "3c45849d-ce52-4590-879e-6c9f3675de3b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "  \n",
-    "pyperclip.copy(\"This wont show up without annotations\")\n",
-    "tmp_var = pyperclip.paste()\n",
+    "# NBVAL_SKIP\n",
+    "b = MyClass()\n",
+    "b.update_counter()\n",
     "\n",
-    "art_annot = lineapy.save(tmp_var, \"annotated_text\")"
+    "art_annot = lineapy.save(b, \"annotated\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "d4d40cd5-a24f-4335-b375-bc2db1003038",
    "metadata": {},
    "outputs": [
@@ -156,10 +202,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "import pyperclip\n",
+      "from .myclass import MyClass\n",
       "\n",
-      "pyperclip.copy(\"This wont show up without annotations\")\n",
-      "tmp_var = pyperclip.paste()\n",
+      "b = MyClass()\n",
+      "b.update_counter()\n",
       "\n"
      ]
     }
@@ -175,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "af881176-279b-4530-8a00-8d9ee2ad7697",
    "metadata": {},
    "outputs": [
@@ -191,24 +237,32 @@
     "# NBVAL_SKIP\n",
     "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
     "\n",
-    "!lineapy annotate delete --name \"custom\"\n",
+    "!lineapy annotate delete --name \"custom2\"\n",
     "os.unlink(\"custom_annotation.yaml\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a8dad571-6078-4aa6-b958-693a45d423ce",
+   "execution_count": 12,
+   "id": "b2eea2fe-9bea-466a-b0d9-85d9ae528056",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<bound method MyClass.update_counter of <myclass.MyClass object at 0x7fdb88891970>>\n"
+     ]
+    }
+   ],
    "source": [
-    "x = 1"
+    "print(a.update_counter)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37be33bb-e999-416c-a63b-03cd432255e0",
+   "id": "f8dc7187-6bb7-47d2-849c-1d8613ce2a62",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -216,15 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcc330ce-f465-4689-b0a4-8e5fceeed455",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "833fec4e-ea26-4f56-bc69-51f29a34657f",
+   "id": "18a50cdc-a1e5-4307-9bdb-957c9843d6fc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/tutorials/04a_adding_library_annotations.ipynb
+++ b/examples/tutorials/04a_adding_library_annotations.ipynb
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "# NBVAL_SKIP\n",
-    "with open(\"custom_annotation.yaml\", \"w\") as f:\n",
+    "with open(\"lib_annotation_sample.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
     "- module: pyperclip\n",
     "  annotations:\n",
@@ -108,7 +108,7 @@
    ],
    "source": [
     "# NBVAL_SKIP\n",
-    "!lineapy annotate add --name \"custom\" \"./custom_annotation.yaml\"\n",
+    "!lineapy annotate add --name \"lib_annotation_sample\" \"./lib_annotation_sample.yaml\"\n",
     "lineapy.reload()"
    ]
   },
@@ -139,6 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
     "  \n",
     "pyperclip.copy(\"This wont show up without annotations\")\n",
     "tmp_var = pyperclip.paste()\n",
@@ -191,43 +192,9 @@
     "# NBVAL_SKIP\n",
     "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
     "\n",
-    "!lineapy annotate delete --name \"custom\"\n",
-    "os.unlink(\"custom_annotation.yaml\")"
+    "!lineapy annotate delete --name \"lib_annotation_sample\"\n",
+    "os.unlink(\"lib_annotation_sample.yaml\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "a8dad571-6078-4aa6-b958-693a45d423ce",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = 1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37be33bb-e999-416c-a63b-03cd432255e0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dcc330ce-f465-4689-b0a4-8e5fceeed455",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "833fec4e-ea26-4f56-bc69-51f29a34657f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/tutorials/04b_adding_custom_annotations.ipynb
+++ b/examples/tutorials/04b_adding_custom_annotations.ipynb
@@ -33,7 +33,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "from .myclass import MyClass\n",
+      "from .sample_user_class import MyClass\n",
       "\n",
       "a = MyClass()\n",
       "\n"
@@ -54,7 +54,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "myclass\n"
+      "sample_user_class\n"
      ]
     }
    ],
@@ -79,7 +79,7 @@
    "source": [
     "with open(\"usercode_annotation_sample.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
-    "- module: myclass\n",
+    "- module: sample_user_class\n",
     "  annotations:\n",
     "    - criteria:\n",
     "          class_instance: MyClass\n",
@@ -127,7 +127,7 @@
      "output_type": "stream",
      "text": [
       "Module specification: {\n",
-      "    \"module\": \"myclass\",\n",
+      "    \"module\": \"sample_user_class\",\n",
       "    \"annotations\": [\n",
       "        {\n",
       "            \"criteria\": {\n",
@@ -145,7 +145,8 @@
       "    ]\n",
       "}\n",
       "\n",
-      "Creating annotation source custom2 at /Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "Creating annotation source usercode_annotation_sample at \u001b[35m/Users/simba/.lineapy/c\u001b[0m\n",
+      "\u001b[35mustom-annotations/\u001b[0m\u001b[95musercode_annotation_sample.annotations.yaml\u001b[0m                   \n",
       "\u001b[0m"
      ]
     }
@@ -166,7 +167,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "custom2\t/Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
+      "usercode_annotation_sample\t/Users/simba/.lineapy/custom-annotations/usercode_annotation_sample.annotations.yaml\n",
+      "custom\t/Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
@@ -199,7 +201,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "from .myclass import MyClass\n",
+      "from .sample_user_class import MyClass\n",
       "\n",
       "b = MyClass()\n",
       "b.update_counter()\n",

--- a/examples/tutorials/04b_adding_custom_annotations.ipynb
+++ b/examples/tutorials/04b_adding_custom_annotations.ipynb
@@ -7,8 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NBVAL_SKIP\n",
-    "from .myclass import MyClass\n"
+    "from .sample_user_class import MyClass\n"
    ]
   },
   {
@@ -60,7 +59,7 @@
     }
    ],
    "source": [
-    "# first understand the module of the function you want to add\n",
+    "# first, lets understand the module of the function you want to add\n",
     "# in this case the module is straightforward since it is being imported from our myclass.py\n",
     "\n",
     "print(a.update_counter.__self__.__module__)\n",
@@ -78,8 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NBVAL_SKIP\n",
-    "with open(\"custom_annotation.yaml\", \"w\") as f:\n",
+    "with open(\"usercode_annotation_sample.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
     "- module: myclass\n",
     "  annotations:\n",
@@ -113,7 +111,7 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "import os\n",
     "os.getcwd()"
    ]
@@ -153,8 +151,8 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
-    "!lineapy annotate add --name \"custom2\" \"./custom_annotation.yaml\"\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "!lineapy annotate add --name \"usercode_annotation_sample\" \"./usercode_annotation_sample.yaml\"\n",
     "lineapy.reload()"
    ]
   },
@@ -185,7 +183,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NBVAL_SKIP\n",
     "b = MyClass()\n",
     "b.update_counter()\n",
     "\n",
@@ -211,7 +208,6 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
     "# The output here will NOT display the line pyperclip.copy\n",
     "# New annotations are reloaded at the start of a session. \n",
     "# Try restarting the kernel and rerun to see the updated output.\n",
@@ -234,46 +230,11 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
     "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
     "\n",
-    "!lineapy annotate delete --name \"custom2\"\n",
-    "os.unlink(\"custom_annotation.yaml\")"
+    "!lineapy annotate delete --name \"usercode_annotation_sample\"\n",
+    "os.unlink(\"usercode_annotation_sample.yaml\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "b2eea2fe-9bea-466a-b0d9-85d9ae528056",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<bound method MyClass.update_counter of <myclass.MyClass object at 0x7fdb88891970>>\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(a.update_counter)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f8dc7187-6bb7-47d2-849c-1d8613ce2a62",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18a50cdc-a1e5-4307-9bdb-957c9843d6fc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/tutorials/custom_annotations-usercode.ipynb
+++ b/examples/tutorials/custom_annotations-usercode.ipynb
@@ -5,26 +5,75 @@
    "execution_count": 1,
    "id": "91401518-703c-4bfe-bfc1-add0eca794b5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Looking in indexes: http://localhost:4040/linea/dev/+simple/\n",
-      "Requirement already satisfied: pyperclip in /Users/simba/opt/miniconda3/envs/py39/lib/python3.9/site-packages (1.8.2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# NBVAL_SKIP\n",
-    "!pip install pyperclip\n",
-    "# NBVAL_SKIP\n",
-    "import pyperclip\n"
+    "from .myclass import MyClass\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "6f2f01af-d2e5-4644-814a-f235d604b348",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MyClass()\n",
+    "a.update_counter()\n",
+    "\n",
+    "art_no_annot = lineapy.save(a, \"notannotated\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f0fcc7c0-742b-496f-aa11-29a01441a3fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from .myclass import MyClass\n",
+      "\n",
+      "a = MyClass()\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(art_no_annot.get_code())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "15149d1d-92e5-46b2-bb7c-c9f39a98d80a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "myclass\n"
+     ]
+    }
+   ],
+   "source": [
+    "# first understand the module of the function you want to add\n",
+    "# in this case the module is straightforward since it is being imported from our myclass.py\n",
+    "\n",
+    "print(a.update_counter.__self__.__module__)\n",
+    "\n",
+    "# This module name should be the first line of the annotation: \"module: myclass\"\n",
+    "# Next is the list of annotations that we want to add. Refer to TODO:<annotation_specs link> in the docs\n",
+    "# In this case, we want to annotate the update_counter class method that modifies the class attribute \"counter\"\n",
+    "# Instead of fine tuning it to the attribute level, we say that the instance itself has been modified "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "a0673d80-d287-47fb-bc2e-45cb2d4c6629",
    "metadata": {},
    "outputs": [],
@@ -32,12 +81,11 @@
     "# NBVAL_SKIP\n",
     "with open(\"custom_annotation.yaml\", \"w\") as f:\n",
     "    f.write(\"\"\"\n",
-    "- module: pyperclip\n",
+    "- module: myclass\n",
     "  annotations:\n",
     "    - criteria:\n",
-    "        function_names:\n",
-    "          - copy\n",
-    "          - paste\n",
+    "          class_instance: MyClass\n",
+    "          class_method_name: update_counter\n",
     "      side_effects:\n",
     "        - mutated_value:\n",
     "            self_ref: SELF_REF\n",
@@ -49,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "9c8f1953-1e81-4bcc-bc34-994b424363b9",
    "metadata": {},
    "outputs": [
@@ -59,7 +107,7 @@
        "'/Users/simba/Projects/lineapy/examples/tutorials'"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "62c5da93-a171-4b4c-9b9b-8cbf108c36c9",
    "metadata": {},
    "outputs": [
@@ -81,14 +129,12 @@
      "output_type": "stream",
      "text": [
       "Module specification: {\n",
-      "    \"module\": \"pyperclip\",\n",
+      "    \"module\": \"myclass\",\n",
       "    \"annotations\": [\n",
       "        {\n",
       "            \"criteria\": {\n",
-      "                \"function_names\": [\n",
-      "                    \"copy\",\n",
-      "                    \"paste\"\n",
-      "                ]\n",
+      "                \"class_instance\": \"MyClass\",\n",
+      "                \"class_method_name\": \"update_counter\"\n",
       "            },\n",
       "            \"side_effects\": [\n",
       "                {\n",
@@ -101,20 +147,20 @@
       "    ]\n",
       "}\n",
       "\n",
-      "Creating annotation source custom at /Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "Creating annotation source custom2 at /Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
    ],
    "source": [
     "# NBVAL_SKIP\n",
-    "!lineapy annotate add --name \"custom\" \"./custom_annotation.yaml\"\n",
+    "!lineapy annotate add --name \"custom2\" \"./custom_annotation.yaml\"\n",
     "lineapy.reload()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "acb7efbe-bd55-403c-8a5d-b5e5690ed014",
    "metadata": {},
    "outputs": [
@@ -122,7 +168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "custom\t/Users/simba/.lineapy/custom-annotations/custom.annotations.yaml\n",
+      "custom2\t/Users/simba/.lineapy/custom-annotations/custom2.annotations.yaml\n",
       "\u001b[0m"
      ]
     }
@@ -134,21 +180,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "3c45849d-ce52-4590-879e-6c9f3675de3b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "  \n",
-    "pyperclip.copy(\"This wont show up without annotations\")\n",
-    "tmp_var = pyperclip.paste()\n",
+    "# NBVAL_SKIP\n",
+    "b = MyClass()\n",
+    "b.update_counter()\n",
     "\n",
-    "art_annot = lineapy.save(tmp_var, \"annotated_text\")"
+    "art_annot = lineapy.save(b, \"annotated\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "d4d40cd5-a24f-4335-b375-bc2db1003038",
    "metadata": {},
    "outputs": [
@@ -156,10 +202,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "import pyperclip\n",
+      "from .myclass import MyClass\n",
       "\n",
-      "pyperclip.copy(\"This wont show up without annotations\")\n",
-      "tmp_var = pyperclip.paste()\n",
+      "b = MyClass()\n",
+      "b.update_counter()\n",
       "\n"
      ]
     }
@@ -175,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "af881176-279b-4530-8a00-8d9ee2ad7697",
    "metadata": {},
    "outputs": [
@@ -191,24 +237,32 @@
     "# NBVAL_SKIP\n",
     "# Uncomment the following lines to clean up the custom annotation that was just added.\n",
     "\n",
-    "!lineapy annotate delete --name \"custom\"\n",
+    "!lineapy annotate delete --name \"custom2\"\n",
     "os.unlink(\"custom_annotation.yaml\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a8dad571-6078-4aa6-b958-693a45d423ce",
+   "execution_count": 12,
+   "id": "b2eea2fe-9bea-466a-b0d9-85d9ae528056",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<bound method MyClass.update_counter of <myclass.MyClass object at 0x7fdb88891970>>\n"
+     ]
+    }
+   ],
    "source": [
-    "x = 1"
+    "print(a.update_counter)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37be33bb-e999-416c-a63b-03cd432255e0",
+   "id": "f8dc7187-6bb7-47d2-849c-1d8613ce2a62",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -216,15 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcc330ce-f465-4689-b0a4-8e5fceeed455",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "833fec4e-ea26-4f56-bc69-51f29a34657f",
+   "id": "18a50cdc-a1e5-4307-9bdb-957c9843d6fc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/tutorials/myclass.py
+++ b/examples/tutorials/myclass.py
@@ -1,0 +1,6 @@
+class MyClass():
+    def __init__(self):
+        self.counter = 0
+    
+    def update_counter(self):
+        self.counter += 10

--- a/examples/tutorials/sample_user_class.py
+++ b/examples/tutorials/sample_user_class.py
@@ -1,6 +1,6 @@
-class MyClass():
+class MyClass:
     def __init__(self):
         self.counter = 0
-    
+
     def update_counter(self):
         self.counter += 10

--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -1,6 +1,13 @@
 import atexit
 
-from lineapy.api.api import artifact_store, delete, get, save, to_pipeline
+from lineapy.api.api import (
+    artifact_store,
+    delete,
+    get,
+    reload,
+    save,
+    to_pipeline,
+)
 from lineapy.data.graph import Graph
 from lineapy.data.types import SessionType, ValueType
 from lineapy.editors.ipython import start, stop, visualize
@@ -16,6 +23,7 @@ __all__ = [
     "get",
     "artifact_store",
     "delete",
+    "reload",
     "to_pipeline",
     "SessionType",
     "ValueType",

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -258,6 +258,19 @@ def get(artifact_name: str, version: Optional[int] = None) -> LineaArtifact:
     return linea_artifact
 
 
+def reload() -> None:
+    """
+    Reloads lineapy context.
+
+    .. note::
+
+    Currently only reloads annotations but in the future can be a container for other items like configs etc.
+
+    """
+    execution_context = get_context()
+    execution_context.executor.reload_annotations()
+
+
 def artifact_store() -> LineaArtifactStore:
     """
     Returns

--- a/lineapy/execution/executor.py
+++ b/lineapy/execution/executor.py
@@ -436,6 +436,9 @@ class Executor:
         # Add executed nodes to DB
         self.db.session.commit()
 
+    def reload_annotations(self) -> None:
+        self._function_inspector.reload_annotations()
+
     def _translate_pointer(
         self, node: CallNode, pointer: ValuePointer
     ) -> ExecutorPointer:

--- a/lineapy/execution/inspect_function.py
+++ b/lineapy/execution/inspect_function.py
@@ -344,6 +344,10 @@ class FunctionInspector:
     def __post_init__(self):
         self._parse()
 
+    def reload_annotations(self) -> None:
+        self.specs = get_specs()
+        self._parse()
+
     def inspect(
         self,
         function: Callable,


### PR DESCRIPTION
# Description

Currently if we add new annotations when a (jupyter/ipython) session has started, the new annotations do not show up. This PR adds a reload api that will re-read the annotations. Ideally we'd create an api that lets us replicate the cli options like MJL's config PR. Leaving that out of scope for this PR so we can merge the new feature in.

Fixes LIN-415

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
New notebook called custom-annotations-usercode.ipynb highlights and tests the feature.