### PR TITLE
Pull out Lineapy related calls

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -70,10 +70,16 @@ def save(reference: object, name: str) -> LineaArtifact:
         returned value offers methods to access
         information we have stored about the artifact (value, version), and other automation capabilities, such as :func:`to_pipeline`.
     """
-    execution_context = get_context()
-    executor = execution_context.executor
-    db = executor.db
-    call_node = execution_context.node
+    logger.warn("Calling save inside control blocks is not supported")
+
+
+def _save(
+    call_node, executor, db, reference: object, name: str
+) -> LineaArtifact:
+    # execution_context = get_context()
+    # executor = execution_context.executor
+    # db = executor.db
+    # call_node = execution_context.node
 
     # If this value is stored as a global in the executor (meaning its an external side effect)
     # then look it up from there, instead of using this node.
@@ -258,6 +264,12 @@ def get(artifact_name: str, version: Optional[int] = None) -> LineaArtifact:
         returned value offers methods to access
         information we have stored about the artifact
     """
+    logger.warn("cant use get inside blackbox")
+
+
+def _get(
+    call_node, executor, db, artifact_name: str, version: Optional[int] = None
+) -> LineaArtifact:
     validated_version = parse_artifact_version(
         "latest" if version is None else version
     )
@@ -265,8 +277,8 @@ def get(artifact_name: str, version: Optional[int] = None) -> LineaArtifact:
         validated_version if isinstance(validated_version, int) else None
     )
 
