### PR TITLE
Oneline bug fix

### DIFF
--- a/lineapy/db/db.py
+++ b/lineapy/db/db.py
@@ -290,10 +290,17 @@ class RelationalLineaDB:
         node_id: LineaID,
         variable_name: str,
     ) -> None:
-        self.session.add(
-            VariableNodeORM(id=node_id, variable_name=variable_name)
-        )
-        self.renew_session()
+        try:
+            self.session.add(
+                VariableNodeORM(id=node_id, variable_name=variable_name)
+            )
+            self.renew_session()
+        except Exception as e:
+            logger.info(
+                "%s has been defined at node %s before; most likely you have imported the library before.",
+                variable_name,
+                node_id,
+            )
 
     def write_artifact(self, artifact: Artifact) -> None:
         artifact_orm = ArtifactORM(

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import fsspec
+from fsspec.implementations.local import LocalFileSystem
 
 from lineapy.data.types import FilePath
 from lineapy.db.utils import create_lineadb_engine
@@ -171,7 +172,7 @@ class lineapy_config:
 
             if isinstance(self.__dict__[name], Path) or isinstance(
                 fsspec.core.url_to_fs(self.__dict__[name])[0],
-                fsspec.implementations.local.LocalFileSystem,
+                LocalFileSystem,
             ):
                 local_path = Path(self.__dict__[name]).resolve()
                 if not local_path.exists():


### PR DESCRIPTION
# Description

Two oneliner bug fixes were found during workshop/demo prep.

1. When running `import pandas as pd` twice, it will get an error because it tries to write to the table with the same records and break the unique (variable_name, node_id) constraint.
2. Sometimes we get an error related to no access to `fsspec.implementations.local.LocalFileSystem` when we configure s3 as the artifact storage backend. Since `fsspec.implementations.local.LocalFileSystem` is not public facing, need to import separately. 

Fixes # (issue)

Hotfix

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pass existing tests
