### PR TITLE
Change submodules to https endpoints

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "tests/integration/sources/tensorflow-decision-forests"]
 	path = tests/integration/sources/tensorflow-decision-forests
 	url = https://github.com/tensorflow/decision-forests.git
-    ignore = all
+        ignore = all
 [submodule "tests/integration/sources/xgboost"]
 	path = tests/integration/sources/xgboost
 	url = https://github.com/dmlc/xgboost.git
@@ -29,7 +29,7 @@
 [submodule "tests/integration/sources/pandas_exercises"]
 	path = tests/integration/sources/pandas_exercises
 	url = https://github.com/guipsamora/pandas_exercises.git
-    ignore = all
+        ignore = all
 [submodule "tests/integration/sources/scikit-learn"]
 	path = tests/integration/sources/scikit-learn
 	url = https://github.com/scikit-learn/scikit-learn.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,34 +1,34 @@
 [submodule "tests/integration/numpy/tutorials"]
 	path = tests/integration/sources/numpy-tutorials
-	url = git@github.com:numpy/numpy-tutorials.git
+	url = https://github.com/numpy/numpy-tutorials.git
 	ignore = all
 [submodule "tests/integration/pytorch/vision"]
 	path = tests/integration/sources/pytorch-vision
-	url = git@github.com:pytorch/vision.git
+	url = https://github.com/pytorch/vision.git
 	ignore = all
 [submodule "tests/sources/pytorch-tutorials"]
 	path = tests/integration/sources/pytorch-tutorials
-	url = git@github.com:pytorch/tutorials.git
+	url = https://github.com/pytorch/tutorials.git
 	ignore = all
 [submodule "tests/integration/sources/dask-examples"]
 	path = tests/integration/sources/dask-examples
-	url = git@github.com:dask/dask-examples.git
+	url = https://github.com/dask/dask-examples.git
 	ignore = all
 [submodule "tests/integration/sources/tensorflow-docs"]
 	path = tests/integration/sources/tensorflow-docs
-	url = git@github.com:tensorflow/docs.git
+	url = https://github.com/tensorflow/docs.git
 	ignore = all
 [submodule "tests/integration/sources/tensorflow-decision-forests"]
 	path = tests/integration/sources/tensorflow-decision-forests
-	url = git@github.com:tensorflow/decision-forests.git
+	url = https://github.com/tensorflow/decision-forests.git
     ignore = all
 [submodule "tests/integration/sources/xgboost"]
 	path = tests/integration/sources/xgboost
-	url = git@github.com:dmlc/xgboost.git
+	url = https://github.com/dmlc/xgboost.git
         ignore = all
 [submodule "tests/integration/sources/pandas_exercises"]
 	path = tests/integration/sources/pandas_exercises
-	url = git@github.com:guipsamora/pandas_exercises.git
+	url = https://github.com/guipsamora/pandas_exercises.git
     ignore = all
 [submodule "tests/integration/sources/scikit-learn"]
 	path = tests/integration/sources/scikit-learn


### PR DESCRIPTION
# Description

Changes submodules to https endpoints to remove the requirement for
public key authentication to install lineapy from source in environments
that do not have GitHub ssh authentication enabled.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally in a Docker environment.

```
docker run -it --rm python
pip install git+https://github.com/hogepodge/lineapy.git@fix-submodules --upgrade
```