### PR TITLE
LIN-483 Add version options to lineapy cli

### DIFF
--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -59,6 +59,13 @@ logger = logging.getLogger(__name__)
     help="Print out logging for graph creation and execution.",
     is_flag=True,
 )
+@click.version_option(
+    None,
+    "--version",
+    "-v",
+    message="%(package)s %(version)s",
+    help="Print the Lineapy version number and exit.",
+)
 @click.option(
     "--home-dir",
     type=click.Path(dir_okay=True, path_type=pathlib.Path),


### PR DESCRIPTION
Summary:
This commit adds a '-v' and '--version' flags to Lineapy CLI.
These options print the package name and version when supplied.

Test Plan:
Local testing.

> (linea-venv-3.9.0) Lineas-MacBook-Pro:~ andrewcui$ lineapy -v
> lineapy 0.1.4

> (linea-venv-3.9.0) Lineas-MacBook-Pro:~ andrewcui$ lineapy --version
> lineapy 0.1.4

JIRA:
LIN-483