### PR TITLE
Fixing pytorch dependencies for integration tests

### DIFF
--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -49,7 +49,7 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
         pip=["gym[atari]"],
     ),
     "pytorch": lambda: Environment(
-        conda_deps=["torchvision=0.11.3"],
+        # conda_deps=["torchvision=0.11.3"],
         conda_channels=["pytorch"],
         pip=[
             line
@@ -65,7 +65,7 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
                 # remove awscli dependency because its incompatible with recent rich version
                 and "awscli" not in line
                 # Make sure we use the conda version of torchvision, otherwise get bus error
-                and "torchvision" not in line
+                # and "torchvision" not in line
             )
         ],
     ),

--- a/tests/integration/test_slice.py
+++ b/tests/integration/test_slice.py
@@ -49,7 +49,9 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
         pip=["gym[atari]"],
     ),
     "pytorch": lambda: Environment(
-        # conda_deps=["torchvision=0.11.3"],
+        # We do not use any conda dependencies and let pip handle all PyTorch dependencies
+        # (including torchvision) as using a particular version of torchvision using conda
+        # causes the child python process to abort and fail the test.
         conda_channels=["pytorch"],
         pip=[
             line
@@ -64,8 +66,6 @@ ENVS: Dict[str, Union[Environment, Callable[[], Environment]]] = {
                 and not line.startswith("#")
                 # remove awscli dependency because its incompatible with recent rich version
                 and "awscli" not in line
-                # Make sure we use the conda version of torchvision, otherwise get bus error
-                # and "torchvision" not in line
             )
         ],
     ),


### PR DESCRIPTION
# Description

Fixed dependencies used for running Pytorch integration tests. The test would not run completely due to bad versioning. Note the test still fails, but runs till completion.

Fixes # LIN-373

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
