### PR TITLE
LIN-452 Add a config option to flag demo

### DIFF
--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -81,7 +81,9 @@ def _session_id() -> str:
 
 @lru_cache(maxsize=1)
 def do_not_track() -> bool:
-    return str(options.get("do_not_track")).lower() == "true"
+    do_not_track: bool = str(options.get("do_not_track")).lower() == "true"
+    is_demo: bool = str(options.get("is_demo")).lower() == "true"
+    return do_not_track or is_demo
 
 
 def _send_amplitude_event(event_type: str, event_properties: dict):

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -51,6 +51,7 @@ class lineapy_config:
     logging_level: str
     logging_file: Optional[Path]
     storage_options: Optional[Dict[str, Any]]
+    is_demo: bool
 
     def __init__(
         self,
@@ -62,6 +63,7 @@ class lineapy_config:
         logging_level="INFO",
         logging_file=None,
         storage_options=None,
+        is_demo=False,
     ):
         if logging_level.isdigit():
             logging_level = logging._levelToName[int(logging_level)]
@@ -74,6 +76,7 @@ class lineapy_config:
         self.logging_level = logging_level
         self.logging_file = logging_file
         self.storage_options = storage_options
+        self.is_demo = is_demo
 
         # config file
         config_file_path = Path(


### PR DESCRIPTION
# Description

Our API call counts in Amplitude are skewed by the number of API calls in demo/tutorial notebooks. To have a better reflection of organic usage, we want to discard calls from any demo/tutorial notebooks. We can achieve this by having a line at top:

```python
lineapy.options.set("is_demo", True)
```

which flags the notebook as a demo run and use this info to turn off usage report.

We are doing this instead of

```python
%env LINEAPY_DO_NOT_TRACK=true
```

because the latter may give the new user an impression that the command is a necessary setup, in which case they will copy it in their own notebook sessions by default (which we do not want).

***NOTE:*** This PR does NOT update existing demo/tutorial notebooks because the new config option is not yet part of PyPI release, so it will result in an error. So, we will update notebooks once the current change is published in our next PyPI release. A separate ticket has been opened to track this remaining task: [LIN-455](https://linea.atlassian.net/browse/LIN-455).

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally tested with simple examples; CI will test integration.