### PR TITLE
Fix xfail in test_linea_api.py

### DIFF
--- a/tests/end_to_end/test_linea_api.py
+++ b/tests/end_to_end/test_linea_api.py
@@ -125,7 +125,6 @@ lineapy.delete('x', version=0)
         assert res.artifacts["x"]
 
 
-@pytest.mark.xfail(reason="There might be a bug with artifact versions")
 def test_delete_artifact_version(execute):
     res = execute(
         """import lineapy
@@ -138,17 +137,16 @@ lineapy.delete('x', version=1)
 catalog = lineapy.catalog()
 versions = [x._version for x in catalog.artifacts if x.name=='x']
 num_versions = len(versions)
-
+x_retrieve = lineapy.get('x').get_value()
 
 """,
         snapshot=False,
     )
 
     assert res.values["num_versions"] == 1
-    assert res.artifacts["x"] == "x = 100\n"
+    assert res.values["x_retrieve"] == 100
 
 
-@pytest.mark.xfail(reason="There might be a bug with artifact versions")
 def test_delete_artifact_version_complex(execute):
     res = execute(
         """import lineapy
@@ -158,19 +156,18 @@ x = 200
 lineapy.save(x, 'x')
 x = 300
 lineapy.save(x, 'x')
-lineapy.delete('x', version=1)
 
-catalog = lineapy.catalog()
-versions = [x._version for x in catalog.artifacts if x.name=='x']
-num_versions = len(versions)
+# We want to Delete version 1, but the code is executed twice in testing, causing no version 1 to be deleted in second execution
+lineapy.delete('x', version=sorted([x._version for x in lineapy.catalog().artifacts if x.name=='x'])[-2])
 
-
+num_versions = len([x._version for x in lineapy.catalog().artifacts if x.name=='x'])
+x_retrieve = lineapy.get('x').get_value()
 """,
         snapshot=False,
     )
 
     assert res.values["num_versions"] == 2
-    assert res.artifacts["x"] == "x = 300\n"
+    assert res.values["x_retrieve"] == 300
 
 
 def test_delete_artifact_all(execute):


### PR DESCRIPTION
# Description

Two reasons causing these two xfail test cases.

* When we called res.values['x']. I think it is actually asking the tracer to return the last value of x but not the last version of x in the artifact store.
* ExecuteFixture actually executes the code twice in the test(i don't know why). I think it should be once. This is why you see cannot delete version 1 error.

Fixes # (issue)

Two xfail in test_linea_api.py

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
