### PR TITLE
LIN-439 Check Python version compatibility when retrieving an artifact

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,3 @@
+## 0.1.5
+
+* DB schema has been updated as per https://github.com/LineaLabs/lineapy/pull/702. For compatibility, users are asked to delete and recreate `.lineapy` folder. This crude resolution shall be replaced by a more systematic DB migration process.

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -4,6 +4,7 @@ User facing APIs.
 
 import logging
 import types
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
@@ -276,6 +277,18 @@ def get(artifact_name: str, version: Optional[int] = None) -> LineaArtifact:
         name=artifact_name,
         date_created=artifact.date_created,  # type: ignore
     )
+
+    # Check version compatibility
+    system_python_version = float(
+        f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    artifact_python_version = db.get_session_context(
+        linea_artifact._session_id
+    ).python_version
+    if system_python_version != artifact_python_version:
+        warnings.warn(
+            f"Current session runs on Python {system_python_version}, but the retrieved artifact was created on Python {artifact_python_version}. This may result in incompatibility issues."
+        )
 
     track(GetEvent(version_specified=version is not None))
     return linea_artifact

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -36,7 +36,7 @@ from lineapy.utils.analytics.usage_tracking import track
 from lineapy.utils.analytics.utils import side_effect_to_str
 from lineapy.utils.config import options
 from lineapy.utils.logging_config import configure_logging
-from lineapy.utils.utils import get_value_type
+from lineapy.utils.utils import get_system_python_version, get_value_type
 
 logger = logging.getLogger(__name__)
 # TODO: figure out if we need to configure it all the time
@@ -279,9 +279,7 @@ def get(artifact_name: str, version: Optional[int] = None) -> LineaArtifact:
     )
 
     # Check version compatibility
-    system_python_version = float(
-        f"{sys.version_info.major}.{sys.version_info.minor}"
-    )
+    system_python_version = get_system_python_version()  # up to minor version
     artifact_python_version = db.get_session_context(
         linea_artifact._session_id
     ).python_version

--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -47,7 +47,7 @@ class SessionContext(BaseModel):
 
     id: LineaID  # populated on creation by uuid.uuid4()
     environment_type: SessionType
-    python_version: float  # record up to minor version
+    python_version: str
     creation_time: datetime.datetime
     working_directory: str  # must be passed in for now
     session_name: Optional[str] = None

--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -47,6 +47,7 @@ class SessionContext(BaseModel):
 
     id: LineaID  # populated on creation by uuid.uuid4()
     environment_type: SessionType
+    python_version: float  # record up to minor version
     creation_time: datetime.datetime
     working_directory: str  # must be passed in for now
     session_name: Optional[str] = None

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     Enum,
+    Float,
     ForeignKey,
     Integer,
     String,
@@ -57,6 +58,7 @@ class SessionContextORM(Base):
     __tablename__ = "session_context"
     id = Column(String, primary_key=True)
     environment_type = Column(Enum(SessionType))
+    python_version = Column(Float)
     creation_time = Column(DateTime)
     working_directory = Column(String)
     session_name = Column(String, nullable=True)

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -34,7 +34,6 @@ from sqlalchemy import (
     Column,
     DateTime,
     Enum,
-    Float,
     ForeignKey,
     Integer,
     String,
@@ -58,7 +57,7 @@ class SessionContextORM(Base):
     __tablename__ = "session_context"
     id = Column(String, primary_key=True)
     environment_type = Column(Enum(SessionType))
-    python_version = Column(Float)
+    python_version = Column(String)
     creation_time = Column(DateTime)
     working_directory = Column(String)
     session_name = Column(String, nullable=True)

--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime
 from os import getcwd
@@ -38,7 +37,11 @@ from lineapy.instrumentation.mutation_tracker import MutationTracker
 from lineapy.instrumentation.tracer_context import TracerContext
 from lineapy.utils.constants import GETATTR, IMPORT_STAR
 from lineapy.utils.lineabuiltins import l_import, l_tuple
-from lineapy.utils.utils import get_lib_package_version, get_new_id
+from lineapy.utils.utils import (
+    get_lib_package_version,
+    get_new_id,
+    get_system_python_version,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,9 +89,7 @@ class Tracer:
         session_context = SessionContext(
             id=get_new_id(),
             environment_type=session_type,
-            python_version=float(
-                f"{sys.version_info.major}.{sys.version_info.minor}"
-            ),
+            python_version=get_system_python_version(),  # up to minor version
             creation_time=datetime.now(),
             working_directory=getcwd(),
             session_name=session_name,

--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime
 from os import getcwd
@@ -85,6 +86,9 @@ class Tracer:
         session_context = SessionContext(
             id=get_new_id(),
             environment_type=session_type,
+            python_version=float(
+                f"{sys.version_info.major}.{sys.version_info.minor}"
+            ),
             creation_time=datetime.now(),
             working_directory=getcwd(),
             session_name=session_name,

--- a/lineapy/utils/utils.py
+++ b/lineapy/utils/utils.py
@@ -149,3 +149,10 @@ def get_lib_package_version(name: str) -> Tuple[str, str]:
         if hasattr(parent_package, "__version__"):
             mod_version = parent_package.__version__
     return package_name if package_name else name, str(mod_version)
+
+
+def get_system_python_version(include_patch_version: bool = False) -> str:
+    ver = sys.version_info
+    if include_patch_version:
+        return f"{ver.major}.{ver.minor}.{ver.micro}"
+    return f"{ver.major}.{ver.minor}"


### PR DESCRIPTION
# Description

When the user uses artifacts saved from other sessions, they need to pay attention to the Python version compatibility. For instance, artifacts created and saved under an older version of Python may generate errors due to syntax deprecation. Our preference is to *warn* the user about this version incompatibility but NOT interrupt the workflow.

This update involves change in ORM, so it demands DB migration to work with previously created LineaPy DB, which is open as a separate ticket (i.e., [LIN-381](https://linea.atlassian.net/browse/LIN-381)).

# Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Locally tested through virtual environments running different Python versions.