### PR TITLE
Clean up custom-annotations folder when testing annotations commands

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -117,16 +117,24 @@ def annotations_folder():
     '.lineapy/custom-annotations'dir and
     replaces it with a temp for testing.
     """
-    path = linea_folder() / CUSTOM_ANNOTATIONS_FOLDER_NAME
-    path_str = str(path.resolve())
-    stash_path = linea_folder() / (CUSTOM_ANNOTATIONS_FOLDER_NAME + ".old")
-    stash_path_str = str(stash_path.resolve())
-    shutil.move(path_str, stash_path_str)
+    current_path = linea_folder() / CUSTOM_ANNOTATIONS_FOLDER_NAME
+    current_path_str = str(current_path.resolve())
+    old_path = linea_folder() / (CUSTOM_ANNOTATIONS_FOLDER_NAME + ".old")
+    old_path_str = str(old_path.resolve())
 
-    yield path
+    # If 'custom-annotations.old exists already, the test was canceled
+    # early previously. Clean up 'custom-annotations' folder from
+    # previous run.
+    if old_path.exists():
+        shutil.rmtree(current_path_str, ignore_errors=True)
+    else:
+        shutil.move(current_path_str, old_path_str)
 
-    shutil.rmtree(path_str)
-    shutil.move(stash_path_str, path_str)
+    yield
+
+    # clean up test-generated directories
+    shutil.rmtree(current_path_str)
+    shutil.move(old_path_str, current_path_str)
 
 
 @pytest.mark.slow

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -133,8 +133,10 @@ def annotations_folder():
     yield
 
     # clean up test-generated directories
-    shutil.rmtree(current_path_str)
-    shutil.move(old_path_str, current_path_str)
+    if current_path.exists():
+        shutil.rmtree(current_path_str)
+    if old_path.exists():
+        shutil.move(old_path_str, current_path_str)
 
 
 @pytest.mark.slow


### PR DESCRIPTION

# Description

If tests were cancelled midway through previously, attempt to clean up mess when running next time.


Fixes # (issue)

LIN 371

## Type of change

Bugfix

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The current suite of unit tests pass.
