### PR TITLE
LIN-495 Fix logging and verbosity options

### DIFF
--- a/lineapy/_alembic/env.py
+++ b/lineapy/_alembic/env.py
@@ -1,5 +1,3 @@
-from logging.config import fileConfig
-
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
@@ -11,11 +9,6 @@ from lineapy.utils.config import options
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -94,11 +94,10 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--logging-level",
     type=click.Choice(
-        list(logging._nameToLevel.keys())
-        + sorted([str(x) for x in set(logging._levelToName.keys())]),
+        list(logging._nameToLevel.keys()),
         case_sensitive=False,
     ),
-    help="Logging level for LineaPy.",
+    help="Logging level for LineaPy, overrides the --verbose flag if set.",
 )
 @click.option(
     "--logging-file",
@@ -122,7 +121,9 @@ def linea_cli(
 
     # Set the logging env variable so its passed to subprocesses, like creating a jupyter kernel
     if verbose:
-        options.set("LINEAPY_LOG_LEVEL", "DEBUG")
+        options.set("logging_level", "DEBUG")
+    if logging_level:
+        options.set("logging_level", logging_level)
 
     configure_logging()
 


### PR DESCRIPTION
Summary:
This commit fixes the --verbose and --logging-level
options for lineapy.

Changes:
1. Fix verbose option by setting correct key in lineapy_config options.set
2. Fix logging level option by implementing logic to set logging level from provided parameter
3. Fix logging by disabling alembic logging override
4. Fix logging by moving off logging.basicConfig, which does not override previously set handler correctly
5. Remove support for logging-level to be set by numbers
6. Changed SQL logging level to match alembic.ini

Test Plan:
Run locally with
lineapy --verbose
lineapy --log-level CRITICAL
lineapy --log-level DEBUG