### PR TITLE
LIN-427 Include runtime info in usage reporting

### DIFF
--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -42,15 +42,15 @@ def _runtime():
     else:
         envars: str = ";".join(list(os.environ))
         if "DATABRICKS_" in envars:
-            runtime = "databricks"
+            runtime = "ipython-databricks"
         elif "COLAB_" in envars:
-            runtime = "colab"
+            runtime = "ipython-colab"
         elif "DEEPNOTE_" in envars:
-            runtime = "deepnote"
+            runtime = "ipython-deepnote"
         elif "BINDER_" in envars:
-            runtime = "binder"
+            runtime = "ipython-binder"
         else:
-            runtime = "local-ipython"
+            runtime = "ipython"
 
     # Support optional custom tag which can be used to flag
     # and discard certain events such as those from dev work

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -14,6 +14,7 @@ from dataclasses import asdict
 from functools import lru_cache
 
 import requests
+from IPython import get_ipython
 
 from lineapy.utils.analytics.event_schemas import AllEvents
 from lineapy.utils.config import options
@@ -31,6 +32,17 @@ def _py_version():
         minor=sys.version_info.minor,
         micro=sys.version_info.micro,
     )
+
+
+@lru_cache(maxsize=1)
+def _runtime():
+    if options.get("runtime") is not None:
+        return str(options.get("runtime"))  # Return manually set value
+
+    if get_ipython() is not None:
+        return str(get_ipython())
+    else:
+        return "non-ipython"
 
 
 def _amplitude_url():
@@ -86,5 +98,6 @@ def track(event: AllEvents):
     event_properties = asdict(event)
     event_properties["py_version"] = _py_version()
     event_properties["lineapy_version"] = LINEAPY_VERSION
+    event_properties["runtime"] = _runtime()
 
     return _send_amplitude_event(event.__class__.__name__, event_properties)

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -13,6 +13,7 @@ import sys
 import uuid
 from dataclasses import asdict
 from functools import lru_cache
+from typing import Union
 
 import requests
 from IPython import get_ipython
@@ -27,7 +28,7 @@ LINEAPY_VERSION: str = importlib_metadata.version("lineapy")
 
 
 @lru_cache(maxsize=1)
-def _py_version():
+def _py_version() -> str:
     return "{major}.{minor}.{micro}".format(
         major=sys.version_info.major,
         minor=sys.version_info.minor,
@@ -36,7 +37,7 @@ def _py_version():
 
 
 @lru_cache(maxsize=1)
-def _runtime():
+def _runtime() -> str:
     if get_ipython() is None:
         runtime = "non-ipython"
     else:
@@ -64,16 +65,16 @@ def _runtime():
     return runtime
 
 
-def _amplitude_url():
+def _amplitude_url() -> str:
     return "https://api.amplitude.com/2/httpapi"
 
 
-def _api_key():
+def _api_key() -> str:
     return "90e7eb47aee98355e46e6f6ed81d1a80"
 
 
 @lru_cache(maxsize=1)
-def _session_id():
+def _session_id() -> str:
     return str(uuid.uuid4())  # uuid that marks current python session
 
 
@@ -82,7 +83,9 @@ def do_not_track() -> bool:
     return str(options.get("do_not_track")).lower() == "true"
 
 
-def _send_amplitude_event(event_type, event_properties):
+def _send_amplitude_event(
+    event_type: str, event_properties: dict
+) -> Union[requests.Response, None]:
     events = [
         {
             "event_type": event_type,
@@ -107,7 +110,7 @@ def _send_amplitude_event(event_type, event_properties):
         logger.debug(f"Tracking Error: {str(err)}")
 
 
-def track(event: AllEvents):
+def track(event: AllEvents) -> Union[requests.Response, None]:
     """ """
     if do_not_track():
         return

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -44,6 +44,9 @@ def _runtime() -> str:
         # Collect and concatenate all env var names to see
         # if this concatenated string contains a pattern
         # unique to each runtime.
+        # NOTE: We are not using ``get_ipython()`` as it does not really give the info we desire.
+        # For instance, it returns ``ipykernel.zmqshell.ZMQInteractiveShell`` object in both Databricks
+        # and local Jupyter; and it does not seem to contain attribute(s) to distinguish the two.
         envars: str = ";".join(list(os.environ))
         if "DATABRICKS_" in envars:
             runtime = "ipython-databricks"

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -54,7 +54,7 @@ def _runtime() -> str:
         elif "BINDER_" in envars:
             runtime = "ipython-binder"
         else:
-            runtime = "ipython"
+            runtime = "ipython-unknown"
 
     # Support optional custom tag which can be used to flag
     # and discard certain events such as those from dev work

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -40,6 +40,9 @@ def _runtime():
     if get_ipython() is None:
         runtime = "non-ipython"
     else:
+        # Collect and concatenate all env var names to see
+        # if this concatenated string contains a pattern
+        # unique to each runtime.
         envars: str = ";".join(list(os.environ))
         if "DATABRICKS_" in envars:
             runtime = "ipython-databricks"

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -13,7 +13,6 @@ import sys
 import uuid
 from dataclasses import asdict
 from functools import lru_cache
-from typing import Union
 
 import requests
 from IPython import get_ipython
@@ -86,9 +85,7 @@ def do_not_track() -> bool:
     return str(options.get("do_not_track")).lower() == "true"
 
 
-def _send_amplitude_event(
-    event_type: str, event_properties: dict
-) -> Union[requests.Response, None]:
+def _send_amplitude_event(event_type: str, event_properties: dict):
     events = [
         {
             "event_type": event_type,
@@ -113,7 +110,7 @@ def _send_amplitude_event(
         logger.debug(f"Tracking Error: {str(err)}")
 
 
-def track(event: AllEvents) -> Union[requests.Response, None]:
+def track(event: AllEvents):
     """ """
     if do_not_track():
         return

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -49,6 +49,7 @@ class lineapy_config:
         do_not_track=False,
         logging_level="INFO",
         logging_file=None,
+        runtime=None,
     ):
         if logging_level.isdigit():
             logging_level = logging._levelToName[int(logging_level)]
@@ -60,6 +61,7 @@ class lineapy_config:
         self.do_not_track = do_not_track
         self.logging_level = logging_level
         self.logging_file = logging_file
+        self.runtime = runtime
 
         # config file
         config_file_path = Path(

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -49,7 +49,6 @@ class lineapy_config:
         do_not_track=False,
         logging_level="INFO",
         logging_file=None,
-        runtime=None,
     ):
         if logging_level.isdigit():
             logging_level = logging._levelToName[int(logging_level)]
@@ -61,7 +60,6 @@ class lineapy_config:
         self.do_not_track = do_not_track
         self.logging_level = logging_level
         self.logging_file = logging_file
-        self.runtime = runtime
 
         # config file
         config_file_path = Path(


### PR DESCRIPTION
# Description

To better understand usage patterns, include runtime env info env info (Colab, IPython, etc.) in existing usage reporting. Specifically, with this update, LineaPy differentiates and records two types of runtime env:

1. `non-ipython`
2. IPython-based, e.g.:
    - `<IPython.terminal.interactiveshell.TerminalInteractiveShell at 0x10511f1c0>`
    - `<ipykernel.zmqshell.ZMQInteractiveShell object at 0x1075df4c0>`
    - `<google.colab._shell.Shell object at 0x7ff79b1d1250>`

This information can be overridden by setting environmental variable `LINEAPY_RUNTIME` to the desired value (e.g., `sangyoon_demo`), which would help us to filter out usage traffic coming from internal dev work.

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally tested with simple examples; CI will kick in.