### PR TITLE
Fix error when import same module twice

### DIFF
--- a/tests/end_to_end/test_import.py
+++ b/tests/end_to_end/test_import.py
@@ -201,3 +201,17 @@ x = pyplot.ylabel('label')
     res = execute(code, artifacts=["x"])
     assert res.values["x"].__class__.__name__ == "Text"
     assert res.artifacts["x"] == prettify(code)
+
+
+def test_import_samething_twice(execute):
+    """
+    Test import samething twice
+    """
+    code = """
+import sys
+import sys
+
+import pandas as pd
+import pandas as pd
+    """
+    res = execute(code, snapshot=False)

--- a/tests/end_to_end/test_variable.py
+++ b/tests/end_to_end/test_variable.py
@@ -5,8 +5,7 @@ from lineapy.data.types import NodeType
 
 def test_variable_assign_to_node(execute):
     """
-    Test
-
+    Test general case for variable assignment
     """
     code = """import lineapy
 a=1
@@ -63,7 +62,7 @@ art_seal = lineapy.save(seal, "seal")
 
 def test_variable_assign_from_other_variable(execute):
     """
-    Test
+    Test variable assignment from existing variables
     """
     code = """import lineapy
 a=[]
@@ -82,7 +81,7 @@ art = lineapy.save(c,'c')
 
 def test_variable_assign_tuple(execute):
     """
-    Test
+    Test tuple assignment to variables
     """
     code = """import lineapy
 a, b = (1,2)


### PR DESCRIPTION
# Description

Found an error while running 

```
import pandas as pd
import pandas as pd
```

because we try to write the same (node_id, variable_name) to the database again. 

This happens when we try to import the same thing twice, we are using the same node.

Fixes # (issue)

LIN-459

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New test added