### PR TITLE
Update .gitignore for contributors who use venv 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,12 @@ ENV/
 env.bak/
 venv.bak/
 .idea/
+lineapy/bin
+lineapy/etc
+lineapy/include
+lineapy/lib64
+lineapy/pyvenv.cfg
+lineapy/share
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
# Description

In [CONTRIBUTING.md](https://github.com/LineaLabs/lineapy/blob/main/CONTRIBUTING.md), I was instructed to create "lineapy" as the folder name for virtualenv. An alternative solution would be updating the folder name (from lineapy to venv) in CONTRIBUTING.md.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Tested locally in venv