### PR TITLE
Fixing settrace call

### DIFF
--- a/lineapy/system_tracing/exec_and_record_function_calls.py
+++ b/lineapy/system_tracing/exec_and_record_function_calls.py
@@ -13,6 +13,13 @@ def exec_and_record_function_calls(
 ) -> TraceFunc:
     """
     Execute the code while recording all the function calls which originate from the code object.
+
+    While recording function calls, we use sys.settrace() with LineaPy's tracer to extract relevant
+    information during the runtime of the user's code's function, and reset the tracer after the user
+    function has completed execution to prevent unnecessary logging.
+    However, to ensure LineaPy works correctly while debugging using VSCode, we first capture any
+    existing tracers using sys.gettrace(), perform our analysis using the LineaPy tracer, and reset
+     the existing tracer using sys.settrace()
     """
     logger.debug("Executing code")
     original_trace = gettrace()

--- a/lineapy/system_tracing/exec_and_record_function_calls.py
+++ b/lineapy/system_tracing/exec_and_record_function_calls.py
@@ -1,5 +1,5 @@
 import logging
-from sys import settrace
+from sys import gettrace, settrace
 from types import CodeType
 from typing import Dict
 
@@ -15,11 +15,12 @@ def exec_and_record_function_calls(
     Execute the code while recording all the function calls which originate from the code object.
     """
     logger.debug("Executing code")
+    original_trace = gettrace()
     trace_func = TraceFunc(code)
     try:
         settrace(trace_func)
         exec(code, globals_)
     # Always stop tracing even if exception raised
     finally:
-        settrace(None)
+        settrace(original_trace)
     return trace_func


### PR DESCRIPTION
# Description

Problem: Currently, the vscode debugger behaves incorrectly whenever the user code has a function definition within it. As soon as a CallNode which deals with a function definition is encountered, when the vscode debugging is in progress, the vscode debugger would ignore the subsequent breakpoints and the program would complete, making subsequent debugging difficult.
Cause: When we call settrace(None), we end up inadvertently disabling all tracers currently set, even vscode's tracer, which causes debugger's unexpected behavior.
Solution: instead of using settrace(None), we store the original tracer and and use settrace(original_tracer), which preserves the original vscode's tracer used for debugging.

Fixes # 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
