### PR TITLE
Lin 361 Missing lineapy import in IPython

### DIFF
--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -115,9 +115,10 @@ def input_transformer_post(
             db, SessionType.JUPYTER, STATE.session_name, ipython_globals
         )
 
-        # add statement so it is include
-        # d in artifact.get_code()
-        code = "import lineapy\n" + code
+        # add statement so it is
+        # included in artifact.get_code()
+        if "import lineapy\n" not in lines:
+            code = "import lineapy\n" + code
 
         STATE = CellsExecutedState(STATE.ipython, tracer, code=code)
     else:

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -117,7 +117,8 @@ def input_transformer_post(
 
         # add statement so it is
         # included in artifact.get_code()
-        code = "import lineapy\n" + code
+        if not "import lineapy\n" in lines:
+            code = "import lineapy\n" + code
 
         STATE = CellsExecutedState(STATE.ipython, tracer, code=code)
     else:

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -115,7 +115,8 @@ def input_transformer_post(
             db, SessionType.JUPYTER, STATE.session_name, ipython_globals
         )
 
-        # add statement so it is included in artifact.get_code()
+        # add statement so it is include
+        # d in artifact.get_code()
         code = "import lineapy\n" + code
 
         STATE = CellsExecutedState(STATE.ipython, tracer, code=code)

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -102,7 +102,7 @@ def input_transformer_post(
             "input_transformer_post shouldn't be called when we don't have an active tracer"
         )
     code = "".join(lines)
-    code = "import lineapy\n" + code
+
     # If we have just started, first start everything up
     if isinstance(STATE, StartedState):
         configure_logging()
@@ -114,6 +114,9 @@ def input_transformer_post(
         tracer = Tracer(
             db, SessionType.JUPYTER, STATE.session_name, ipython_globals
         )
+
+        # add statement so it is included in artifact.get_code()
+        code = "import lineapy\n" + code
 
         STATE = CellsExecutedState(STATE.ipython, tracer, code=code)
     else:

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -102,6 +102,7 @@ def input_transformer_post(
             "input_transformer_post shouldn't be called when we don't have an active tracer"
         )
     code = "".join(lines)
+    code = "import lineapy\n" + code
     # If we have just started, first start everything up
     if isinstance(STATE, StartedState):
         configure_logging()

--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -117,8 +117,7 @@ def input_transformer_post(
 
         # add statement so it is
         # included in artifact.get_code()
-        if "import lineapy\n" not in lines:
-            code = "import lineapy\n" + code
+        code = "import lineapy\n" + code
 
         STATE = CellsExecutedState(STATE.ipython, tracer, code=code)
     else:

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -132,11 +132,7 @@ res = lineapy.get("deferencedy")
 
     assert (
         run_cell("res.get_session_code()")
-        == importl
-        + importl
-        + code_body
-        + artifact_f_save
-        + "res.get_session_code()\n"
+        == importl + code_body + artifact_f_save + "res.get_session_code()\n"
     )
     assert (
         run_cell(

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -129,7 +129,6 @@ res = lineapy.get("deferencedy")
     assert run_cell(importl) is None
     assert run_cell(code_body) is None
     assert run_cell(artifact_f_save) is None
-
     assert (
         run_cell("res.get_session_code()")
         == importl + code_body + artifact_f_save + "res.get_session_code()\n"

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -132,12 +132,7 @@ res = lineapy.get("deferencedy")
 
     assert (
         run_cell("res.get_session_code()")
-        == importl
-        + code_body
-        + importl
-        + artifact_f_save
-        + importl
-        + "res.get_session_code()\n"
+        == importl + code_body + artifact_f_save + "res.get_session_code()\n"
     )
     assert (
         run_cell(

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -126,7 +126,7 @@ print(y)
     artifact_f_save = """lineapy.save(y, "deferencedy")
 res = lineapy.get("deferencedy")
 """
-    # assert run_cell(importl) is None
+    assert run_cell(importl) is None
     assert run_cell(code_body) is None
     assert run_cell(artifact_f_save) is None
 

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -132,7 +132,11 @@ res = lineapy.get("deferencedy")
 
     assert (
         run_cell("res.get_session_code()")
-        == importl + code_body + artifact_f_save + "res.get_session_code()\n"
+        == importl
+        + importl
+        + code_body
+        + artifact_f_save
+        + "res.get_session_code()\n"
     )
     assert (
         run_cell(

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -150,8 +150,12 @@ y = x +1
 art2 = lineapy.save(y,"anthertest")"""
     run_cell(code_body)
     out = run_cell("art2.get_code()")
-    print(out)
-    assert "import lineapy\n" in out
+    expected = """import lineapy
+
+x = lineapy.get("test").get_value()
+y = x + 1
+"""
+    assert expected == out
 
 
 @pytest.fixture

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -126,11 +126,12 @@ print(y)
     artifact_f_save = """lineapy.save(y, "deferencedy")
 res = lineapy.get("deferencedy")
 """
-    assert run_cell(importl) is None
+    # assert run_cell(importl) is None
     assert run_cell(code_body) is None
     assert run_cell(artifact_f_save) is None
+    out = run_cell("res.get_session_code()")
     assert (
-        run_cell("res.get_session_code()")
+        out
         == importl + code_body + artifact_f_save + "res.get_session_code()\n"
     )
     assert (
@@ -139,6 +140,18 @@ res = lineapy.get("deferencedy")
         )
         == "JUPYTER"
     )
+
+
+def test_lineapy_import_included_in_artifact(run_cell):
+    code_body = """x = 1
+art = lineapy.save(x,"test")
+x =lineapy.get("test").get_value()
+y = x +1
+art2 = lineapy.save(y,"anthertest")"""
+    run_cell(code_body)
+    out = run_cell("art2.get_code()")
+    print(out)
+    assert "import lineapy\n" in out
 
 
 @pytest.fixture

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -129,10 +129,15 @@ res = lineapy.get("deferencedy")
     # assert run_cell(importl) is None
     assert run_cell(code_body) is None
     assert run_cell(artifact_f_save) is None
-    out = run_cell("res.get_session_code()")
+
     assert (
-        out
-        == importl + code_body + artifact_f_save + "res.get_session_code()\n"
+        run_cell("res.get_session_code()")
+        == importl
+        + code_body
+        + importl
+        + artifact_f_save
+        + importl
+        + "res.get_session_code()\n"
     )
     assert (
         run_cell(


### PR DESCRIPTION
# Description

When using IPython, add `import lineapy` to the result of `artifact.get_code()` if the artifact contains a lineapy call.
Because lineapy is loaded as an extension when using ipython, `import lineapy` is not needed. However, the line still needs to be added into the code of an artifact so it does not break when the user attempts to re-executes the artifact in a non-IPython environment.

Fixes # (issue)
361

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`test_lineapy_import_included_in_artifact` added in `test_ipython.py`
