### PR TITLE
LIN-417 fix blackbox trace error

### DIFF
--- a/lineapy/system_tracing/_function_calls_to_object_side_effects.py
+++ b/lineapy/system_tracing/_function_calls_to_object_side_effects.py
@@ -73,10 +73,10 @@ def pointer_to_objects(
     elif isinstance(pointer, AllPositionalArgs):
         yield from function_call.args
     elif isinstance(pointer, BoundSelfOfFunction):
-        if hasattr(function_call.fn, "self"):
+        if hasattr(function_call.fn, "__self__"):
             yield function_call.fn.__self__  # type: ignore
         else:
-            yield []
+            yield from []
     elif isinstance(pointer, Result):
         yield function_call.res
     elif isinstance(pointer, ExternalState):

--- a/lineapy/system_tracing/_function_calls_to_object_side_effects.py
+++ b/lineapy/system_tracing/_function_calls_to_object_side_effects.py
@@ -73,7 +73,10 @@ def pointer_to_objects(
     elif isinstance(pointer, AllPositionalArgs):
         yield from function_call.args
     elif isinstance(pointer, BoundSelfOfFunction):
-        yield function_call.fn.__self__  # type: ignore
+        if hasattr(function_call.fn, "self"):
+            yield function_call.fn.__self__  # type: ignore
+        else:
+            yield []
     elif isinstance(pointer, Result):
         yield function_call.res
     elif isinstance(pointer, ExternalState):

--- a/tests/end_to_end/test_blackbox_tracing.py
+++ b/tests/end_to_end/test_blackbox_tracing.py
@@ -34,7 +34,7 @@ artifact = lineapy.save(lineapy.file_system, "test_mplt")
 """
 
 
-@pytest.mark.xfail("libraries used inside a blackbox are not captured")
+@pytest.mark.xfail(reason="libraries used inside a blackbox are not captured")
 def test_mplt_inside_blackbox_does_not_fail(execute):
     # simply a test to check if the code runs without exceptions.
     # Later on this will be edited to ensure that the slice is accurate.

--- a/tests/end_to_end/test_blackbox_tracing.py
+++ b/tests/end_to_end/test_blackbox_tracing.py
@@ -2,6 +2,7 @@ import pytest
 
 LINEA_CODE = """import lineapy
 """
+
 CODE = """import matplotlib.pyplot as plt
 import numpy as np
 

--- a/tests/end_to_end/test_blackbox_tracing.py
+++ b/tests/end_to_end/test_blackbox_tracing.py
@@ -1,3 +1,7 @@
+import pytest
+
+LINEA_CODE = """import lineapy
+"""
 CODE = """import matplotlib.pyplot as plt
 import numpy as np
 
@@ -18,10 +22,22 @@ for i in range(3):
         linewidth=8,
         dash_joinstyle=dash_styles[i],
     )
+
+plt.xlim(0, 12), plt.ylim(-1, 2)
+plt.xticks([]), plt.yticks([])
+plt.savefig("output/dash_joinstyle.png", dpi=dpi)
+
+"""
+
+ARTIFACT_CODE = """
+artifact = lineapy.save(lineapy.file_system, "test_mplt")
 """
 
 
+@pytest.mark.xfail("libraries used inside a blackbox are not captured")
 def test_mplt_inside_blackbox_does_not_fail(execute):
-    res = execute(CODE)
-    assert res.success
+    # simply a test to check if the code runs without exceptions.
+    # Later on this will be edited to ensure that the slice is accurate.
+    res = execute(LINEA_CODE + CODE + ARTIFACT_CODE, snapshot=False)
+    assert res.values["artifact"].get_code() == CODE
     # assert res.values["fig"] is not None

--- a/tests/end_to_end/test_blackbox_tracing.py
+++ b/tests/end_to_end/test_blackbox_tracing.py
@@ -1,0 +1,27 @@
+CODE = """import matplotlib.pyplot as plt
+import numpy as np
+
+size = 256, 16
+dpi = 72.0
+figsize = size[0] / float(dpi), size[1] / float(dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
+plt.axes([0, 0, 1, 1], frameon=False)
+
+dash_styles = ["miter", "bevel", "round"]
+
+for i in range(3):
+    plt.plot(
+        i * 4 + np.arange(3),
+        [0, 1, 0],
+        color="blue",
+        dashes=[12, 5],
+        linewidth=8,
+        dash_joinstyle=dash_styles[i],
+    )
+"""
+
+
+def test_mplt_inside_blackbox_does_not_fail(execute):
+    res = execute(CODE)
+    assert res.success
+    # assert res.values["fig"] is not None


### PR DESCRIPTION
# Description

Added a sample code that fails to execute. Lineapy should not stop execution of usercode even if tracing is not possible. This PR adds an escape if the __self__ attribute is missing. Also added a failing test highlighting where the inside-blackbox tracing is not working.

Fixes LIN-417

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Added a test_blackbox_tracing.py. It still fails but the execution does not halt (fails because the slice is wrong)