### PR TITLE
move transform function into its own module.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
         entry: mypy .
         language: python
         additional_dependencies: ["mypy==0.931", "SQLAlchemy==1.4.29", "sqlalchemy[mypy]",
-                                  "mypy-extensions==0.4.3", "pydantic==1.9.0", "types-PyYAML", "types-requests"]
+                                  "mypy-extensions==0.4.3", "pydantic==1.9.0", "types-PyYAML", "types-requests", "types-mock"]
         types: [python]
         pass_filenames: false

--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -33,7 +33,7 @@ from lineapy.exceptions.excepthook import set_custom_excepthook
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.plugins.airflow import AirflowPlugin
 from lineapy.plugins.utils import slugify
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.analytics.utils import send_lib_info_from_db
 from lineapy.utils.benchmarks import distribution_change
 from lineapy.utils.config import (

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -18,7 +18,7 @@ from lineapy.exceptions.excepthook import transform_except_hook_args
 from lineapy.exceptions.flag import REWRITE_EXCEPTIONS
 from lineapy.exceptions.user_exception import AddFrame
 from lineapy.instrumentation.tracer import Tracer
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.analytics.utils import send_lib_info_from_db
 from lineapy.utils.config import options
 from lineapy.utils.logging_config import configure_logging

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -1,0 +1,68 @@
+import ast
+import logging
+import sys
+from typing import Optional
+
+from lineapy.data.types import Node, SourceCodeLocation
+from lineapy.editors.ipython_cell_storage import get_location_path
+from lineapy.exceptions.user_exception import RemoveFrames, UserException
+from lineapy.instrumentation.tracer import Tracer
+from lineapy.transformer.node_transformer import NodeTransformer
+
+logger = logging.getLogger(__name__)
+
+
+def transform(
+    code: str, location: SourceCodeLocation, tracer: Tracer
+) -> Optional[Node]:
+    """
+    Traces the given code, executing it and writing the results to the DB.
+
+    It returns the node corresponding to the last statement in the code,
+    if it exists.
+    """
+
+    transformers = [
+        NodeTransformer(code, location, tracer),
+    ]
+    try:
+        tree = ast.parse(
+            code,
+            str(get_location_path(location).absolute()),
+        )
+    except SyntaxError as e:
+        raise UserException(e, RemoveFrames(2))
+    if sys.version_info < (3, 8):
+        from asttokens import ASTTokens
+
+        from lineapy.transformer.source_giver import SourceGiver
+
+        # if python version is 3.7 or below, we need to run the source_giver
+        # to add the end_lineno's to the nodes. We do this in two steps - first
+        # the asttoken lib does its thing and adds tokens to the nodes
+        # and then we swoop in and copy the end_lineno from the tokens
+        # and claim credit for their hard work
+        ASTTokens(code, parse=False, tree=tree)
+        SourceGiver().transform(tree)
+
+    for stmt in tree.body:
+        res = None
+        for trans in transformers:
+            # print(ast.dump(stmt))
+            res = trans.visit(stmt)
+            # or some other statement to figure out whether the node is properly processed or not
+            if res is not None:
+                stmt = res  # swap the node with the output of previous transformer and use that for further calls
+        # if no transformers can process it - we'll change node transformer to not throw not implemented exception
+        # so that it can be extended and move it here.
+        if isinstance(res, ast.AST):
+            raise NotImplementedError(
+                f"Don't know how to transform {type(stmt).__name__}"
+            )
+        # FIXME - this is needed for jupyter, will revisit this after prototype phase.
+        last_statement_result = res  # type: ignore
+    # replaced by the for loop above
+    # node_transformer.visit(tree)
+
+    tracer.db.commit()
+    return last_statement_result  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,4 @@ ignore_missing_imports = true
 # Do not raise errors on ignores which we don't need - hassle when supporting multiple python versions
 warn_unused_ignores = false
 
-
 warn_unreachable = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ graphviz==0.19.2
 isort==5.10.1
 jupyterlab==3.3.3
 matplotlib==3.5.1
-mypy==0.942
+mypy==0.931
 nbconvert==6.5.0
 nbformat==5.3.0
 nbsphinx==0.8.8
@@ -33,13 +33,14 @@ pytest-virtualenv==1.7.0
 pytest-xdist==2.5.0
 requests==2.27.1
 rich==12.2.0
+scikit-learn==1.0.2
 scipy==1.7.3
 scour==0.38.2
 seaborn==0.11.2
-scikit-learn==1.0.2
 sphinx-autobuild==2021.3.14
 sphinx-rtd-theme==1.0.0
 SQLAlchemy==1.4.35
 syrupy==1.4.5
+types-mock==4.0.15
 types-PyYAML==6.0.5
 types-requests==2.27.16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from lineapy.execution.inspect_function import FunctionInspector
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.plugins.airflow import AirflowPlugin
 from lineapy.plugins.script import ScriptPlugin
-from lineapy.transformer.node_transformer import transform
+from lineapy.transformer.transform_code import transform
 from lineapy.utils.config import DB_FILE_NAME, options
 from lineapy.utils.constants import DB_SQLITE_PREFIX
 from lineapy.utils.logging_config import configure_logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,7 +397,7 @@ def db_url(tmp_path_factory):
 @pytest.fixture
 def alembic_config(db_url):
     lp_install_dir = Path(__file__).resolve().parent.parent / "lineapy"
-    alembic_cfg = config.Config(lp_install_dir / "alembic.ini")
+    alembic_cfg = config.Config(str(lp_install_dir / "alembic.ini"))
     alembic_cfg.set_main_option(
         "script_location",
         (lp_install_dir / "_alembic").as_posix(),

--- a/tests/tools/requirements_txt_gen.py
+++ b/tests/tools/requirements_txt_gen.py
@@ -26,6 +26,7 @@ INSTALL_REQUIRES = [
     "nbformat",
     "nbconvert",
     "requests",
+    "alembic==1.8.0",
 ]
 
 
@@ -40,7 +41,7 @@ DEV_REQUIRES = [
     ##
     "altair",
     "pandas",
-    "sklearn",
+    "scikit-learn",
     "flake8",
     "fastparquet",
     "matplotlib",
@@ -59,6 +60,7 @@ DEV_REQUIRES = [
     "pytest-cov",
     "pdbpp",
     "pytest-virtualenv",
+    "pytest-alembic",
     "nbval",
     "coveralls",
     "pre-commit",
@@ -78,6 +80,7 @@ DEV_REQUIRES = [
     "mypy",
     "types-PyYAML",
     "types-requests",
+    "types-mock",
     "SQLAlchemy[mypy]>=1.4.0",
     ##
     # DBs

--- a/tests/unit/transformer/test_node_transformer.py
+++ b/tests/unit/transformer/test_node_transformer.py
@@ -9,8 +9,9 @@ import asttokens
 import pytest
 from mock import MagicMock, patch
 
-from lineapy.transformer.node_transformer import NodeTransformer, transform
+from lineapy.transformer.node_transformer import NodeTransformer
 from lineapy.transformer.source_giver import SourceGiver
+from lineapy.transformer.transform_code import transform
 
 
 def _get_ast_node(code):
@@ -23,7 +24,7 @@ def _get_ast_node(code):
 
 
 @patch(
-    "lineapy.transformer.node_transformer.NodeTransformer",
+    "lineapy.transformer.transform_code.NodeTransformer",
 )
 def test_transform_fn(nt_mock: MagicMock):
     """

--- a/tests/unit/transformer/test_node_transformer.py
+++ b/tests/unit/transformer/test_node_transformer.py
@@ -7,11 +7,10 @@ import sys
 
 import asttokens
 import pytest
-from mock import MagicMock, patch
+from mock import MagicMock
 
 from lineapy.transformer.node_transformer import NodeTransformer
 from lineapy.transformer.source_giver import SourceGiver
-from lineapy.transformer.transform_code import transform
 
 
 def _get_ast_node(code):
@@ -21,21 +20,6 @@ def _get_ast_node(code):
         SourceGiver().transform(node)
 
     return node
-
-
-@patch(
-    "lineapy.transformer.transform_code.NodeTransformer",
-)
-def test_transform_fn(nt_mock: MagicMock):
-    """
-    Test that the transform function calls the NodeTransformer
-    """
-    mocked_tracer = MagicMock()
-    source_location = MagicMock()
-    transform("x = 1", source_location, mocked_tracer)
-    nt_mock.assert_called_once_with("x = 1", source_location, mocked_tracer)
-    mocked_tracer.db.commit.assert_called_once()
-    # TODO - test that source giver is called only for 3.7 and below
 
 
 class TestNodeTransformer:

--- a/tests/unit/transformer/test_transform_code.py
+++ b/tests/unit/transformer/test_transform_code.py
@@ -1,0 +1,18 @@
+from mock import MagicMock, patch
+
+from lineapy.transformer.transform_code import transform
+
+
+@patch(
+    "lineapy.transformer.transform_code.NodeTransformer",
+)
+def test_transform_fn(nt_mock: MagicMock):
+    """
+    Test that the transform function calls the NodeTransformer
+    """
+    mocked_tracer = MagicMock()
+    source_location = MagicMock()
+    transform("x = 1", source_location, mocked_tracer)
+    nt_mock.assert_called_once_with("x = 1", source_location, mocked_tracer)
+    mocked_tracer.db.commit.assert_called_once()
+    # TODO - test that source giver is called only for 3.7 and below


### PR DESCRIPTION
# Description

This was done when preparing for another design task. Looks like a helpful change since we had transform function sitting inside nodetransformer module.

Fixes N/A

## Type of change

Please delete options that are not relevant.

- [ x ] This change requires a documentation update

# How Has This Been Tested?
existing tests