### PR TITLE
LIN-457 `is not` is not functional under LineaPy

### DIFF
--- a/lineapy/system_tracing/_trace_func.py
+++ b/lineapy/system_tracing/_trace_func.py
@@ -249,6 +249,7 @@ COMPARE_OPS: Dict[str, Callable] = {
     # Python 3.7
     "in": operator.contains,
     "is": operator.is_,
+    "is not": operator.is_not,
     "not in": composer(operator.not_, operator.contains),
 }
 

--- a/lineapy/system_tracing/_trace_func.py
+++ b/lineapy/system_tracing/_trace_func.py
@@ -655,7 +655,9 @@ def resolve_bytecode_execution(
     if name == "IS_OP":
         args = [stack[-2], stack[-1]]
         return lambda post_stack, _: FunctionCall(
-            operator.is_, args, res=post_stack[-1]
+            operator.is_not if value == 1 else operator.is_,
+            args,
+            res=post_stack[-1],
         )
     if name == "CONTAINS_OP":
         args = [stack[-1], stack[-2]]

--- a/tests/unit/system_tracing/test_exec_and_record_function_calls.py
+++ b/tests/unit/system_tracing/test_exec_and_record_function_calls.py
@@ -560,6 +560,14 @@ PYTHON_39 = version_info >= (3, 9)
             id="IS_OP",
         ),
         pytest.param(
+            "x is not y",
+            {"x": 3, "y": 1},
+            [
+                FunctionCall(operator.is_not, [3, 1], res=True),
+            ],
+            id="IS_NOT_OP",
+        ),
+        pytest.param(
             "x in y",
             {"x": 3, "y": [1]},
             [


### PR DESCRIPTION
# Description

Running
```python
if None is not None:
    pass
```
in 3.8 and below crashes the interpreter.

The issue was in the function tracer, where `is not` was missing from the `COMPARE_OPS` registry. This bug doesn't appear in 3.9+, because `is not` was separated out of the `COMPARE_OP` bytecode instruction.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit test to `test_exec_and_record_function_calls.py`.