-    execution_context = get_context()
-    db = execution_context.executor.db
+    # execution_context = get_context()
+    # db = execution_context.executor.db
     artifact = db.get_artifact_by_name(artifact_name, final_version)
     linea_artifact = LineaArtifact(
         db=db,
@@ -312,8 +324,11 @@ def artifact_store() -> LineaArtifactStore:
     LineaArtifactStore
         An object of the class `LineaArtifactStore` that allows for printing and exporting artifacts metadata.
     """
-    execution_context = get_context()
-    cat = LineaArtifactStore(execution_context.executor.db)
+    logger.warn("Cant use artifact_store in blackboxes")
+
+
+def _artifact_store(_call_node, _executor, db) -> LineaArtifactStore:
+    cat = LineaArtifactStore(db)
     track(CatalogEvent(catalog_size=cat.len))
     return cat
 
@@ -385,3 +400,8 @@ def to_pipeline(
 
     else:
         raise Exception(f"No PipelineType for {framework}")
+
+
+def healthcheck(*args, **kwargs):
+    print(args)
+    print(kwargs)

--- a/lineapy/api/api_classes.py
+++ b/lineapy/api/api_classes.py
@@ -142,10 +142,13 @@ class LineaArtifact:
             )
         )
         code = str(
-            get_source_code_from_graph(self._get_subgraph(keep_lineapy_save))
+            get_source_code_from_graph(
+                self._get_subgraph(keep_lineapy_save),
+                use_lineapy_serialization,
+            )
         )
-        if not use_lineapy_serialization:
-            code = de_lineate_code(code, self.db)
+        # if not use_lineapy_serialization:
+        #     code = de_lineate_code(code, self.db)
         return prettify(code)
 
     @lru_cache(maxsize=None)
@@ -169,8 +172,8 @@ class LineaArtifact:
             )
         )
         code = self.db.get_source_code_for_session(self._session_id)
-        if not use_lineapy_serialization:
-            code = de_lineate_code(code, self.db)
+        # if not use_lineapy_serialization:
+        #     code = de_lineate_code(code, self.db)
         # NOTE: we are not prettifying this code because we want to preserve what
         # the user wrote originally, without processing
         return code

--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -32,7 +32,7 @@ from lineapy.exceptions.excepthook import set_custom_excepthook
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.plugins.airflow import AirflowPlugin
 from lineapy.plugins.utils import slugify
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.analytics.utils import send_lib_info_from_db
 from lineapy.utils.benchmarks import distribution_change
 from lineapy.utils.config import (

--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -355,6 +355,14 @@ class CallNode(BaseNode):
         yield from self.implicit_dependencies
 
 
+class LineaCallNode(CallNode):
+    module_name: str  # lineapy.api.api or lineapy.api.api_classes type of string
+    function_name: str  # save/get type of string
+    artifact_name: str
+    artifact_version: Optional[str]
+    execution_count: int = 0
+
+
 class LiteralNode(BaseNode):
     node_type: NodeType = Field(NodeType.LiteralNode, repr=False)
     value: Any

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -18,7 +18,7 @@ from lineapy.exceptions.excepthook import transform_except_hook_args
 from lineapy.exceptions.flag import REWRITE_EXCEPTIONS
 from lineapy.exceptions.user_exception import AddFrame
 from lineapy.instrumentation.tracer import Tracer
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.analytics.utils import send_lib_info_from_db
 from lineapy.utils.config import options
 from lineapy.utils.logging_config import configure_logging

--- a/lineapy/execution/executor.py
+++ b/lineapy/execution/executor.py
@@ -23,6 +23,7 @@ from lineapy.data.types import (
     Execution,
     GlobalNode,
     ImportNode,
+    LineaCallNode,
     LineaID,
     LiteralNode,
     LookupNode,
@@ -355,6 +356,23 @@ class Executor:
         ]
 
         return PrivateExecuteResult(res, start_time, end_time, side_effects)
+
+    @_execute.register
+    def _execute_linea_call(
+        self,
+        node: LineaCallNode,
+        changes: Iterable[TracebackChange],
+        variables: Optional[Dict[str, LineaID]],
+    ) -> PrivateExecuteResult:
+        # dummy
+        # TODO - the value here should be the artifact. this should probably come from linea transformer.
+        # best if linea transformer adds the artifact's id to tracer directly and this piece can tie the value to the graph.
+        return PrivateExecuteResult(
+            value=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            side_effects=[],
+        )
 
     def lookup_external_state(self, state: ExternalState) -> Optional[LineaID]:
         """

--- a/lineapy/execution/executor.py
+++ b/lineapy/execution/executor.py
@@ -368,7 +368,7 @@ class Executor:
         # TODO - the value here should be the artifact. this should probably come from linea transformer.
         # best if linea transformer adds the artifact's id to tracer directly and this piece can tie the value to the graph.
         return PrivateExecuteResult(
-            value=None,
+            value=self._id_to_value[node.id],
             start_time=datetime.now(),
             end_time=datetime.now(),
             side_effects=[],

--- a/lineapy/graph_reader/program_slice.py
+++ b/lineapy/graph_reader/program_slice.py
@@ -1,10 +1,9 @@
 import logging
 from dataclasses import dataclass
-from re import L
 from typing import DefaultDict, List, Set
 
 from lineapy.data.graph import Graph
-from lineapy.data.types import CallNode, ImportNode, LineaID, SourceCode
+from lineapy.data.types import ImportNode, LineaCallNode, LineaID, SourceCode
 from lineapy.db.db import RelationalLineaDB
 from lineapy.utils.utils import prettify
 
@@ -42,7 +41,7 @@ def get_slice_graph(
                 # first_arg = c_node.positional_args[0]
                 # if "lineapy.save" in line_code and first_arg.id == sink:
                 if (
-                    isinstance(c_node, LineaNode)
+                    isinstance(c_node, LineaCallNode)
                     and c_node.function_name == "save"
                 ):  # and first_arg.id == sink:
                     new_sink = c_id

--- a/lineapy/instrumentation/tracer.py
+++ b/lineapy/instrumentation/tracer.py
@@ -56,6 +56,7 @@ class Tracer:
 
     variable_name_to_node: Dict[str, Node] = field(default_factory=dict)
     module_name_to_node: Dict[str, Node] = field(default_factory=dict)
+    linea_node_id_to_value: dict[LineaID, object] = field(default_factory=dict)
 
     tracer_context: TracerContext = field(init=False)
     executor: Executor = field(init=False)

--- a/lineapy/plugins/base.py
+++ b/lineapy/plugins/base.py
@@ -57,9 +57,7 @@ class BasePlugin:
             full_import_block += "\n" + _import_block
             full_code_block += "\n" + _code_block
 
-        full_code = prettify(
-            de_lineate_code(full_import_block + full_code_block, self.db)
-        )
+        full_code = prettify(full_import_block + full_code_block)
         (output_dir_path / f"{module_name}.py").write_text(full_code)
         logger.info(f"Generated python module {module_name}.py")
 
@@ -132,7 +130,10 @@ class BasePlugin:
             if len(artifact_var) == 0:
                 raise ValueError(f"Invalid slice name {slice_name}.")
             slice_code: CodeSlice = get_program_slice_by_artifact_name(
-                self.db, slice_name, keep_lineapy_save=True
+                self.db,
+                slice_name,
+                keep_lineapy_save=True,
+                use_lineapy_serialization=False,
             )
             artifacts_code[artifact_var] = slice_code
             artifact_safe_names.append(artifact_var)

--- a/lineapy/transformer/linea_transformer.py
+++ b/lineapy/transformer/linea_transformer.py
@@ -1,0 +1,111 @@
+import ast
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Optional, Union
+from winreg import KEY_WOW64_32KEY
+
+from lineapy.data.types import (
+    LineaCallNode,
+    Node,
+    SourceCode,
+    SourceCodeLocation,
+    SourceLocation,
+)
+from lineapy.instrumentation.tracer import Tracer
+from lineapy.utils.utils import get_new_id
+
+logger = logging.getLogger(__name__)
+
+
+class LineaTransformer(ast.NodeTransformer):
+    def __init__(
+        self,
+        code: str,
+        location: SourceCodeLocation,
+        tracer: Tracer,
+    ):
+        self.source_code = SourceCode(
+            id=get_new_id(), code=code, location=location
+        )
+        # tracer.db.write_source_code(self.source_code)
+        self.tracer = tracer
+        # Set __file__ to the pathname of the file
+        if isinstance(location, Path):
+            tracer.executor.module_file = str(location)
+        # The result of the last line, a node if it was an expression,
+        # None if it was a statement. Used by ipython to grab the last value
+        self.last_statement_result: Optional[Node] = None
+
+    def lgeneric_visit(self, node: ast.AST):
+        return node
+
+    def lvisit(self, node):
+        """Visit a node."""
+        method = "lvisit_" + node.__class__.__name__
+        visitor = getattr(self, method, self.lgeneric_visit)
+        return visitor(node)
+
+    def visit_Call(self, node: ast.Call) -> Union[ast.Call, LineaCallNode]:
+        func = self.lvisit(node.func)
+        if func is not None and func[0] == "lineapy":
+            argument_values = [self.lvisit(arg) for arg in node.args]
+            # keyword_values = {key:value for }
+            if func[1] == "save":
+                artifact_name = argument_values[1]
+                # this is to locate this node in the graph. its predecessors
+                # are the var we are trying to save as an artifact
+                dependent = self.tracer.lookup_node(
+                    argument_values[0], self.get_source(node)
+                )
+            if func[1] == "get":
+                artifact_name = argument_values[0]
+
+            lineanode = LineaCallNode(
+                id=get_new_id(),
+                session_id=self.tracer.get_session_id(),
+                function_id=get_new_id(),
+                artifact_name=artifact_name,
+                artifact_version=None,
+                positional_args=[dependent],  # there can only be one - for now
+                keyword_args=[],
+                module_name=func[0],
+                function_name=func[1],
+            )
+
+            # TODO - save the artifact here and attach the result to the graph.
+            print(
+                "I'm gonna do it.. i'm gonna save the artifact here. ready or not"
+            )
+            return lineanode
+
+        return node
+
+    def lvisit_Attribute(self, node: ast.Attribute):
+        value = self.lvisit(node.value)
+        if value in self.tracer.variable_name_to_node:
+            module_imported: ModuleType = self.tracer.executor.get_value(  # type: ignore
+                self.tracer.variable_name_to_node[value].id
+            )
+            module_name = module_imported.__name__
+            attribute = node.attr
+            return (module_name, attribute)
+        return None
+
+    def lvisit_Name(self, node):
+        return node.id
+
+    def lvisit_Constant(self, node):
+        # name of the artifact etc
+        return node.value
+
+    def get_source(self, node: ast.AST) -> Optional[SourceLocation]:
+        if not hasattr(node, "lineno"):
+            return None
+        return SourceLocation(
+            source_code=self.source_code,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,  # type: ignore
+            end_col_offset=node.end_col_offset,  # type: ignore
+        )

--- a/lineapy/transformer/lineapy-sample.md
+++ b/lineapy/transformer/lineapy-sample.md
@@ -1,3 +1,4 @@
+# noqa
 from lineapy.transformer.node_transformer import NodeTransformer
 
 

--- a/lineapy/transformer/lineapy-sample.py
+++ b/lineapy/transformer/lineapy-sample.py
@@ -1,0 +1,84 @@
+from lineapy.transformer.node_transformer import NodeTransformer
+
+
+class LineaCallNode(CallNode):
+    # might not be used directly yet.
+    module_name: str #lineapy.api.api or lineapy.api.api_classes type of string
+    function_name: str # save/get type of string
+    artifact_name:str
+    artifact_version: str
+    execution_count:int = 0
+
+
+
+class lapi():
+    def __init__(self):
+        #initialize tracer here
+        db: RelationalLineaDB
+        executor: executor = Executor(db)
+        ExecutionContext: ExecutionContext
+        tracer: Tracer = Tracer(executor, db)
+        self.transformers = [ LineaCallTransformer(tracer), NodeTransformer(tracer) ]
+
+    def transform():
+    # get the contents of orig transform here.
+    try:
+        tree = ast.parse(
+            code,
+            str(get_location_path(location).absolute()),
+        )
+    except SyntaxError as e:
+        raise UserException(e, RemoveFrames(2))
+    if sys.version_info < (3, 8):
+        from asttokens import ASTTokens
+
+        from lineapy.transformer.source_giver import SourceGiverfor
+
+        # if python version is 3.7 or below, we need to run the source_giver
+        # to add the end_lineno's to the nodes. We do this in two steps - first
+        # the asttoken lib does its thing and adds tokens to the nodes
+        # and then we swoop in and copy the end_lineno from the tokens
+        # and claim credit for their hard work
+        ASTTokens(code, parse=False, tree=tree)
+        SourceGiver().transform(tree)
+
+    #tree is of module type - atleast for scripts - check for jupyter
+    for node in tree.body:
+        for trans in self.transformer:
+            res = trans.visit(node)
+            # or some other statement to figure out whether the node is properly processed or not
+            if res is not None:
+                node = res # swap the node with the output of previous transformer and use that for further calls
+        # if no transformers can process it - we'll change node transformer to not throw not implemented exception
+        # so that it can be extended and move it here.
+        if isinstance(node, ast.Any):
+            raise NotImplementedError(
+                f"Don't know how to transform {type(node).__name__}"
+            )
+    
+    db.commit()
+    return self.transformers[-1].last_statement_result
+
+
+class LineaCallTransformer(NodeTransformer):
+    def visit_Call(self, node):
+        # check if function is lineapy-ish
+        # we have access to tracer here. so we can simply get the function from the
+        # tracer.variable_name_to_node dict and can get the orig object from there.
+        # if the object does not exist, simple pass along and let node_transformer handle it
+        # if the object does exist, get it and check its module/function name and if 
+        # it is a lineapy function, EXECUTE IT without involving the executor and make 
+        # it into a LineaCallNode and pass it along to the next transformer.
+        # this new node should still be made part of the tree, so we will pass it along 
+        # for node transformer to process it and add to the graph.
+
+class NodeTransformer(NodeTransformer):
+    # add new function
+    def visit_LineaCallNode(self, node):
+        # should never be passed to executor since it already should be executed.
+        # execute_call will not be called.
+
+        # this instead can be used to do other stuff like count executions 
+        # for the same graph. it will look up executions by artifact_name, artifact_version, 
+        # (or alternately node_id bcause it was already executed in lineapytransformer) and 
+        # up the execution count by 1

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -308,7 +308,8 @@ class NodeTransformer(ast.NodeTransformer):
 
     def visit_LineaCallNode(self, node: LineaCallNode):
         print("Nothing to do here but we'll need to save this")
-        return self.tracer.process_node(node)
+        self.tracer.process_node(node)
+        return node
 
     def visit_Delete(self, node: ast.Delete) -> None:
         target = node.targets[0]

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -6,14 +6,13 @@ from typing import Any, Iterable, Optional, cast
 
 from lineapy.data.types import (
     CallNode,
+    LineaCallNode,
     LiteralNode,
     Node,
     SourceCode,
     SourceCodeLocation,
     SourceLocation,
 )
-from lineapy.editors.ipython_cell_storage import get_location_path
-from lineapy.exceptions.user_exception import RemoveFrames, UserException
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.transformer.transformer_util import create_lib_attributes
 from lineapy.utils.constants import (
@@ -64,43 +63,6 @@ from lineapy.utils.lineabuiltins import (
 from lineapy.utils.utils import get_new_id
 
 logger = logging.getLogger(__name__)
-
-
-def transform(
-    code: str, location: SourceCodeLocation, tracer: Tracer
-) -> Optional[Node]:
-    """
-    Traces the given code, executing it and writing the results to the DB.
-
-    It returns the node corresponding to the last statement in the code,
-    if it exists.
-    """
-
-    node_transformer = NodeTransformer(code, location, tracer)
-    try:
-        tree = ast.parse(
-            code,
-            str(get_location_path(location).absolute()),
-        )
-    except SyntaxError as e:
-        raise UserException(e, RemoveFrames(2))
-    if sys.version_info < (3, 8):
-        from asttokens import ASTTokens
-
-        from lineapy.transformer.source_giver import SourceGiver
-
-        # if python version is 3.7 or below, we need to run the source_giver
-        # to add the end_lineno's to the nodes. We do this in two steps - first
-        # the asttoken lib does its thing and adds tokens to the nodes
-        # and then we swoop in and copy the end_lineno from the tokens
-        # and claim credit for their hard work
-        ASTTokens(code, parse=False, tree=tree)
-        SourceGiver().transform(tree)
-
-    node_transformer.visit(tree)
-
-    tracer.db.commit()
-    return node_transformer.last_statement_result
 
 
 class NodeTransformer(ast.NodeTransformer):
@@ -343,6 +305,10 @@ class NodeTransformer(ast.NodeTransformer):
             *argument_nodes,
             **keyword_argument_nodes,
         )
+
+    def visit_LineaCallNode(self, node: LineaCallNode):
+        print("Nothing to do here but we'll need to save this")
+        return self.tracer.process_node(node)
 
     def visit_Delete(self, node: ast.Delete) -> None:
         target = node.targets[0]

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -1,0 +1,67 @@
+import ast
+import logging
+import sys
+from typing import Optional
+
+from lineapy.data.types import Node, SourceCodeLocation
+from lineapy.editors.ipython_cell_storage import get_location_path
+from lineapy.exceptions.user_exception import RemoveFrames, UserException
+from lineapy.instrumentation.tracer import Tracer
+from lineapy.transformer.linea_transformer import LineaTransformer
+from lineapy.transformer.node_transformer import NodeTransformer
+
+logger = logging.getLogger(__name__)
+
+
+def transform(
+    code: str, location: SourceCodeLocation, tracer: Tracer
+) -> Optional[Node]:
+    """
+    Traces the given code, executing it and writing the results to the DB.
+
+    It returns the node corresponding to the last statement in the code,
+    if it exists.
+    """
+
+    transformers = [LineaTransformer(code,location,tracer), NodeTransformer(code, location, tracer)]
+    try:
+        tree = ast.parse(
+            code,
+            str(get_location_path(location).absolute()),
+        )
+    except SyntaxError as e:
+        raise UserException(e, RemoveFrames(2))
+    if sys.version_info < (3, 8):
+        from asttokens import ASTTokens
+
+        from lineapy.transformer.source_giver import SourceGiver
+
+        # if python version is 3.7 or below, we need to run the source_giver
+        # to add the end_lineno's to the nodes. We do this in two steps - first
+        # the asttoken lib does its thing and adds tokens to the nodes
+        # and then we swoop in and copy the end_lineno from the tokens
+        # and claim credit for their hard work
+        ASTTokens(code, parse=False, tree=tree)
+        SourceGiver().transform(tree)
+
+    for stmt in tree.body:
+        res = None
+        for trans in transformers:
+            print(ast.dump(stmt))
+            res = trans.visit(stmt)
+            # or some other statement to figure out whether the node is properly processed or not
+            if res is not None:
+                stmt = res  # swap the node with the output of previous transformer and use that for further calls
+        # if no transformers can process it - we'll change node transformer to not throw not implemented exception
+        # so that it can be extended and move it here.
+        if isinstance(res, ast.AST):
+            raise NotImplementedError(
+                f"Don't know how to transform {type(stmt).__name__}"
+            )
+        # FIXME - this is needed for jupyter, will revisit this after prototype phase.
+        last_statement_result = res  # type: ignore
+    # replaced by the for loop above
+    # node_transformer.visit(tree)
+
+    tracer.db.commit()
+    return last_statement_result  # type: ignore

--- a/lineapy/visualizer/graphviz.py
+++ b/lineapy/visualizer/graphviz.py
@@ -100,6 +100,7 @@ COLORS: Dict[ColorableType, str] = defaultdict(
     lambda: "#d4d4d4",  # use a slightly darker grey by default
     {
         NodeType.CallNode: BREWER_PASTEL["pink"],
+        NodeType.LineaCallNode: BREWER_PASTEL["pink"],
         NodeType.LiteralNode: BREWER_PASTEL["green"],
         NodeType.MutateNode: BREWER_PASTEL["red"],
         NodeType.ImportNode: BREWER_PASTEL["purple"],
@@ -117,6 +118,7 @@ COLORS: Dict[ColorableType, str] = defaultdict(
 # Labels for node types for legend
 NODE_LABELS: Dict[NodeType, str] = {
     NodeType.CallNode: "Call",
+    NodeType.LineaCallNode: "LineaCall",
     NodeType.LiteralNode: "Literal",
     NodeType.ImportNode: "Import",
     NodeType.LookupNode: "Lookup",
@@ -127,6 +129,7 @@ NODE_LABELS: Dict[NodeType, str] = {
 
 NODE_SHAPES: Dict[NodeType, str] = {
     NodeType.CallNode: "record",
+    NodeType.LineaCallNode: "record",
     NodeType.LiteralNode: "box",
     NodeType.ImportNode: "box",
     NodeType.LookupNode: "box",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,8 @@ class ExecuteFixture:
 
         # Verify that execution works again, with a new session
         new_executor = Executor(self.db, globals())
+        for ids in tracer.linea_node_id_to_value:
+            new_executor._id_to_value[ids] = tracer.linea_node_id_to_value[ids]
         current_working_dir = os.getcwd()
         os.chdir(self.tmp_path)
         new_executor.execute_graph(tracer.graph)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from lineapy.execution.inspect_function import FunctionInspector
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.plugins.airflow import AirflowPlugin
 from lineapy.plugins.script import ScriptPlugin
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.config import DB_FILE_NAME, options
 from lineapy.utils.constants import DB_SQLITE_PREFIX
 from lineapy.utils.logging_config import configure_logging

--- a/tests/unit/transformer/test_node_transformer.py
+++ b/tests/unit/transformer/test_node_transformer.py
@@ -9,8 +9,9 @@ import asttokens
 import pytest
 from mock import MagicMock, patch
 
-from lineapy.transformer.node_transformer import NodeTransformer, transform
+from lineapy.transformer.node_transformer import NodeTransformer
 from lineapy.transformer.source_giver import SourceGiver
+from lineapy.transformer.transform_code import transform
 
 
 def _get_ast_node(code):


### PR DESCRIPTION
# Description

Calls nodes that are wrappers for functions inside lineapy will be pulled out as special nodes. to do this properly, i had to also implement the placeholder functions and this gives us the desirable result of not letting you save/get etc inside blackboxes.

Fixes LIN-414 partially. also should address LIN-361

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] This change requires a documentation update

# How Has This Been Tested?
existing tests. will also add new tests to demonstrate working/non-working cases.