### PR TITLE
LIN-459 save graph variable name information

### DIFF
--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -414,6 +414,15 @@ Node = Union[
 ]
 
 
+class AssignedVariable:
+    """
+    For local variables, this is the node that is assigned to.
+    """
+
+    node_id: LineaID
+    assigned_variable: str
+
+
 class PipelineType(Enum):
     """
     Pipeline types allow the to_pipeline to know what to expect

--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from sqlalchemy.orm import defaultload, scoped_session, sessionmaker
 from sqlalchemy.sql.expression import and_
@@ -693,3 +693,39 @@ class RelationalLineaDB:
 
         self.session.delete(value_orm)
         self.renew_session()
+
+    def get_variable_by_id(self, linea_id: LineaID) -> List[str]:
+        """
+        Returns the variable names(as a list) for a node with a certain ID
+        """
+
+        variable_node_orm = (
+            self.session.query(VariableNodeORM)
+            .filter(VariableNodeORM.id == linea_id)
+            .all()
+        )
+        return [n.variable_name for n in variable_node_orm]
+
+    def get_variables_for_session(
+        self, session_id: LineaID
+    ) -> List[Tuple[LineaID, str]]:
+        """
+        Returns the variable names for a session, as (LineaID, variable_name)
+        """
+
+        results = (
+            self.session.query(BaseNodeORM, VariableNodeORM)
+            .join(
+                VariableNodeORM,
+                VariableNodeORM.id == BaseNodeORM.id,
+                # isouter=None,
+            )
+            .filter(
+                and_(
+                    BaseNodeORM.id == VariableNodeORM.id,
+                    BaseNodeORM.session_id == session_id,
+                )
+            )
+            .all()
+        )
+        return [(n[0].id, n[1].variable_name) for n in results]

--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -46,6 +46,7 @@ from lineapy.db.relational import (
     PositionalArgORM,
     SessionContextORM,
     SourceCodeORM,
+    VariableNodeORM,
 )
 from lineapy.db.utils import create_lineadb_engine
 from lineapy.exceptions.db_exceptions import ArtifactSaveException
@@ -260,6 +261,16 @@ class RelationalLineaDB:
         node_value: NodeValue,
     ) -> None:
         self.session.add(NodeValueORM(**node_value.dict()))
+        self.renew_session()
+
+    def write_assigned_variable(
+        self,
+        node_id: LineaID,
+        variable_name: str,
+    ) -> None:
+        self.session.add(
+            VariableNodeORM(id=node_id, variable_name=variable_name)
+        )
         self.renew_session()
 
     def write_artifact(self, artifact: Artifact) -> None:

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -346,3 +346,11 @@ NodeORM = Union[
     MutateNodeORM,
     GlobalNodeORM,
 ]
+
+
+class VariableNodeORM(Base):
+
+    __tablename__ = "assigned_variable_node"
+    id = Column(String, primary_key=True)
+    # Warlus operator can assign to multiple variables at the same node,  so need two primary keys
+    variable_name: str = Column(String, nullable=False, primary_key=True)

--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -468,6 +468,7 @@ class Tracer:
         """
         logger.debug("assigning %s = %s", variable_name, value_node)
         self.variable_name_to_node[variable_name] = value_node
+        self.db.write_assigned_variable(value_node.id, variable_name)
         return
 
     def tuple(

--- a/tests/end_to_end/test_variable.py
+++ b/tests/end_to_end/test_variable.py
@@ -1,0 +1,60 @@
+from lineapy.data.types import NodeType
+
+
+def test_node_variables(execute):
+    """
+    Test
+
+    """
+    code = """import lineapy
+a=1
+b=a+2
+c=b*3
+d=a*4
+e=d+5
+art_a = lineapy.save(a, "a")
+art_c = lineapy.save(c, "c")
+art_e = lineapy.save(e, "e")
+"""
+    res = execute(
+        code,
+        snapshot=False,
+    )
+
+    art_e = res.values["art_e"]
+    node_with_variablename = art_e.db.get_variables_for_session(
+        art_e._session_id
+    )
+    # All variables are captured in the node
+    # including the import lineapy and all artifacts
+    assert len(node_with_variablename) == 9
+    # Only variable 'a' is an LiteralNode; others are all CallNodes
+    for node_id, variable_name in node_with_variablename:
+        if variable_name == "a":
+            assert (
+                art_e.db.get_node_by_id(node_id).node_type
+                == NodeType.LiteralNode
+            )
+        else:
+            assert (
+                art_e.db.get_node_by_id(node_id).node_type == NodeType.CallNode
+            )
+
+    walrus_code = """import lineapy
+seal = (b:='seal')
+art_seal = lineapy.save(seal, "seal")
+    """
+    warlus_res = execute(walrus_code, snapshot=False)
+    warlus_art = warlus_res.values["art_seal"]
+    warlus_code_variables = [
+        x[1]
+        for x in warlus_art.db.get_variables_for_session(
+            warlus_art._session_id
+        )
+    ]
+
+    assert len(warlus_code_variables) == 4
+    assert ["lineapy" in warlus_code_variables]
+    assert ["b" in warlus_code_variables]
+    assert ["seal" in warlus_code_variables]
+    assert ["art_seal" in warlus_code_variables]

--- a/tests/end_to_end/test_variable.py
+++ b/tests/end_to_end/test_variable.py
@@ -1,3 +1,5 @@
+import sys
+
 from lineapy.data.types import NodeType
 
 
@@ -40,21 +42,22 @@ art_e = lineapy.save(e, "e")
                 art_e.db.get_node_by_id(node_id).node_type == NodeType.CallNode
             )
 
-    walrus_code = """import lineapy
+    if sys.version_info.minor >= 8:
+        walrus_code = """import lineapy
 seal = (b:='seal')
 art_seal = lineapy.save(seal, "seal")
-    """
-    warlus_res = execute(walrus_code, snapshot=False)
-    warlus_art = warlus_res.values["art_seal"]
-    warlus_code_variables = [
-        x[1]
-        for x in warlus_art.db.get_variables_for_session(
-            warlus_art._session_id
-        )
-    ]
+        """
+        warlus_res = execute(walrus_code, snapshot=False)
+        warlus_art = warlus_res.values["art_seal"]
+        warlus_code_variables = [
+            x[1]
+            for x in warlus_art.db.get_variables_for_session(
+                warlus_art._session_id
+            )
+        ]
 
-    assert len(warlus_code_variables) == 4
-    assert ["lineapy" in warlus_code_variables]
-    assert ["b" in warlus_code_variables]
-    assert ["seal" in warlus_code_variables]
-    assert ["art_seal" in warlus_code_variables]
+        assert len(warlus_code_variables) == 4
+        assert ["lineapy" in warlus_code_variables]
+        assert ["b" in warlus_code_variables]
+        assert ["seal" in warlus_code_variables]
+        assert ["art_seal" in warlus_code_variables]


### PR DESCRIPTION
# Description

* Save session variable assignment to `assigned_variable_node` table
* Add class method to read variable assignment by `node_id` or `session` as following

``` python
# Get variable for a node (walrus operator might involve more than one variables per node)
db.db.get_variable_by_id(self, linea_id: LineaID) -> List[str]

# Get all variables for a session
db.db.get_variables_for_session(self, session_id: LineaID) -> List[Tuple[LineaID, str]]
```

If we go with this approach, (LIN-428) doesn't require database migration (LIN-381)

Fixes # (issue)

LIN-459

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Add new test and pass all existing tests