### PR TITLE
LIN-435 Fix broken Colab demo notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ data scientists bring their work to production more quickly and easily, with jus
 <p align="center">
     <b style="font-size:48px;">👇 Try It Out! 👇</b>
     <br>
-    <a href="https://bit.ly/38jC9Zq"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>
+    <a href="https://bit.ly/3N9WvDB"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>
 </p>
 
 https://user-images.githubusercontent.com/13392380/169427654-487d8d4b-3eda-462a-a96c-51c151f39ab9.mp4
@@ -50,7 +50,7 @@ One way to deal with this problem is to keep the notebook in sequential operatio
 the entire notebook during development. However, we soon realize that this interrupts our natural workflows and stream of
 thoughts, decreasing our productivity. Therefore, it is much more common to clean up the notebook after development. This is a very time-consuming process and is not immune from reproducibility issues caused by deleting cells and out-of-order cell executions.
 
-To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/clean_up_a_messy_notebook/clean_up_a_messy_notebook.ipynb) demo.
+To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/clean_up_a_messy_notebook/clean_up_a_messy_notebook.ipynb) demo or <a href="https://bit.ly/3NMffcb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>.
 
 ### Use Case 2: Revisiting Previous Work
 
@@ -66,7 +66,7 @@ Or, the person may no longer be in the organization with no proper handover of t
 In any of these cases, it becomes extremely difficult to identify the root of the issue, which may render the result
 unreliable and even unusable.
 
-To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/discover_and_trace_past_work/discover_and_trace_past_work.ipynb) demo.
+To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/discover_and_trace_past_work/discover_and_trace_past_work.ipynb) demo or <a href="https://bit.ly/3GEYM7c"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>.
 
 ### Use Case 3: Building Pipelines
 
@@ -79,7 +79,7 @@ orchestration systems or job schedulers (e.g., cron, Apache Airflow, Prefect). O
 what they are and how to work with them. If not, we need to spend time learning about them in the first place.
 All this operational work involves time-consuming, manual labor, which means less time for us to spend on our core duties as a data scientist.
 
-To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/create_a_simple_pipeline/create_a_simple_pipeline.ipynb) demo.
+To see how LineaPy can help here, check out [this](https://github.com/LineaLabs/demos/blob/main/story/create_a_simple_pipeline/create_a_simple_pipeline.ipynb) demo or <a href="https://bit.ly/3x4YOkq"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>.
 
 ## Getting Started
 


### PR DESCRIPTION
# Description

* Fix `Use Case 2: Revisiting Previous Work` demo notebook on Google Colab.
* Directly open GitHub demo notebooks from Google Colab, no more accidentally change.
* Add *Open in Colab* option for each use case in README.md.
* The api_basic notebook and three use cases notebook has been merged in https://github.com/LineaLabs/demos .

Fixes # (issue)

LIN-435

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Manually click on the link and run demo notebooks in Colab.