### PR TITLE
Parameter Refactoring﻿ Demo (DO NOT MERGE)

### DIFF
--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -6,6 +6,7 @@ from lineapy.api.api import (
     get,
     reload,
     save,
+    test_refactor,
     to_pipeline,
 )
 from lineapy.data.graph import Graph

--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -4,6 +4,8 @@ from lineapy.api.api import (
     artifact_store,
     delete,
     get,
+    get_function,
+    get_module_definition,
     reload,
     save,
     to_pipeline,

--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -6,7 +6,6 @@ from lineapy.api.api import (
     get,
     reload,
     save,
-    test_refactor,
     to_pipeline,
 )
 from lineapy.data.graph import Graph

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -19,6 +19,7 @@ from lineapy.db.utils import parse_artifact_version
 from lineapy.exceptions.db_exceptions import ArtifactSaveException
 from lineapy.exceptions.user_exception import UserException
 from lineapy.execution.context import get_context
+from lineapy.graph_reader.graph_refactorer import GraphRefactorer
 from lineapy.instrumentation.annotation_spec import ExternalState
 from lineapy.plugins.airflow import AirflowDagConfig, AirflowPlugin
 from lineapy.plugins.script import ScriptPlugin
@@ -385,3 +386,9 @@ def to_pipeline(
 
     else:
         raise Exception(f"No PipelineType for {framework}")
+
+
+def test_refactor(session_id):
+    execution_context = get_context()
+    db = execution_context.executor.db
+    return GraphRefactorer(db)._segment_session_graph_by_artifacts(session_id)

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -385,3 +385,24 @@ def to_pipeline(
 
     else:
         raise Exception(f"No PipelineType for {framework}")
+
+
+from typing import Callable
+
+from lineapy.graph_reader.graph_refactorer import SessionArtifacts
+
+
+def get_module_definition(artifact_list, input_parameters=[], **kwargs) -> str:
+    sas = SessionArtifacts(
+        [get(art_name) for art_name in artifact_list],
+        input_parameters=input_parameters,
+    )
+    return sas.get_session_module_definition(**kwargs)
+
+
+def get_function(artifact_list, input_parameters=[], **kwargs) -> Callable:
+    sas = SessionArtifacts(
+        [get(art_name) for art_name in artifact_list],
+        input_parameters=input_parameters,
+    )
+    return sas.get_session_module(**kwargs).pipeline

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -19,7 +19,6 @@ from lineapy.db.utils import parse_artifact_version
 from lineapy.exceptions.db_exceptions import ArtifactSaveException
 from lineapy.exceptions.user_exception import UserException
 from lineapy.execution.context import get_context
-from lineapy.graph_reader.graph_refactorer import GraphRefactorer
 from lineapy.instrumentation.annotation_spec import ExternalState
 from lineapy.plugins.airflow import AirflowDagConfig, AirflowPlugin
 from lineapy.plugins.script import ScriptPlugin
@@ -386,9 +385,3 @@ def to_pipeline(
 
     else:
         raise Exception(f"No PipelineType for {framework}")
-
-
-def test_refactor(session_id):
-    execution_context = get_context()
-    db = execution_context.executor.db
-    return GraphRefactorer(db)._segment_session_graph_by_artifacts(session_id)

--- a/lineapy/data/graph.py
+++ b/lineapy/data/graph.py
@@ -34,6 +34,7 @@ class Graph(object):
                 (parent_id, node.id)
                 for node in nodes
                 for parent_id in node.parents()
+                if parent_id in set(self.ids.keys())
             ]
         )
 

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -139,11 +139,12 @@ class SessionArtifacts:
         Traverse every node within the session in topologically sorted order and update
         node_context with following informations
 
-        assigned_variables : some variables are assigned at this node
+        assigned_variables : variables assigned at this node
         assigned_artifact : this node is pointing to some artifact
         predecessors : predecessors of the node
         dependent_variables : union of if any variable is assigned at predecessor node,
             use the assigned variables; otherwise, use the dependent_variables
+        tracked_variables : variables that this node is point to
         """
 
         # Map each variable node ID to the corresponding variable name(when variable assigned)
@@ -184,8 +185,8 @@ class SessionArtifacts:
                     dep
                 )
 
+            # Edit me when you see return variables in refactor behaves strange
             node = self.graph.get_node(node_id=node_id)
-
             if len(self.node_context[node_id]["assigned_variables"]) > 0:
                 self.node_context[node_id][
                     "tracked_variables"
@@ -228,7 +229,8 @@ class SessionArtifacts:
                         "tracked_variables"
                     ]
                 elif (
-                    node.positional_args[0].id
+                    len(node.positional_args) > 0
+                    and node.positional_args[0].id
                     in self.node_context[node_id]["predecessors"]
                 ):
                     self.node_context[node_id][

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -3,9 +3,11 @@ import logging
 import string
 from collections import OrderedDict
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, Set, Tuple, Union
 
 import networkx as nx
+from sqlalchemy import over
 
 from lineapy.api.api import get
 from lineapy.api.api_classes import LineaArtifact
@@ -22,20 +24,27 @@ logger = logging.getLogger(__name__)
 configure_logging()
 
 
-function_definition_template = string.Template(
-    """def get_${aname}(${args_string}):
-${artifact_codeblock}
-${indentation_block}return ${return_string}
-"""
-)
+class GraphSegmentType(Enum):
+    """
+    GraphSegment type to identify the purpose of the graph segment
+    - ARTIFACT : the segment returns an artifact
+    - HELPER : the segment returns variables used in multiple artifacts
+    """
+
+    ARTIFACT = 1
+    COMMON_VARIABLE = 2
 
 
 @dataclass
 class GraphSegment:
-    """This"""
+    """
+    This class contains information required to wrap a lineapy Graph object as a function
+    """
 
     artifact_name: str
+    artifact_safename: str
     graph_segment: Graph
+    segment_type: GraphSegmentType
     all_variables: Set[str]
     input_variables: Set[str]
     return_variables: List[str]
@@ -49,6 +58,7 @@ class GraphSegment:
         return_variables,
     ) -> None:
         self.artifact_name = artifact_name
+        self.artifact_safename = artifact_name  # Fix me
         self.graph_segment = graph_segment
         self.all_variables = all_variables
         self.input_variables = input_variables
@@ -66,26 +76,20 @@ class GraphSegment:
             ]
         )
 
+        function_definition_template = string.Template(
+            """def get_${aname}(${args_string}):
+${artifact_codeblock}
+${indentation_block}return ${return_string}
+"""
+        )
+
         return function_definition_template.safe_substitute(
-            aname=self.artifact_name,
+            aname=self.artifact_safename,
             args_string=", ".join([v for v in self.input_variables]),
             artifact_codeblock=artifact_codeblock,
             indentation_block=indentation_block,
             return_string=", ".join([v for v in self.return_variables]),
         )
-
-
-session_module_definitaion_template = string.Template(
-    """${function_definitions}
-
-def pipeline():
-${calculation_codeblock}
-${indentation_block}return ${return_string}
-
-if __name__=='__main__':
-${indentation_block}pipeline()
-"""
-)
 
 
 @dataclass
@@ -96,11 +100,13 @@ class SessionArtifacts:
 
     session_id: LineaID
     graph: Graph
-    session_variables: List[str]
     db: RelationalLineaDB
     nx_graph: nx.DiGraph
     graph_segments: List[GraphSegment]
     artifact_list: List[LineaArtifact]
+    artifact_ordering: List
+    artifact_dict: OrderedDict[LineaID, str]
+    variable_dict: OrderedDict[LineaID, Set[str]]
     node_context: Dict[LineaID, Dict[str, Any]]
 
     def __init__(self, artifacts: List[LineaArtifact]) -> None:
@@ -116,35 +122,35 @@ class SessionArtifacts:
         self._slice_session_artifacts()
 
     def _resolve_dependencies(self):
+
         # Map each variable node ID to the corresponding variable name(when variable assigned)
-        self.session_variables = self.db.get_variables_for_session(
+        self.variable_dict = OrderedDict()
+        for node_id, variable_name in self.db.get_variables_for_session(
             self.session_id
-        )
-        variable_dict: Dict[LineaID, Set[str]] = dict()
-        for node_id, variable_name in self.session_variables:
-            variable_dict[node_id] = (
+        ):
+            self.variable_dict[node_id] = (
                 set([variable_name])
-                if node_id not in variable_dict.keys()
-                else variable_dict[node_id].union(set([variable_name]))
+                if node_id not in self.variable_dict.keys()
+                else self.variable_dict[node_id].union(set([variable_name]))
             )
 
         # Map each artifact node ID to the corresponding artifact name
-        session_artifacts = self.db.get_artifacts_for_session(self.session_id)
-        artifact_dict = {
-            artifact.node_id: artifact.name for artifact in session_artifacts
+        self.artifact_dict = {
+            artifact.node_id: artifact.name
+            for artifact in self.db.get_artifacts_for_session(self.session_id)
         }
 
         # Identify variable dependencies of each node in topological order
         for node_id in nx.topological_sort(self.nx_graph):
-            predecessors = self.nx_graph.predecessors(node_id)
             self.node_context[node_id] = {
-                "assigned_variables": variable_dict.get(node_id, set()),
-                "assigned_artifact": artifact_dict.get(node_id, None),
+                "assigned_variables": self.variable_dict.get(node_id, set()),
+                "assigned_artifact": self.artifact_dict.get(node_id, None),
                 "dependent_variables": set(),
+                "predecessors": set(self.nx_graph.predecessors(node_id)),
             }
-            for p_node_id in predecessors:
-                # If predecessor is variable assignment use the variable, else use its dependencies
-                dep = variable_dict.get(
+            for p_node_id in self.node_context[node_id]["predecessors"]:
+                # If predecessor is variable assignment use the variable; otherwise, use its dependencies.
+                dep = self.variable_dict.get(
                     p_node_id,
                     self.node_context[p_node_id]["dependent_variables"],
                 )
@@ -154,15 +160,72 @@ class SessionArtifacts:
                     dep
                 )
 
+    def _get_subgraph_from_node_list(self, node_list: List[LineaID]) -> Graph:
+        return self.graph.get_subgraph(
+            [self.graph.get_node(node_id) for node_id in node_list]
+        )
+
+    def _get_involved_variables_from_node_list(
+        self, node_list
+    ) -> Dict[str, Set[str]]:
+
+        involved_variables = dict()
+        involved_variables["dependent_variables"] = set(
+            itertools.chain.from_iterable(
+                [
+                    self.node_context[nid]["dependent_variables"]
+                    for nid in node_list
+                ]
+            )
+        )
+        # variables got assigned within these nodes
+        involved_variables["assigned_variables"] = set(
+            itertools.chain.from_iterable(
+                [
+                    self.node_context[nid]["assigned_variables"]
+                    for nid in node_list
+                ]
+            )
+        )
+        # all variables within these nodes
+        involved_variables["all_variables"] = involved_variables[
+            "dependent_variables"
+        ].union(involved_variables["assigned_variables"])
+        # required input variables
+        involved_variables["input_variables"] = (
+            involved_variables["all_variables"]
+            - involved_variables["assigned_variables"]
+        )
+
+        return involved_variables
+
+    def _get_graph_segment_from_artifact_context(
+        self, artifact_context
+    ) -> GraphSegment:
+        subgraph = self._get_subgraph_from_node_list(
+            artifact_context["node_list"]
+        )
+        involved_variables = self._get_involved_variables_from_node_list(
+            artifact_context["node_list"]
+        )
+        return GraphSegment(
+            artifact_name=artifact_context["artifact_name"],
+            graph_segment=subgraph,
+            all_variables=involved_variables["all_variables"],
+            input_variables=involved_variables["input_variables"],
+            return_variables=artifact_context["return_variables"],
+        )
+
     def _slice_session_artifacts(self) -> None:
-        # Identify artifact nodes and topologically sort them
         used_node_ids: Set[LineaID] = set()  # Track nodes that get ever used
-        artifact_ordering = OrderedDict()
+        self.artifact_ordering = list()
         for node_id, n in self.node_context.items():
             if n["assigned_artifact"] is not None and node_id in [
                 art._node_id for art in self.artifact_list
             ]:
-                artifact_ordering[node_id] = {
+                artifact_context = {
+                    "node_id": node_id,
+                    "artifact_type": GraphSegmentType.ARTIFACT,
                     "artifact_name": n["assigned_artifact"],
                     "return_variables": list(
                         n["assigned_variables"]
@@ -171,92 +234,550 @@ class SessionArtifacts:
                     ),
                 }
 
-                # Identify "non-overlapping" nodes that solely belong to the artifact
-                artifact_slice_graph = get_slice_graph(self.graph, [node_id])
-                artifact_node_ids = (
-                    set(artifact_slice_graph.nx_graph.nodes) - used_node_ids
+                artifact_sliced_node_list = set(
+                    get_slice_graph(self.graph, [node_id]).nx_graph.nodes
                 )
-                artifact_nodes = [
-                    self.graph.get_node(node_id)
-                    for node_id in artifact_node_ids
-                ]
-                artifact_ordering[node_id][
-                    "nonoverlapping_graph"
-                ] = self.graph.get_subgraph(
-                    [n for n in artifact_nodes if n is not None]
+
+                artifact_context["node_list"] = (
+                    set(get_slice_graph(self.graph, [node_id]).nx_graph.nodes)
+                    - used_node_ids
                 )
 
                 # Update used nodes for next iteration
-                used_node_ids = used_node_ids.union(artifact_node_ids)
+                used_node_ids = used_node_ids.union(
+                    artifact_context["node_list"]
+                )
 
-                # Calculate the artifact's variable relations
-                # dependent variables for all these nodes
-                dependent_variables = set(
+                artifact_context = {
+                    **artifact_context,
+                    **self._get_involved_variables_from_node_list(
+                        artifact_context["node_list"]
+                    ),
+                }
+
+                for n_id in artifact_context["node_list"]:
+                    self.node_context[n_id]["artifact_name"] = n[
+                        "assigned_artifact"
+                    ]
+
+                artifact_context["predecessor_nodes"] = set(
                     itertools.chain.from_iterable(
                         [
-                            self.node_context[nid]["dependent_variables"]
-                            for nid in artifact_node_ids
+                            self.node_context[n_id]["predecessors"]
+                            for n_id in artifact_context["node_list"]
                         ]
                     )
-                )
-                # variables got assigned within these nodes
-                assigned_variables = set(
-                    itertools.chain.from_iterable(
-                        [
-                            self.node_context[nid]["assigned_variables"]
-                            for nid in artifact_node_ids
-                        ]
-                    )
-                )
-                # all variables within these nodes
-                artifact_ordering[node_id][
-                    "all_variables"
-                ] = dependent_variables.union(assigned_variables)
-                # required input variables
-                artifact_ordering[node_id]["input_variables"] = (
-                    artifact_ordering[node_id]["all_variables"]
-                    - assigned_variables
+                ) - set(artifact_context["node_list"])
+
+                artifact_context["predecessor_artifact"] = set(
+                    [
+                        self.node_context[n_id]["artifact_name"]
+                        for n_id in artifact_context["predecessor_nodes"]
+                    ]
                 )
 
-                self.graph_segments.append(
-                    GraphSegment(
-                        artifact_name=artifact_ordering[node_id][
-                            "artifact_name"
-                        ],
-                        graph_segment=artifact_ordering[node_id][
-                            "nonoverlapping_graph"
-                        ],
-                        all_variables=artifact_ordering[node_id][
-                            "all_variables"
-                        ],
-                        input_variables=artifact_ordering[node_id][
-                            "input_variables"
-                        ],
-                        return_variables=artifact_ordering[node_id][
-                            "return_variables"
-                        ],
-                    )
-                )
+                artifact_context["input_variable_sources"] = dict()
 
-        # Add extra return variables that are used for downstream artifacts to each artifact
-        for i, graph_segment in enumerate(self.graph_segments):
-            for p, prev_graph_segment in enumerate(self.graph_segments):
-                if p < i:
-                    variables_required_downstream = (
-                        graph_segment.input_variables.intersection(
-                            prev_graph_segment.all_variables
-                        )
-                    )
-                    if len(variables_required_downstream) > 0:
-                        prev_graph_segment.return_variables += sorted(
-                            [
-                                x
-                                for x in variables_required_downstream
-                                if x not in prev_graph_segment.return_variables
+                for pred_node_id in artifact_context["predecessor_nodes"]:
+                    predecessor_variables = (
+                        self.node_context[pred_node_id]["assigned_variables"]
+                        if len(
+                            self.node_context[pred_node_id][
+                                "assigned_variables"
                             ]
                         )
+                        > 0
+                        else self.node_context[pred_node_id][
+                            "dependent_variables"
+                        ]
+                    )
+                    predecessor_artifact = self.node_context[pred_node_id][
+                        "artifact_name"
+                    ]
+                    artifact_context["input_variable_sources"][
+                        predecessor_artifact
+                    ] = (
+                        artifact_context["input_variable_sources"]
+                        .get(predecessor_artifact, set())
+                        .union(predecessor_variables)
+                    )
 
-    def get_session_module_definition(self, indentation=4) -> str:
+                for source_artifact_name, variables in artifact_context[
+                    "input_variable_sources"
+                ].items():
+                    source_artifact_context_index, source_artifact_context = [
+                        (i, context)
+                        for i, context in enumerate(self.artifact_ordering)
+                        if context["artifact_name"] == source_artifact_name
+                    ][0]
+                    print(
+                        source_artifact_context_index,
+                        len(self.artifact_ordering),
+                    )
+
+                    common_return_variables = set(
+                        source_artifact_context["return_variables"]
+                    ).intersection(
+                        artifact_context["input_variable_sources"][
+                            source_artifact_context["artifact_name"]
+                        ]
+                    )
+
+                    common_inner_variables = (
+                        source_artifact_context["all_variables"]
+                        - set(source_artifact_context["return_variables"])
+                    ).intersection(
+                        artifact_context["input_variable_sources"][
+                            source_artifact_context["artifact_name"]
+                        ]
+                    )
+                    if len(common_inner_variables) > 0:
+
+                        source_art_graph = self._get_subgraph_from_node_list(
+                            source_artifact_context["node_list"]
+                        )
+                        source_art_slice_variable_graph = get_slice_graph(
+                            source_art_graph,
+                            [
+                                n
+                                for n in artifact_context["predecessor_nodes"]
+                                if n in source_art_graph.nx_graph.nodes
+                            ],
+                        )
+                        common_nodes = artifact_sliced_node_list.intersection(
+                            set(source_art_slice_variable_graph.nx_graph.nodes)
+                        )
+
+                        if len(common_nodes) > 0:
+                            common_artifact_variables = (
+                                self._get_involved_variables_from_node_list(
+                                    common_nodes
+                                )
+                            )
+                            common_artifact_context = {
+                                "artifact_name": f"{'_'.join(common_inner_variables)}_for_{artifact_context['artifact_name']}",
+                                "artifact_type": GraphSegmentType.COMMON_VARIABLE,
+                                "node_list": common_nodes,
+                                "input_variables": common_artifact_variables[
+                                    "input_variables"
+                                ],
+                                "all_variables": common_artifact_variables[
+                                    "all_variables"
+                                ],
+                                "return_variables": list(
+                                    common_inner_variables
+                                ),
+                            }
+
+                            remaining_nodes = source_artifact_context[
+                                "node_list"
+                            ].difference(common_nodes)
+                            remaining_artifact_variables = (
+                                self._get_involved_variables_from_node_list(
+                                    remaining_nodes
+                                )
+                            )
+                            remaining_artifact_context = {
+                                "artifact_name": source_artifact_context[
+                                    "artifact_name"
+                                ],
+                                "artifact_type": GraphSegmentType.ARTIFACT,
+                                "node_list": remaining_nodes,
+                                "input_variables": remaining_artifact_variables[
+                                    "input_variables"
+                                ],
+                                "all_variables": remaining_artifact_variables[
+                                    "all_variables"
+                                ],
+                                "return_variables": source_artifact_context[
+                                    "return_variables"
+                                ],
+                            }
+
+                            self.artifact_ordering = (
+                                self.artifact_ordering[
+                                    :source_artifact_context_index
+                                ]
+                                + [
+                                    common_artifact_context,
+                                    remaining_artifact_context,
+                                ]
+                                + self.artifact_ordering[
+                                    (source_artifact_context_index + 1) :
+                                ]
+                            )
+
+                self.artifact_ordering.append(artifact_context)
+
+        self.graph_segments = [
+            self._get_graph_segment_from_artifact_context(artifact_context)
+            for artifact_context in self.artifact_ordering
+        ]
+
+        # for prev_art in self.artifact_ordering:
+        #     if (
+        #         prev_art["artifact_name"]
+        #         in artifact_context["input_variable_sources"].keys()
+        #     ):
+        #         return_variables_intersection = set(
+        #             prev_art["return_variables"]
+        #         ).intersection(
+        #             artifact_context["input_variable_sources"][
+        #                 prev_art["artifact_name"]
+        #             ]
+        #         )
+
+        #         if len(return_variables_intersection) > 0:
+        #             print(
+        #                 artifact_context["artifact_name"],
+        #                 "is taking",
+        #                 return_variables_intersection,
+        #                 "from return of ",
+        #                 prev_art["artifact_name"],
+        #             )
+
+        #         inner_variables_intersection = (
+        #             prev_art["all_variables"]
+        #             - set(prev_art["return_variables"])
+        #         ).intersection(
+        #             artifact_context["input_variable_sources"][
+        #                 prev_art["artifact_name"]
+        #             ]
+        #         )
+
+        #         if len(inner_variables_intersection) > 0:
+        #             print(
+        #                 artifact_context["artifact_name"],
+        #                 "is taking",
+        #                 inner_variables_intersection,
+        #                 "from inside of ",
+        #                 prev_art["artifact_name"],
+        #             )
+
+        #             # print("prev artifact nodes", prev_art["node_list"])
+        #             prev_art_graph = self._get_subgraph_from_node_list(
+        #                 prev_art["node_list"]
+        #             )
+        #             prev_art_slice_variable_graph = get_slice_graph(
+        #                 prev_art_graph,
+        #                 [
+        #                     n
+        #                     for n in artifact_context[
+        #                         "predecessor_nodes"
+        #                     ]
+        #                     if n in prev_art_graph.nx_graph.nodes
+        #                 ],
+        #             )
+        #             intersection_nodes = artifact_sliced_node_list.intersection(
+        #                 set(
+        #                     prev_art_slice_variable_graph.nx_graph.nodes
+        #                 )
+        #             )
+
+        #             print("common code")
+        #             print(
+        #                 get_source_code_from_graph(
+        #                     self.graph.get_subgraph(
+        #                         [
+        #                             self.graph.get_node(node_id)
+        #                             for node_id in intersection_nodes
+        #                         ]
+        #                     )
+        #                 )
+        #             )
+        #             print("remaining code")
+        #             print(
+        #                 get_source_code_from_graph(
+        #                     self.graph.get_subgraph(
+        #                         [
+        #                             self.graph.get_node(node_id)
+        #                             for node_id in artifact_context[
+        #                                 "node_list"
+        #                             ]
+        #                             if node_id
+        #                             not in intersection_nodes
+        #                         ]
+        #                     )
+        #                 )
+        #             )
+
+        # gsegment = self._get_graph_segment_from_artifact_context(
+        #     artifact_context
+        # )
+
+        # input_variables = set(artifact_context["input_variables"])
+        # while len(input_variables) > 0 and segment_counter <= len(
+        #     self.artifact_ordering
+        # ):
+        #     segment = self.artifact_ordering[-segment_counter]
+        #     return_variables_intersection = set(
+        #         segment["return_variables"]
+        #     ).intersection(input_variables)
+        #     if len(return_variables_intersection) > 0:
+        #         print(
+        #             artifact_context["artifact_name"],
+        #             input_variables,
+        #             "intersect with return variables of",
+        #             segment["artifact_name"],
+        #             segment["return_variables"],
+        #         )
+        #         input_variables -= return_variables_intersection
+        #     all_variables_intersection = (
+        #         segment["all_variables"]
+        #         - set(segment["return_variables"])
+        #     ).intersection(input_variables)
+        #     if len(all_variables_intersection) > 0:
+        #         print(
+        #             artifact_context["artifact_name"],
+        #             input_variables,
+        #             "intersect with inner variables of",
+        #             segment["artifact_name"],
+        #             segment["all_variables"]
+        #             - set(segment["return_variables"]),
+        #         )
+
+        #         intersect_nodes = segment["node_list"].intersection(
+        #             artifact_sliced_node_list
+        #         )
+        #         print("common nodes", intersect_nodes)
+        #         print("common code")
+        #         print(
+        #             get_source_code_from_graph(
+        #                 self.graph.get_subgraph(
+        #                     [
+        #                         self.graph.get_node(node_id)
+        #                         for node_id in intersect_nodes
+        #                     ]
+        #                 )
+        #             )
+        #         )
+
+        #         input_variables -= all_variables_intersection
+        #     segment_counter += 1
+
+        # artifact_nodes = [
+        #     self.graph.get_node(node_id)
+        #     for node_id in artifact_context["node_list"]
+        # ]
+        # artifact_context[
+        #     "nonoverlapping_graph"
+        # ] = self.graph.get_subgraph(
+        #     [n for n in artifact_nodes if n is not None]
+        # )
+
+    #     def _slice_session_artifacts(self) -> None:
+    #         # Identify artifact nodes and topologically sort them
+    #         used_node_ids: Set[LineaID] = set()  # Track nodes that get ever used
+    #         artifact_ordering = OrderedDict()
+    #         for node_id, n in self.node_context.items():
+    #             if n["assigned_artifact"] is not None and node_id in [
+    #                 art._node_id for art in self.artifact_list
+    #             ]:
+    #                 artifact_ordering[node_id] = {
+    #                     "artifact_name": n["assigned_artifact"],
+    #                     "return_variables": list(
+    #                         n["assigned_variables"]
+    #                         if len(n["assigned_variables"]) > 0
+    #                         else n["dependent_variables"]
+    #                     ),
+    #                 }
+
+    #                 # Identify "non-overlapping" nodes that solely belong to the artifact
+    #                 artifact_node_ids = (
+    #                     set(get_slice_graph(self.graph, [node_id]).nx_graph.nodes)
+    #                     - used_node_ids
+    #                 )
+    #                 artifact_nodes = [
+    #                     self.graph.get_node(node_id)
+    #                     for node_id in artifact_node_ids
+    #                 ]
+    #                 for n_id in artifact_node_ids:
+    #                     self.node_context[n_id]["artifact_name"] = n[
+    #                         "assigned_artifact"
+    #                     ]
+
+    #                 artifact_ordering[node_id][
+    #                     "nonoverlapping_graph"
+    #                 ] = self.graph.get_subgraph(
+    #                     [n for n in artifact_nodes if n is not None]
+    #                 )
+
+    #                 # Update used nodes for next iteration
+    #                 used_node_ids = used_node_ids.union(artifact_node_ids)
+
+    #                 # Calculate the artifact's variable relations
+    #                 # dependent variables for all these nodes
+    #                 dependent_variables = set(
+    #                     itertools.chain.from_iterable(
+    #                         [
+    #                             self.node_context[nid]["dependent_variables"]
+    #                             for nid in artifact_node_ids
+    #                         ]
+    #                     )
+    #                 )
+    #                 # variables got assigned within these nodes
+    #                 assigned_variables = set(
+    #                     itertools.chain.from_iterable(
+    #                         [
+    #                             self.node_context[nid]["assigned_variables"]
+    #                             for nid in artifact_node_ids
+    #                         ]
+    #                     )
+    #                 )
+    #                 # all variables within these nodes
+    #                 artifact_ordering[node_id][
+    #                     "all_variables"
+    #                 ] = dependent_variables.union(assigned_variables)
+    #                 # required input variables
+    #                 artifact_ordering[node_id]["input_variables"] = (
+    #                     artifact_ordering[node_id]["all_variables"]
+    #                     - assigned_variables
+    #                 )
+
+    #                 self.graph_segments.append(
+    #                     GraphSegment(
+    #                         artifact_name=artifact_ordering[node_id][
+    #                             "artifact_name"
+    #                         ],
+    #                         graph_segment=artifact_ordering[node_id][
+    #                             "nonoverlapping_graph"
+    #                         ],
+    #                         all_variables=artifact_ordering[node_id][
+    #                             "all_variables"
+    #                         ],
+    #                         input_variables=artifact_ordering[node_id][
+    #                             "input_variables"
+    #                         ],
+    #                         return_variables=artifact_ordering[node_id][
+    #                             "return_variables"
+    #                         ],
+    #                     )
+    #                 )
+
+    #         # Add extra return variables that are used for downstream artifacts to each artifact
+    #         for i, graph_segment in enumerate(self.graph_segments):
+    #             for p, prev_graph_segment in enumerate(self.graph_segments):
+    #                 if p < i:
+    #                     variables_required_downstream = (
+    #                         graph_segment.input_variables.intersection(
+    #                             prev_graph_segment.all_variables
+    #                         )
+    #                     )
+    #                     if len(variables_required_downstream) > 0:
+    #                         prev_graph_segment.return_variables += sorted(
+    #                             [
+    #                                 x
+    #                                 for x in variables_required_downstream
+    #                                 if x not in prev_graph_segment.return_variables
+    #                             ]
+    #                         )
+
+    #         # # Add extra return variables that are used for downstream artifacts to each artifact
+    #         # for i, graph_segment in enumerate(self.graph_segments):
+    #         #     for p, prev_graph_segment in enumerate(self.graph_segments):
+    #         #         if p < i:
+    #         #             extra_variables_to_return = (
+    #         #                 graph_segment.input_variables.intersection(
+    #         #                     prev_graph_segment.all_variables
+    #         #                 )
+    #         #                 - set(prev_graph_segment.return_variables)
+    #         #             )
+
+    #         #             if len(extra_variables_to_return) > 0:
+
+    #         # for i, graph_segment in enumerate(self.graph_segments):
+    #         #     for p, prev_graph_segment in reversed(
+    #         #         list(enumerate(self.graph_segments))
+    #         #     ):
+    #         #         if p < i and any(
+    #         #             [
+    #         #                 v in prev_graph_segment.return_variables[1:]
+    #         #                 for v in graph_segment.input_variables
+    #         #             ]
+    #         #         ):
+    #         #             common_variables = (
+    #         #                 graph_segment.input_variables.intersection(
+    #         #                     set(prev_graph_segment.return_variables)
+    #         #                 )
+    #         #             )
+
+    #         #             common_nodes = list(
+    #         #                 nx.intersection_all(
+    #         #                     [
+    #         #                         prev_graph_segment.graph_segment.nx_graph,
+    #         #                         get_slice_graph(
+    #         #                             self.graph,
+    #         #                             list(
+    #         #                                 graph_segment.graph_segment.nx_graph.nodes
+    #         #                             ),
+    #         #                         ).nx_graph,
+    #         #                     ]
+    #         #                 ).nodes
+    #         #             )
+
+    #         #             prev_artifact_id = [
+    #         #                 art._node_id
+    #         #                 for art in self.artifact_list
+    #         #                 if art.name == prev_graph_segment.artifact_name
+    #         #             ]
+
+    #         #             # Check whether common nodes include the previous artifact node (if yes, no refactor possible)6
+    #         #             if (
+    #         #                 len(prev_artifact_id) > 0
+    #         #                 and prev_artifact_id[0] not in common_nodes
+    #         #             ) and len(common_nodes) > 0:
+
+    #         #                 print(
+    #         #                     graph_segment.artifact_name,
+    #         #                     graph_segment.input_variables,
+    #         #                     "need to extract",
+    #         #                     common_variables,
+    #         #                     "from",
+    #         #                     prev_graph_segment.artifact_name,
+    #         #                     prev_graph_segment.return_variables,
+    #         #                 )
+
+    #         #                 print("prev graph segment code")
+    #         #                 print(
+    #         #                     get_source_code_from_graph(
+    #         #                         prev_graph_segment.graph_segment
+    #         #                     )
+    #         #                 )
+
+    #         #                 common_graph = self.graph.get_subgraph(
+    #         #                     [
+    #         #                         self.graph.get_node(nodeid)
+    #         #                         for nodeid in common_nodes
+    #         #                     ]
+    #         #                 )
+
+    #         #                 print(
+    #         #                     set(common_nodes)
+    #         #                     - set(
+    #         #                         prev_graph_segment.graph_segment.nx_graph.nodes
+    #         #                     )
+    #         #                 )
+
+    #         #                 print(
+    #         #                     set(common_graph.nx_graph.nodes)
+    #         #                     - set(
+    #         #                         prev_graph_segment.graph_segment.nx_graph.nodes
+    #         #                     )
+    #         #                 )
+
+    #         #                 common_code = get_source_code_from_graph(common_graph)
+
+    #         #                 print("common code")
+    #         #                 print(common_code)
+    #         #                 print("-" * 80)
+
+    def get_session_module_definition(
+        self, indentation: int = 4, keep_lineapy_save: bool = False
+    ) -> str:
+        """
+        Generate pipeline at session level
+        """
+
         indentation_block = " " * indentation
 
         function_definitions = "\n".join(
@@ -268,6 +789,9 @@ class SessionArtifacts:
         calculation_codeblock = "\n".join(
             [
                 f"{indentation_block}{', '.join(graph_seg.return_variables)} = get_{graph_seg.artifact_name}({','.join(graph_seg.input_variables)})"
+                if not keep_lineapy_save
+                else f"""{indentation_block}{', '.join(graph_seg.return_variables)} = get_{graph_seg.artifact_name}({','.join(graph_seg.input_variables)})
+{indentation_block}lineapy.save({graph_seg.return_variables[0]}, '{graph_seg.artifact_name}')"""
                 for graph_seg in self.graph_segments
             ]
         )
@@ -276,6 +800,18 @@ class SessionArtifacts:
                 graph_seg.return_variables[0]
                 for graph_seg in self.graph_segments
             ]
+        )
+
+        session_module_definitaion_template = string.Template(
+            """${function_definitions}
+
+def pipeline():
+${calculation_codeblock}
+${indentation_block}return ${return_string}
+
+if __name__=='__main__':
+${indentation_block}pipeline()
+"""
         )
 
         return session_module_definitaion_template.safe_substitute(

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -281,6 +281,7 @@ class SessionArtifacts:
                     "node_id": node_id,
                     "artifact_type": GraphSegmentType.ARTIFACT,
                     "artifact_name": n["assigned_artifact"],
+                    "tracked_variables": n["assigned_variables"],
                     "return_variables": list(
                         n["assigned_variables"]
                         if len(n["assigned_variables"]) > 0
@@ -382,7 +383,6 @@ class SessionArtifacts:
                         ]
                     )
                     if len(common_inner_variables) > 0:
-
                         source_art_graph = self._get_subgraph_from_node_list(
                             source_artifact_context["node_list"]
                         )
@@ -392,6 +392,8 @@ class SessionArtifacts:
                                 n
                                 for n in artifact_context["predecessor_nodes"]
                                 if n in source_art_graph.nx_graph.nodes
+                                and self.node_context[n]["assigned_artifact"]
+                                != self.node_context[n]["artifact_name"]
                             ],
                         )
                         common_nodes = artifact_sliced_node_list.intersection(

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -114,7 +114,7 @@ class SessionArtifacts:
     artifact_list: List[LineaArtifact]
     artifact_ordering: List
     artifact_dict: Dict[LineaID, Optional[str]]
-    variable_dict: OrderedDict[LineaID, Set]
+    variable_dict: Dict[LineaID, Set[str]]
     node_context: Dict[LineaID, Dict[str, Any]]
 
     def __init__(self, artifacts: List[LineaArtifact]) -> None:

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -3,13 +3,13 @@ import logging
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 import networkx as nx
 
 from lineapy.api.api_classes import LineaArtifact
 from lineapy.data.graph import Graph
-from lineapy.data.types import LineaID
+from lineapy.data.types import LineaID, Node
 from lineapy.db.db import RelationalLineaDB
 from lineapy.graph_reader.program_slice import (
     get_slice_graph,
@@ -112,7 +112,7 @@ class SessionArtifacts:
     graph_segments: List[GraphSegment]
     artifact_list: List[LineaArtifact]
     artifact_ordering: List
-    artifact_dict: OrderedDict[LineaID, str]
+    artifact_dict: Dict[LineaID, Optional[str]]
     variable_dict: OrderedDict[LineaID, Set[str]]
     node_context: Dict[LineaID, Dict[str, Any]]
 
@@ -182,9 +182,14 @@ class SessionArtifacts:
         Return the subgraph from list of node id
         """
 
-        return self.graph.get_subgraph(
-            [self.graph.get_node(node_id) for node_id in node_list]
-        )
+        # Fix me, ugly code to satisfy type checking
+        nodes: List[Node] = []
+        for node_id in node_list:
+            node = self.graph.get_node(node_id)
+            if node is not None:
+                nodes.append(node)
+
+        return self.graph.get_subgraph(nodes)
 
     def _get_involved_variables_from_node_list(
         self, node_list

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -702,7 +702,7 @@ class SessionArtifacts:
             return_variables=[],
         )
 
-        print(self.input_parameters_node)
+        # print(self.input_parameters_node)
         self.input_parameters_segment = GraphSegment(
             artifact_name="",
             graph_segment=self._get_subgraph_from_node_list(
@@ -790,3 +790,22 @@ if __name__=="__main__":
 """
 
         return module_definition_string
+
+    def get_session_module(self, keep_lineapy_save: bool = False):
+        import importlib.util
+        import sys
+
+        module_name = f"session_{self.session_id.replace('-','_')}"
+        with open(f"/tmp/{module_name}.py", "w") as f:
+            f.writelines(
+                self.get_session_module_definition(
+                    keep_lineapy_save=keep_lineapy_save
+                )
+            )
+        spec = importlib.util.spec_from_file_location(
+            module_name, f"/tmp/{module_name}.py"
+        )
+        session_module = importlib.util.module_from_spec(spec)
+        sys.modules["module.name"] = session_module
+        spec.loader.exec_module(session_module)
+        return session_module

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -1,7 +1,8 @@
 import itertools
 import string
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
+from typing import Set
 
 import networkx as nx
 
@@ -12,6 +13,16 @@ from lineapy.graph_reader.program_slice import (
     get_slice_graph,
     get_source_code_from_graph,
 )
+
+
+@dataclass
+class GraphSegment:
+    graph_segment: Graph
+    dependent_variables: Set[str]
+    created_variables: Set[str]
+    related_variables: Set[str]
+    required_variables: Set[str]
+    return_variables: Set[str]
 
 
 @dataclass
@@ -43,7 +54,7 @@ class GraphRefactorer:
 
         # Identify variable dependencies of each node in topological order
         node_dependency = dict()
-        for node_id in nx.topological_sort(full_graph.nx_graph):
+        for node_id in nx.topological_sort(full_nxgraph):
             predecessors = full_nxgraph.predecessors(node_id)
             node_dependency[node_id] = set()
             for p_node_id in predecessors:
@@ -51,67 +62,68 @@ class GraphRefactorer:
                 node_dependency[node_id] = node_dependency[node_id].union(dep)
 
         # Identify artifact nodes and topologically sort them
-        artifact_ordering = [
-            (artifact_dict[node_id], node_id)
+        artifact_ids_sorted = [
+            node_id
             for node_id in nx.topological_sort(full_nxgraph)
-            if artifact_dict.get(node_id) is not None
+            if node_id in artifact_dict
         ]
 
-        used_nodes = set()  # Track nodes that get ever used
-        nonoverlapping_artifact_graph = {}
-        artifact_variables = {}
-        for art_name, art_id in artifact_ordering:
-            artifact_subgraph = get_slice_graph(full_graph, [art_id])
-            artifact_nodes = set(artifact_subgraph.nx_graph.nodes) - used_nodes
+        # Construct a collection of graph segments
+        used_node_ids = set()  # Track nodes that get ever used
+        art_segment_dict = OrderedDict()
+        for art_id in artifact_ids_sorted:
+            # Identify "non-overlapping" nodes that solely belong to the artifact
+            art_name = artifact_dict[art_id]
+            art_slice = get_slice_graph(full_graph, [art_id])
+            art_node_ids = set(art_slice.nx_graph.nodes) - used_node_ids
+            art_graph_segment = full_graph.get_subgraph(
+                [full_graph.get_node(node_id) for node_id in art_node_ids]
+            )
 
-            nonoverlapping_artifact_graph[art_name] = full_graph.get_subgraph(
-                [
-                    full_graph.get_node(node_id)
-                    for node_id in set(artifact_nodes) - used_nodes
-                ]
-            )
-            used_nodes = used_nodes.union(
-                set(nonoverlapping_artifact_graph[art_name].nx_graph.nodes)
-            )
+            # Update used nodes for next iteration
+            used_node_ids = used_node_ids.union(art_node_ids)
+
+            # Calculate the artifact's variable relations
             dependent_variables = set(
                 itertools.chain.from_iterable(
-                    [node_dependency[node_id] for node_id in artifact_nodes]
+                    [node_dependency[node_id] for node_id in art_node_ids]
                 )
             )
             created_variables = set(
                 itertools.chain.from_iterable(
                     [
                         variable_dict.get(node_id, set())
-                        for node_id in artifact_nodes
+                        for node_id in art_node_ids
                     ]
                 )
             )
             related_variables = dependent_variables.union(created_variables)
             required_variables = related_variables - created_variables
-            return_variables = set([art_name])
+            return_variables = set([art_name])  # FIXME: Should be var name
 
-            artifact_variables[art_name] = {
-                "dependent_variables": dependent_variables,
-                "created_variables": created_variables,
-                "related_variables": related_variables,
-                "required_variables": required_variables,
-                "return_variables": return_variables,
-            }
+            # Create graph segment object for the artifact
+            art_segment_dict[art_name] = GraphSegment(
+                graph_segment=art_graph_segment,
+                dependent_variables=dependent_variables,
+                created_variables=created_variables,
+                related_variables=related_variables,
+                required_variables=required_variables,
+                return_variables=return_variables,
+            )
 
-        for i, (art_name, _) in enumerate(artifact_ordering):
-            required_variable = artifact_variables[art_name][
-                "required_variables"
-            ]
-            for p, (prev_art_name, _) in enumerate(artifact_ordering):
+        # Update `return_variables`` in each artifact segment to account for downstream requirements
+        for i, art_segment in enumerate(art_segment_dict.values()):
+            for p, prev_art_segment in enumerate(art_segment_dict.values()):
                 if p < i:
-                    artifact_variables[prev_art_name][
-                        "return_variables"
-                    ] = artifact_variables[prev_art_name][
-                        "return_variables"
-                    ].union(
-                        artifact_variables[prev_art_name][
-                            "related_variables"
-                        ].intersection(required_variable)
+                    variables_required_downstream = (
+                        prev_art_segment.related_variables.intersection(
+                            art_segment.required_variables
+                        )
+                    )
+                    prev_art_segment.return_variables = (
+                        prev_art_segment.return_variables.union(
+                            variables_required_downstream
+                        )
                     )
 
-        return artifact_variables
+        return art_segment_dict

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -230,21 +230,6 @@ class SessionArtifacts:
                             ]
                         )
 
-        for i, art in enumerate(artifact_ordering.items()):
-            for p, prev_art in enumerate(artifact_ordering.items()):
-                if p < i:
-                    variables_required_downstream = art[1][
-                        "input_variables"
-                    ].intersection(prev_art[1]["all_variables"])
-                    if len(variables_required_downstream) > 0:
-                        prev_art[1]["return_variables"] += sorted(
-                            [
-                                x
-                                for x in variables_required_downstream
-                                if x not in prev_art[1]["return_variables"]
-                            ]
-                        )
-
 
 """
 call from 

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -1,15 +1,12 @@
 import itertools
 import logging
-import string
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Set
 
 import networkx as nx
-from sqlalchemy import over
 
-from lineapy.api.api import get
 from lineapy.api.api_classes import LineaArtifact
 from lineapy.data.graph import Graph
 from lineapy.data.types import LineaID
@@ -53,18 +50,23 @@ class GraphSegment:
         self,
         artifact_name,
         graph_segment,
+        segment_type,
         all_variables,
         input_variables,
         return_variables,
     ) -> None:
         self.artifact_name = artifact_name
-        self.artifact_safename = artifact_name  # Fix me
+        self.artifact_safename = artifact_name.replace(" ", "")
         self.graph_segment = graph_segment
+        self.segment_type = segment_type
         self.all_variables = all_variables
         self.input_variables = input_variables
         self.return_variables = return_variables
 
     def get_function_definition(self, indentation=4) -> str:
+        """
+        Return a codeblock to define the function
+        """
         indentation_block = " " * indentation
         artifact_code = get_source_code_from_graph(
             self.graph_segment
@@ -75,21 +77,26 @@ class GraphSegment:
                 for line in artifact_code.split("\n")
             ]
         )
+        artifact_name = self.artifact_safename
+        args_string = ", ".join([v for v in self.input_variables])
+        return_string = ", ".join([v for v in self.return_variables])
 
-        function_definition_template = string.Template(
-            """def get_${aname}(${args_string}):
-${artifact_codeblock}
-${indentation_block}return ${return_string}
-"""
-        )
+        return f"def get_{artifact_name}({args_string}):\n{artifact_codeblock}\n{indentation_block}return {return_string}"
 
-        return function_definition_template.safe_substitute(
-            aname=self.artifact_safename,
-            args_string=", ".join([v for v in self.input_variables]),
-            artifact_codeblock=artifact_codeblock,
-            indentation_block=indentation_block,
-            return_string=", ".join([v for v in self.return_variables]),
+    def get_function_call_block(self, keep_lineapy_save=False) -> str:
+        """
+        Return a codeblock to call the function with return variables
+        """
+        return_string = ", ".join(self.return_variables)
+        args_string = ",".join(self.input_variables)
+
+        codeblock = (
+            f"{return_string} = get_{self.artifact_safename}({args_string})"
         )
+        if keep_lineapy_save:
+            codeblock += f"\nlineapy.save({self.return_variables[0]}, '{self.artifact_name}')"
+
+        return codeblock
 
 
 @dataclass
@@ -118,10 +125,20 @@ class SessionArtifacts:
         self.graph_segments = []
         self.node_context = OrderedDict()
 
-        self._resolve_dependencies()
+        self._update_node_context()
         self._slice_session_artifacts()
 
-    def _resolve_dependencies(self):
+    def _update_node_context(self):
+        """
+        Traverse every node within the session in topologically sorted order and update
+        node_context with following informations
+
+        assigned_variables : some variables are assigned at this node
+        assigned_artifact : this node is pointing to some artifact
+        predecessors : predecessors of the node
+        dependent_variables : union of if any variable is assigned at predecessor node,
+            use the assigned variables; otherwise, use the dependent_variables
+        """
 
         # Map each variable node ID to the corresponding variable name(when variable assigned)
         self.variable_dict = OrderedDict()
@@ -161,6 +178,10 @@ class SessionArtifacts:
                 )
 
     def _get_subgraph_from_node_list(self, node_list: List[LineaID]) -> Graph:
+        """
+        Return the subgraph from list of node id
+        """
+
         return self.graph.get_subgraph(
             [self.graph.get_node(node_id) for node_id in node_list]
         )
@@ -168,6 +189,15 @@ class SessionArtifacts:
     def _get_involved_variables_from_node_list(
         self, node_list
     ) -> Dict[str, Set[str]]:
+        """
+        How each variables are involved within these nodes.
+
+        Return a dictionary with following keys
+        dependent_variables : union of all dependent_variables of each node
+        assigned_variables : union of all assigned_variables of each node
+        all_variables : union of dependent_variables and assigned_variables
+        input_variables : all_variables - assigned_variables
+        """
 
         involved_variables = dict()
         involved_variables["dependent_variables"] = set(
@@ -211,12 +241,25 @@ class SessionArtifacts:
         return GraphSegment(
             artifact_name=artifact_context["artifact_name"],
             graph_segment=subgraph,
+            segment_type=artifact_context["artifact_type"],
             all_variables=involved_variables["all_variables"],
             input_variables=involved_variables["input_variables"],
             return_variables=artifact_context["return_variables"],
         )
 
     def _slice_session_artifacts(self) -> None:
+        """
+        Iterate over artifacts in topological sorted order(on artifact node id).
+        Assigned nodes of artifact sliced graph to the artifact context for
+        those nodes that are not belong to prior artifacts. For each node,
+        update the artifact_name in node_context.
+        For union of all predecessor nodes, if the predecessor node comes from
+        previous artifact. Find the common nodes of current artifact subgraph and
+        sliced graph to the predecessor node in the predecessor artifact.
+        If there are common nodes between the two graphs, we need to break the
+        graph of predecessor artifact into two pieces. One for common variables,
+        the other for the artifact itself.
+        """
         used_node_ids: Set[LineaID] = set()  # Track nodes that get ever used
         self.artifact_ordering = list()
         for node_id, n in self.node_context.items():
@@ -234,10 +277,12 @@ class SessionArtifacts:
                     ),
                 }
 
+                # All nodes related to this artifact
                 artifact_sliced_node_list = set(
                     get_slice_graph(self.graph, [node_id]).nx_graph.nodes
                 )
 
+                # Nodes only belong to this artifact
                 artifact_context["node_list"] = (
                     set(get_slice_graph(self.graph, [node_id]).nx_graph.nodes)
                     - used_node_ids
@@ -255,11 +300,13 @@ class SessionArtifacts:
                     ),
                 }
 
+                # Update node context to label the node is assigned to this artifact
                 for n_id in artifact_context["node_list"]:
                     self.node_context[n_id]["artifact_name"] = n[
                         "assigned_artifact"
                     ]
 
+                # Figure out where each predecessor is coming from which artifact
                 artifact_context["predecessor_nodes"] = set(
                     itertools.chain.from_iterable(
                         [
@@ -276,8 +323,8 @@ class SessionArtifacts:
                     ]
                 )
 
+                # Get information about which input variable is originated from which artifact
                 artifact_context["input_variable_sources"] = dict()
-
                 for pred_node_id in artifact_context["predecessor_nodes"]:
                     predecessor_variables = (
                         self.node_context[pred_node_id]["assigned_variables"]
@@ -302,6 +349,10 @@ class SessionArtifacts:
                         .union(predecessor_variables)
                     )
 
+                # Check whether we need to breakdown existing artifact graph
+                # segment. If the precedent node in precedent artifact graph
+                # is not the artifact itself, this means we should split the
+                # existing artifact graph segment.
                 for source_artifact_name, variables in artifact_context[
                     "input_variable_sources"
                 ].items():
@@ -310,18 +361,6 @@ class SessionArtifacts:
                         for i, context in enumerate(self.artifact_ordering)
                         if context["artifact_name"] == source_artifact_name
                     ][0]
-                    print(
-                        source_artifact_context_index,
-                        len(self.artifact_ordering),
-                    )
-
-                    common_return_variables = set(
-                        source_artifact_context["return_variables"]
-                    ).intersection(
-                        artifact_context["input_variable_sources"][
-                            source_artifact_context["artifact_name"]
-                        ]
-                    )
 
                     common_inner_variables = (
                         source_artifact_context["all_variables"]
@@ -348,6 +387,7 @@ class SessionArtifacts:
                             set(source_art_slice_variable_graph.nx_graph.nodes)
                         )
 
+                        # Split one artifact_context into two
                         if len(common_nodes) > 0:
                             common_artifact_variables = (
                                 self._get_involved_variables_from_node_list(
@@ -355,7 +395,7 @@ class SessionArtifacts:
                                 )
                             )
                             common_artifact_context = {
-                                "artifact_name": f"{'_'.join(common_inner_variables)}_for_{artifact_context['artifact_name']}",
+                                "artifact_name": f"{'_'.join(common_inner_variables)}_for_artifact_{source_artifact_context['artifact_name']}_and_downstream",
                                 "artifact_type": GraphSegmentType.COMMON_VARIABLE,
                                 "node_list": common_nodes,
                                 "input_variables": common_artifact_variables[
@@ -414,363 +454,6 @@ class SessionArtifacts:
             for artifact_context in self.artifact_ordering
         ]
 
-        # for prev_art in self.artifact_ordering:
-        #     if (
-        #         prev_art["artifact_name"]
-        #         in artifact_context["input_variable_sources"].keys()
-        #     ):
-        #         return_variables_intersection = set(
-        #             prev_art["return_variables"]
-        #         ).intersection(
-        #             artifact_context["input_variable_sources"][
-        #                 prev_art["artifact_name"]
-        #             ]
-        #         )
-
-        #         if len(return_variables_intersection) > 0:
-        #             print(
-        #                 artifact_context["artifact_name"],
-        #                 "is taking",
-        #                 return_variables_intersection,
-        #                 "from return of ",
-        #                 prev_art["artifact_name"],
-        #             )
-
-        #         inner_variables_intersection = (
-        #             prev_art["all_variables"]
-        #             - set(prev_art["return_variables"])
-        #         ).intersection(
-        #             artifact_context["input_variable_sources"][
-        #                 prev_art["artifact_name"]
-        #             ]
-        #         )
-
-        #         if len(inner_variables_intersection) > 0:
-        #             print(
-        #                 artifact_context["artifact_name"],
-        #                 "is taking",
-        #                 inner_variables_intersection,
-        #                 "from inside of ",
-        #                 prev_art["artifact_name"],
-        #             )
-
-        #             # print("prev artifact nodes", prev_art["node_list"])
-        #             prev_art_graph = self._get_subgraph_from_node_list(
-        #                 prev_art["node_list"]
-        #             )
-        #             prev_art_slice_variable_graph = get_slice_graph(
-        #                 prev_art_graph,
-        #                 [
-        #                     n
-        #                     for n in artifact_context[
-        #                         "predecessor_nodes"
-        #                     ]
-        #                     if n in prev_art_graph.nx_graph.nodes
-        #                 ],
-        #             )
-        #             intersection_nodes = artifact_sliced_node_list.intersection(
-        #                 set(
-        #                     prev_art_slice_variable_graph.nx_graph.nodes
-        #                 )
-        #             )
-
-        #             print("common code")
-        #             print(
-        #                 get_source_code_from_graph(
-        #                     self.graph.get_subgraph(
-        #                         [
-        #                             self.graph.get_node(node_id)
-        #                             for node_id in intersection_nodes
-        #                         ]
-        #                     )
-        #                 )
-        #             )
-        #             print("remaining code")
-        #             print(
-        #                 get_source_code_from_graph(
-        #                     self.graph.get_subgraph(
-        #                         [
-        #                             self.graph.get_node(node_id)
-        #                             for node_id in artifact_context[
-        #                                 "node_list"
-        #                             ]
-        #                             if node_id
-        #                             not in intersection_nodes
-        #                         ]
-        #                     )
-        #                 )
-        #             )
-
-        # gsegment = self._get_graph_segment_from_artifact_context(
-        #     artifact_context
-        # )
-
-        # input_variables = set(artifact_context["input_variables"])
-        # while len(input_variables) > 0 and segment_counter <= len(
-        #     self.artifact_ordering
-        # ):
-        #     segment = self.artifact_ordering[-segment_counter]
-        #     return_variables_intersection = set(
-        #         segment["return_variables"]
-        #     ).intersection(input_variables)
-        #     if len(return_variables_intersection) > 0:
-        #         print(
-        #             artifact_context["artifact_name"],
-        #             input_variables,
-        #             "intersect with return variables of",
-        #             segment["artifact_name"],
-        #             segment["return_variables"],
-        #         )
-        #         input_variables -= return_variables_intersection
-        #     all_variables_intersection = (
-        #         segment["all_variables"]
-        #         - set(segment["return_variables"])
-        #     ).intersection(input_variables)
-        #     if len(all_variables_intersection) > 0:
-        #         print(
-        #             artifact_context["artifact_name"],
-        #             input_variables,
-        #             "intersect with inner variables of",
-        #             segment["artifact_name"],
-        #             segment["all_variables"]
-        #             - set(segment["return_variables"]),
-        #         )
-
-        #         intersect_nodes = segment["node_list"].intersection(
-        #             artifact_sliced_node_list
-        #         )
-        #         print("common nodes", intersect_nodes)
-        #         print("common code")
-        #         print(
-        #             get_source_code_from_graph(
-        #                 self.graph.get_subgraph(
-        #                     [
-        #                         self.graph.get_node(node_id)
-        #                         for node_id in intersect_nodes
-        #                     ]
-        #                 )
-        #             )
-        #         )
-
-        #         input_variables -= all_variables_intersection
-        #     segment_counter += 1
-
-        # artifact_nodes = [
-        #     self.graph.get_node(node_id)
-        #     for node_id in artifact_context["node_list"]
-        # ]
-        # artifact_context[
-        #     "nonoverlapping_graph"
-        # ] = self.graph.get_subgraph(
-        #     [n for n in artifact_nodes if n is not None]
-        # )
-
-    #     def _slice_session_artifacts(self) -> None:
-    #         # Identify artifact nodes and topologically sort them
-    #         used_node_ids: Set[LineaID] = set()  # Track nodes that get ever used
-    #         artifact_ordering = OrderedDict()
-    #         for node_id, n in self.node_context.items():
-    #             if n["assigned_artifact"] is not None and node_id in [
-    #                 art._node_id for art in self.artifact_list
-    #             ]:
-    #                 artifact_ordering[node_id] = {
-    #                     "artifact_name": n["assigned_artifact"],
-    #                     "return_variables": list(
-    #                         n["assigned_variables"]
-    #                         if len(n["assigned_variables"]) > 0
-    #                         else n["dependent_variables"]
-    #                     ),
-    #                 }
-
-    #                 # Identify "non-overlapping" nodes that solely belong to the artifact
-    #                 artifact_node_ids = (
-    #                     set(get_slice_graph(self.graph, [node_id]).nx_graph.nodes)
-    #                     - used_node_ids
-    #                 )
-    #                 artifact_nodes = [
-    #                     self.graph.get_node(node_id)
-    #                     for node_id in artifact_node_ids
-    #                 ]
-    #                 for n_id in artifact_node_ids:
-    #                     self.node_context[n_id]["artifact_name"] = n[
-    #                         "assigned_artifact"
-    #                     ]
-
-    #                 artifact_ordering[node_id][
-    #                     "nonoverlapping_graph"
-    #                 ] = self.graph.get_subgraph(
-    #                     [n for n in artifact_nodes if n is not None]
-    #                 )
-
-    #                 # Update used nodes for next iteration
-    #                 used_node_ids = used_node_ids.union(artifact_node_ids)
-
-    #                 # Calculate the artifact's variable relations
-    #                 # dependent variables for all these nodes
-    #                 dependent_variables = set(
-    #                     itertools.chain.from_iterable(
-    #                         [
-    #                             self.node_context[nid]["dependent_variables"]
-    #                             for nid in artifact_node_ids
-    #                         ]
-    #                     )
-    #                 )
-    #                 # variables got assigned within these nodes
-    #                 assigned_variables = set(
-    #                     itertools.chain.from_iterable(
-    #                         [
-    #                             self.node_context[nid]["assigned_variables"]
-    #                             for nid in artifact_node_ids
-    #                         ]
-    #                     )
-    #                 )
-    #                 # all variables within these nodes
-    #                 artifact_ordering[node_id][
-    #                     "all_variables"
-    #                 ] = dependent_variables.union(assigned_variables)
-    #                 # required input variables
-    #                 artifact_ordering[node_id]["input_variables"] = (
-    #                     artifact_ordering[node_id]["all_variables"]
-    #                     - assigned_variables
-    #                 )
-
-    #                 self.graph_segments.append(
-    #                     GraphSegment(
-    #                         artifact_name=artifact_ordering[node_id][
-    #                             "artifact_name"
-    #                         ],
-    #                         graph_segment=artifact_ordering[node_id][
-    #                             "nonoverlapping_graph"
-    #                         ],
-    #                         all_variables=artifact_ordering[node_id][
-    #                             "all_variables"
-    #                         ],
-    #                         input_variables=artifact_ordering[node_id][
-    #                             "input_variables"
-    #                         ],
-    #                         return_variables=artifact_ordering[node_id][
-    #                             "return_variables"
-    #                         ],
-    #                     )
-    #                 )
-
-    #         # Add extra return variables that are used for downstream artifacts to each artifact
-    #         for i, graph_segment in enumerate(self.graph_segments):
-    #             for p, prev_graph_segment in enumerate(self.graph_segments):
-    #                 if p < i:
-    #                     variables_required_downstream = (
-    #                         graph_segment.input_variables.intersection(
-    #                             prev_graph_segment.all_variables
-    #                         )
-    #                     )
-    #                     if len(variables_required_downstream) > 0:
-    #                         prev_graph_segment.return_variables += sorted(
-    #                             [
-    #                                 x
-    #                                 for x in variables_required_downstream
-    #                                 if x not in prev_graph_segment.return_variables
-    #                             ]
-    #                         )
-
-    #         # # Add extra return variables that are used for downstream artifacts to each artifact
-    #         # for i, graph_segment in enumerate(self.graph_segments):
-    #         #     for p, prev_graph_segment in enumerate(self.graph_segments):
-    #         #         if p < i:
-    #         #             extra_variables_to_return = (
-    #         #                 graph_segment.input_variables.intersection(
-    #         #                     prev_graph_segment.all_variables
-    #         #                 )
-    #         #                 - set(prev_graph_segment.return_variables)
-    #         #             )
-
-    #         #             if len(extra_variables_to_return) > 0:
-
-    #         # for i, graph_segment in enumerate(self.graph_segments):
-    #         #     for p, prev_graph_segment in reversed(
-    #         #         list(enumerate(self.graph_segments))
-    #         #     ):
-    #         #         if p < i and any(
-    #         #             [
-    #         #                 v in prev_graph_segment.return_variables[1:]
-    #         #                 for v in graph_segment.input_variables
-    #         #             ]
-    #         #         ):
-    #         #             common_variables = (
-    #         #                 graph_segment.input_variables.intersection(
-    #         #                     set(prev_graph_segment.return_variables)
-    #         #                 )
-    #         #             )
-
-    #         #             common_nodes = list(
-    #         #                 nx.intersection_all(
-    #         #                     [
-    #         #                         prev_graph_segment.graph_segment.nx_graph,
-    #         #                         get_slice_graph(
-    #         #                             self.graph,
-    #         #                             list(
-    #         #                                 graph_segment.graph_segment.nx_graph.nodes
-    #         #                             ),
-    #         #                         ).nx_graph,
-    #         #                     ]
-    #         #                 ).nodes
-    #         #             )
-
-    #         #             prev_artifact_id = [
-    #         #                 art._node_id
-    #         #                 for art in self.artifact_list
-    #         #                 if art.name == prev_graph_segment.artifact_name
-    #         #             ]
-
-    #         #             # Check whether common nodes include the previous artifact node (if yes, no refactor possible)6
-    #         #             if (
-    #         #                 len(prev_artifact_id) > 0
-    #         #                 and prev_artifact_id[0] not in common_nodes
-    #         #             ) and len(common_nodes) > 0:
-
-    #         #                 print(
-    #         #                     graph_segment.artifact_name,
-    #         #                     graph_segment.input_variables,
-    #         #                     "need to extract",
-    #         #                     common_variables,
-    #         #                     "from",
-    #         #                     prev_graph_segment.artifact_name,
-    #         #                     prev_graph_segment.return_variables,
-    #         #                 )
-
-    #         #                 print("prev graph segment code")
-    #         #                 print(
-    #         #                     get_source_code_from_graph(
-    #         #                         prev_graph_segment.graph_segment
-    #         #                     )
-    #         #                 )
-
-    #         #                 common_graph = self.graph.get_subgraph(
-    #         #                     [
-    #         #                         self.graph.get_node(nodeid)
-    #         #                         for nodeid in common_nodes
-    #         #                     ]
-    #         #                 )
-
-    #         #                 print(
-    #         #                     set(common_nodes)
-    #         #                     - set(
-    #         #                         prev_graph_segment.graph_segment.nx_graph.nodes
-    #         #                     )
-    #         #                 )
-
-    #         #                 print(
-    #         #                     set(common_graph.nx_graph.nodes)
-    #         #                     - set(
-    #         #                         prev_graph_segment.graph_segment.nx_graph.nodes
-    #         #                     )
-    #         #                 )
-
-    #         #                 common_code = get_source_code_from_graph(common_graph)
-
-    #         #                 print("common code")
-    #         #                 print(common_code)
-    #         #                 print("-" * 80)
-
     def get_session_module_definition(
         self, indentation: int = 4, keep_lineapy_save: bool = False
     ) -> str:
@@ -780,18 +463,23 @@ class SessionArtifacts:
 
         indentation_block = " " * indentation
 
-        function_definitions = "\n".join(
+        function_definitions = "\n\n".join(
             [
                 graph_seg.get_function_definition(indentation=indentation)
                 for graph_seg in self.graph_segments
             ]
         )
+
         calculation_codeblock = "\n".join(
             [
-                f"{indentation_block}{', '.join(graph_seg.return_variables)} = get_{graph_seg.artifact_name}({','.join(graph_seg.input_variables)})"
-                if not keep_lineapy_save
-                else f"""{indentation_block}{', '.join(graph_seg.return_variables)} = get_{graph_seg.artifact_name}({','.join(graph_seg.input_variables)})
-{indentation_block}lineapy.save({graph_seg.return_variables[0]}, '{graph_seg.artifact_name}')"""
+                "\n".join(
+                    [
+                        f"{indentation_block}{row}"
+                        for row in graph_seg.get_function_call_block(
+                            keep_lineapy_save=keep_lineapy_save
+                        ).split("\n")
+                    ]
+                )
                 for graph_seg in self.graph_segments
             ]
         )
@@ -799,24 +487,16 @@ class SessionArtifacts:
             [
                 graph_seg.return_variables[0]
                 for graph_seg in self.graph_segments
+                if graph_seg.segment_type == GraphSegmentType.ARTIFACT
             ]
         )
 
-        session_module_definitaion_template = string.Template(
-            """${function_definitions}
+        return f"""{function_definitions}
 
 def pipeline():
-${calculation_codeblock}
-${indentation_block}return ${return_string}
+{calculation_codeblock}
+{indentation_block}return {return_string}
 
 if __name__=='__main__':
-${indentation_block}pipeline()
+{indentation_block}pipeline()
 """
-        )
-
-        return session_module_definitaion_template.safe_substitute(
-            indentation_block=indentation_block,
-            function_definitions=function_definitions,
-            calculation_codeblock=calculation_codeblock,
-            return_string=return_string,
-        )

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -1,0 +1,117 @@
+import itertools
+import string
+from collections import defaultdict
+from dataclasses import dataclass
+
+import networkx as nx
+
+from lineapy.data.graph import Graph
+from lineapy.data.types import LineaID
+from lineapy.db.db import RelationalLineaDB
+from lineapy.graph_reader.program_slice import (
+    get_slice_graph,
+    get_source_code_from_graph,
+)
+
+
+@dataclass
+class GraphRefactorer:
+    """
+    Refactor a given session graph for use in a downstream task (e.g., pipeline building).
+    """
+
+    db: RelationalLineaDB
+
+    def _segment_session_graph_by_artifacts(self, session_id) -> str:
+        # Map each variable node ID to the corresponding variable name
+        session_variables = self.db.get_variables_for_session(session_id)
+        variable_dict = defaultdict(set)
+        for node_id, variable_name in session_variables:
+            variable_dict[node_id].add(variable_name)
+
+        # Map each artifact node ID to the corresponding artifact name
+        session_artifacts = self.db.get_artifacts_for_session(session_id)
+        artifact_dict = {
+            artifact.node_id: artifact.name for artifact in session_artifacts
+        }
+
+        # Get the full session graph
+        session_context = self.db.get_session_context(session_id)
+        nodes = self.db.get_nodes_for_session(session_id)
+        full_graph = Graph(nodes, session_context)
+        full_nxgraph = full_graph.nx_graph
+
+        # Identify variable dependencies of each node in topological order
+        node_dependency = dict()
+        for node_id in nx.topological_sort(full_graph.nx_graph):
+            predecessors = full_nxgraph.predecessors(node_id)
+            node_dependency[node_id] = set()
+            for p_node_id in predecessors:
+                dep = variable_dict.get(p_node_id, node_dependency[p_node_id])
+                node_dependency[node_id] = node_dependency[node_id].union(dep)
+
+        # Identify artifact nodes and topologically sort them
+        artifact_ordering = [
+            (artifact_dict[node_id], node_id)
+            for node_id in nx.topological_sort(full_nxgraph)
+            if artifact_dict.get(node_id) is not None
+        ]
+
+        used_nodes = set()  # Track nodes that get ever used
+        nonoverlapping_artifact_graph = {}
+        artifact_variables = {}
+        for art_name, art_id in artifact_ordering:
+            artifact_subgraph = get_slice_graph(full_graph, [art_id])
+            artifact_nodes = set(artifact_subgraph.nx_graph.nodes) - used_nodes
+
+            nonoverlapping_artifact_graph[art_name] = full_graph.get_subgraph(
+                [
+                    full_graph.get_node(node_id)
+                    for node_id in set(artifact_nodes) - used_nodes
+                ]
+            )
+            used_nodes = used_nodes.union(
+                set(nonoverlapping_artifact_graph[art_name].nx_graph.nodes)
+            )
+            dependent_variables = set(
+                itertools.chain.from_iterable(
+                    [node_dependency[node_id] for node_id in artifact_nodes]
+                )
+            )
+            created_variables = set(
+                itertools.chain.from_iterable(
+                    [
+                        variable_dict.get(node_id, set())
+                        for node_id in artifact_nodes
+                    ]
+                )
+            )
+            related_variables = dependent_variables.union(created_variables)
+            required_variables = related_variables - created_variables
+            return_variables = set([art_name])
+
+            artifact_variables[art_name] = {
+                "dependent_variables": dependent_variables,
+                "created_variables": created_variables,
+                "related_variables": related_variables,
+                "required_variables": required_variables,
+                "return_variables": return_variables,
+            }
+
+        for i, (art_name, _) in enumerate(artifact_ordering):
+            required_variable = artifact_variables[art_name][
+                "required_variables"
+            ]
+            for p, (prev_art_name, _) in enumerate(artifact_ordering):
+                if p < i:
+                    artifact_variables[prev_art_name][
+                        "return_variables"
+                    ] = artifact_variables[prev_art_name][
+                        "return_variables"
+                    ].union(
+                        artifact_variables[prev_art_name][
+                            "related_variables"
+                        ].intersection(required_variable)
+                    )
+
+        return artifact_variables

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -75,6 +75,7 @@ class GraphSegment:
             [
                 f"{indentation_block}{line}"
                 for line in artifact_code.split("\n")
+                if len(line.strip(" ")) > 0
             ]
         )
         artifact_name = self.artifact_safename

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -90,6 +90,7 @@ class SessionArtifacts:
     graph_segments: List[GraphSegment]
 
     def __init__(self, artifacts: List[LineaArtifact]) -> None:
+        # TODO: Check if all passed artifacts come from the same session; if not, raise error
         self.session_id = artifacts[0]._session_id
         self.db = artifacts[0].db
         self.graph = artifacts[0]._get_graph()
@@ -98,9 +99,11 @@ class SessionArtifacts:
         self.graph_segments = []
 
         # Map each variable node ID to the corresponding variable name(when variable assigned)
-        session_variables = self.db.get_variables_for_session(self.session_id)
+        self.session_variables = self.db.get_variables_for_session(
+            self.session_id
+        )
         variable_dict: Dict[LineaID, Set[str]] = dict()
-        for node_id, variable_name in session_variables:
+        for node_id, variable_name in self.session_variables:
             variable_dict[node_id] = (
                 set([variable_name])
                 if node_id not in variable_dict.keys()
@@ -276,7 +279,7 @@ class ArtifactCollections:
                     art = get(art_name[0], version=art_name[1])
             except:
                 logger.error("Cannot retrive artifact %s", art_name)
-                raise  # Fix me, add error type
+                raise  # FIXME: add error type
 
             self.artifacts.append(art)
             self.sessions.add(art._session_id)

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -1,11 +1,14 @@
 import itertools
+import logging
 import string
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Set
+from typing import Any, Dict, List, Set, Tuple, Union
 
 import networkx as nx
 
+from lineapy.api.api import get
+from lineapy.api.api_classes import LineaArtifact
 from lineapy.data.graph import Graph
 from lineapy.data.types import LineaID
 from lineapy.db.db import RelationalLineaDB
@@ -13,117 +16,293 @@ from lineapy.graph_reader.program_slice import (
     get_slice_graph,
     get_source_code_from_graph,
 )
+from lineapy.utils.logging_config import configure_logging
+
+logger = logging.getLogger(__name__)
+configure_logging()
+
+
+function_definition_template = string.Template(
+    """
+def get_${aname}(${args_string}):
+${artifact_codeblock}
+${indentation_block}return ${return_string}
+"""
+)
 
 
 @dataclass
 class GraphSegment:
+    """This"""
+
+    artifact_name: str
     graph_segment: Graph
-    dependent_variables: Set[str]
-    created_variables: Set[str]
-    related_variables: Set[str]
-    required_variables: Set[str]
-    return_variables: Set[str]
+    all_variables: Set[str]
+    input_variables: Set[str]
+    return_variables: List[str]
+
+    def __init__(
+        self,
+        artifact_name,
+        graph_segment,
+        all_variables,
+        input_variables,
+        return_variables,
+    ) -> None:
+        self.artifact_name = artifact_name
+        self.graph_segment = graph_segment
+        self.all_variables = all_variables
+        self.input_variables = input_variables
+        self.return_variables = return_variables
+
+    def get_function_definition(self, indentation=4) -> str:
+        indentation_block = " " * indentation
+        artifact_code = get_source_code_from_graph(
+            self.graph_segment
+        ).__str__()
+        artifact_codeblock = "\n".join(
+            [
+                f"{indentation_block}{line}"
+                for line in artifact_code.split("\n")
+            ]
+        )
+
+        return function_definition_template.safe_substitute(
+            aname=self.artifact_name,
+            args_string=", ".join([v for v in self.input_variables]),
+            artifact_codeblock=artifact_codeblock,
+            indentation_block=indentation_block,
+            return_string=", ".join([v for v in self.return_variables]),
+        )
 
 
 @dataclass
-class GraphRefactorer:
+class SessionArtifacts:
     """
     Refactor a given session graph for use in a downstream task (e.g., pipeline building).
     """
 
+    session_id: LineaID
+    graph: Graph
+    session_variables: List[str]
     db: RelationalLineaDB
+    nx_graph: nx.DiGraph
+    graph_segments: List[GraphSegment]
 
-    def _segment_session_graph_by_artifacts(self, session_id) -> str:
-        # Map each variable node ID to the corresponding variable name
-        session_variables = self.db.get_variables_for_session(session_id)
-        variable_dict = defaultdict(set)
+    def __init__(self, artifacts: List[LineaArtifact]) -> None:
+        self.session_id = artifacts[0]._session_id
+        self.db = artifacts[0].db
+        self.graph = artifacts[0]._get_graph()
+        self.nx_graph = self.graph.nx_graph
+
+        self.graph_segments = []
+
+        # Map each variable node ID to the corresponding variable name(when variable assigned)
+        session_variables = self.db.get_variables_for_session(self.session_id)
+        variable_dict: Dict[LineaID, Set[str]] = dict()
         for node_id, variable_name in session_variables:
-            variable_dict[node_id].add(variable_name)
+            variable_dict[node_id] = (
+                set([variable_name])
+                if node_id not in variable_dict.keys()
+                else variable_dict[node_id].union(set([variable_name]))
+            )
 
         # Map each artifact node ID to the corresponding artifact name
-        session_artifacts = self.db.get_artifacts_for_session(session_id)
+        session_artifacts = self.db.get_artifacts_for_session(self.session_id)
         artifact_dict = {
             artifact.node_id: artifact.name for artifact in session_artifacts
         }
 
-        # Get the full session graph
-        session_context = self.db.get_session_context(session_id)
-        nodes = self.db.get_nodes_for_session(session_id)
-        full_graph = Graph(nodes, session_context)
-        full_nxgraph = full_graph.nx_graph
-
         # Identify variable dependencies of each node in topological order
-        node_dependency = dict()
-        for node_id in nx.topological_sort(full_nxgraph):
-            predecessors = full_nxgraph.predecessors(node_id)
-            node_dependency[node_id] = set()
+        node_context: Dict[LineaID, Dict[str, Any]] = OrderedDict()
+        for node_id in nx.topological_sort(self.nx_graph):
+            predecessors = self.nx_graph.predecessors(node_id)
+            node_context[node_id] = {
+                "assigned_variables": variable_dict.get(node_id, set()),
+                "assigned_artifact": artifact_dict.get(node_id, None),
+                "dependent_variables": set(),
+            }
             for p_node_id in predecessors:
-                dep = variable_dict.get(p_node_id, node_dependency[p_node_id])
-                node_dependency[node_id] = node_dependency[node_id].union(dep)
+                # If predecessor is variable assignment use the variable, else use its dependencies
+                dep = variable_dict.get(
+                    p_node_id, node_context[p_node_id]["dependent_variables"]
+                )
+                node_context[node_id]["dependent_variables"] = node_context[
+                    node_id
+                ]["dependent_variables"].union(dep)
 
         # Identify artifact nodes and topologically sort them
-        artifact_ids_sorted = [
-            node_id
-            for node_id in nx.topological_sort(full_nxgraph)
-            if node_id in artifact_dict
-        ]
+        used_node_ids: Set[LineaID] = set()  # Track nodes that get ever used
+        artifact_ordering = OrderedDict()
+        for node_id, n in node_context.items():
+            if n["assigned_artifact"] is not None:
+                artifact_ordering[node_id] = {
+                    "artifact_name": n["assigned_artifact"],
+                    "return_variables": list(
+                        n["assigned_variables"]
+                        if len(n["assigned_variables"]) > 0
+                        else n["dependent_variables"]
+                    ),
+                }
 
-        # Construct a collection of graph segments
-        used_node_ids = set()  # Track nodes that get ever used
-        art_segment_dict = OrderedDict()
-        for art_id in artifact_ids_sorted:
-            # Identify "non-overlapping" nodes that solely belong to the artifact
-            art_name = artifact_dict[art_id]
-            art_slice = get_slice_graph(full_graph, [art_id])
-            art_node_ids = set(art_slice.nx_graph.nodes) - used_node_ids
-            art_graph_segment = full_graph.get_subgraph(
-                [full_graph.get_node(node_id) for node_id in art_node_ids]
-            )
-
-            # Update used nodes for next iteration
-            used_node_ids = used_node_ids.union(art_node_ids)
-
-            # Calculate the artifact's variable relations
-            dependent_variables = set(
-                itertools.chain.from_iterable(
-                    [node_dependency[node_id] for node_id in art_node_ids]
+                # Identify "non-overlapping" nodes that solely belong to the artifact
+                artifact_slice_graph = get_slice_graph(self.graph, [node_id])
+                artifact_node_ids = (
+                    set(artifact_slice_graph.nx_graph.nodes) - used_node_ids
                 )
-            )
-            created_variables = set(
-                itertools.chain.from_iterable(
-                    [
-                        variable_dict.get(node_id, set())
-                        for node_id in art_node_ids
-                    ]
+                artifact_nodes = [
+                    self.graph.get_node(node_id)
+                    for node_id in artifact_node_ids
+                ]
+                artifact_ordering[node_id][
+                    "nonoverlapping_graph"
+                ] = self.graph.get_subgraph(
+                    [n for n in artifact_nodes if n is not None]
                 )
-            )
-            related_variables = dependent_variables.union(created_variables)
-            required_variables = related_variables - created_variables
-            return_variables = set([art_name])  # FIXME: Should be var name
 
-            # Create graph segment object for the artifact
-            art_segment_dict[art_name] = GraphSegment(
-                graph_segment=art_graph_segment,
-                dependent_variables=dependent_variables,
-                created_variables=created_variables,
-                related_variables=related_variables,
-                required_variables=required_variables,
-                return_variables=return_variables,
-            )
+                # Update used nodes for next iteration
+                used_node_ids = used_node_ids.union(artifact_node_ids)
 
-        # Update `return_variables`` in each artifact segment to account for downstream requirements
-        for i, art_segment in enumerate(art_segment_dict.values()):
-            for p, prev_art_segment in enumerate(art_segment_dict.values()):
+                # Calculate the artifact's variable relations
+                # dependent variables for all these nodes
+                dependent_variables = set(
+                    itertools.chain.from_iterable(
+                        [
+                            node_context[nid]["dependent_variables"]
+                            for nid in artifact_node_ids
+                        ]
+                    )
+                )
+                # variables got assigned within these nodes
+                assigned_variables = set(
+                    itertools.chain.from_iterable(
+                        [
+                            node_context[nid]["assigned_variables"]
+                            for nid in artifact_node_ids
+                        ]
+                    )
+                )
+                # all variables within these nodes
+                artifact_ordering[node_id][
+                    "all_variables"
+                ] = dependent_variables.union(assigned_variables)
+                # required input variables
+                artifact_ordering[node_id]["input_variables"] = (
+                    artifact_ordering[node_id]["all_variables"]
+                    - assigned_variables
+                )
+
+                self.graph_segments.append(
+                    GraphSegment(
+                        artifact_name=artifact_ordering[node_id][
+                            "artifact_name"
+                        ],
+                        graph_segment=artifact_ordering[node_id][
+                            "nonoverlapping_graph"
+                        ],
+                        all_variables=artifact_ordering[node_id][
+                            "all_variables"
+                        ],
+                        input_variables=artifact_ordering[node_id][
+                            "input_variables"
+                        ],
+                        return_variables=artifact_ordering[node_id][
+                            "return_variables"
+                        ],
+                    )
+                )
+
+        # Add extra return variables that are used for downstream artifacts to each artifact
+        for i, graph_segment in enumerate(self.graph_segments):
+            for p, prev_graph_segment in enumerate(self.graph_segments):
                 if p < i:
                     variables_required_downstream = (
-                        prev_art_segment.related_variables.intersection(
-                            art_segment.required_variables
+                        graph_segment.input_variables.intersection(
+                            prev_graph_segment.all_variables
                         )
                     )
-                    prev_art_segment.return_variables = (
-                        prev_art_segment.return_variables.union(
-                            variables_required_downstream
+                    if len(variables_required_downstream) > 0:
+                        prev_graph_segment.return_variables += sorted(
+                            [
+                                x
+                                for x in variables_required_downstream
+                                if x not in prev_graph_segment.return_variables
+                            ]
                         )
-                    )
 
-        return art_segment_dict
+        for i, art in enumerate(artifact_ordering.items()):
+            for p, prev_art in enumerate(artifact_ordering.items()):
+                if p < i:
+                    variables_required_downstream = art[1][
+                        "input_variables"
+                    ].intersection(prev_art[1]["all_variables"])
+                    if len(variables_required_downstream) > 0:
+                        prev_art[1]["return_variables"] += sorted(
+                            [
+                                x
+                                for x in variables_required_downstream
+                                if x not in prev_art[1]["return_variables"]
+                            ]
+                        )
+
+
+"""
+call from 
+def to_pipeline_2(
+    artifacts: List[str], #
+    framework: str = "SCRIPT",
+    pipeline_name: Optional[str] = None,
+    dependencies: TaskGraphEdge = {},
+    pipeline_dag_config: Optional[AirflowDagConfig] = {},
+    output_dir: Optional[str] = None,
+) -> Path:
+
+eventually replace current to_pipeline
+
+"""
+
+
+@dataclass
+class ArtifactCollections:
+    """
+    Take all artifact name, get session id, check input dependency,
+
+    TBD --- need more work !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    """
+
+    artifacts: List[LineaArtifact]
+    # sessions : Set[LineaID]
+    session_artifacts: Dict[LineaID, SessionArtifacts]
+
+    """
+    add whatever necessary you think you need
+    """
+
+    def __init__(self, artifacts=List[Union[str, Tuple[str, int]]]) -> None:
+        self.artifacts = []
+        self.sessions = set()
+
+        for art_name in artifacts:
+            try:
+                if isinstance(art_name, str):
+                    art = get(art_name)
+                elif isinstance(art_name, tuple):
+                    art = get(art_name[0], version=art_name[1])
+            except:
+                logger.error("Cannot retrive artifact %s", art_name)
+                raise  # Fix me, add error type
+
+            self.artifacts.append(art)
+            self.sessions.add(art._session_id)
+
+
+#         for session_id in list_of_session_id:
+
+#             SessionArtifacts()
+
+#     def code_generation(self, framework, lineapysave, ....):
+#         pass
+
+
+# ------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -83,18 +83,19 @@ class GraphSegment:
 
         return f"def get_{artifact_name}({args_string}):\n{artifact_codeblock}\n{indentation_block}return {return_string}"
 
-    def get_function_call_block(self, keep_lineapy_save=False) -> str:
+    def get_function_call_block(
+        self, indentation=0, keep_lineapy_save=False
+    ) -> str:
         """
         Return a codeblock to call the function with return variables
         """
+        indentation_block = " " * indentation
         return_string = ", ".join(self.return_variables)
         args_string = ",".join(self.input_variables)
 
-        codeblock = (
-            f"{return_string} = get_{self.artifact_safename}({args_string})"
-        )
+        codeblock = f"{indentation_block}{return_string} = get_{self.artifact_safename}({args_string})"
         if keep_lineapy_save:
-            codeblock += f"\nlineapy.save({self.return_variables[0]}, '{self.artifact_name}')"
+            codeblock += f"\n{indentation_block}lineapy.save({self.return_variables[0]}, '{self.artifact_name}')"
 
         return codeblock
 
@@ -113,7 +114,7 @@ class SessionArtifacts:
     artifact_list: List[LineaArtifact]
     artifact_ordering: List
     artifact_dict: Dict[LineaID, Optional[str]]
-    variable_dict: OrderedDict[LineaID, Set[str]]
+    variable_dict: OrderedDict[LineaID, Set]
     node_context: Dict[LineaID, Dict[str, Any]]
 
     def __init__(self, artifacts: List[LineaArtifact]) -> None:
@@ -477,13 +478,9 @@ class SessionArtifacts:
 
         calculation_codeblock = "\n".join(
             [
-                "\n".join(
-                    [
-                        f"{indentation_block}{row}"
-                        for row in graph_seg.get_function_call_block(
-                            keep_lineapy_save=keep_lineapy_save
-                        ).split("\n")
-                    ]
+                graph_seg.get_function_call_block(
+                    indentation=indentation,
+                    keep_lineapy_save=keep_lineapy_save,
                 )
                 for graph_seg in self.graph_segments
             ]

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -340,12 +340,7 @@ class SessionArtifacts:
                     "artifact_type": GraphSegmentType.ARTIFACT,
                     "artifact_name": n["assigned_artifact"],
                     "tracked_variables": n["tracked_variables"],
-                    "return_variables": list(n["tracked_variables"])
-                    # "return_variables": list(
-                    #     n["assigned_variables"]
-                    #     if len(n["assigned_variables"]) > 0
-                    #     else n["dependent_variables"]
-                    # ),
+                    "return_variables": list(n["tracked_variables"]),
                 }
 
                 # All nodes related to this artifact

--- a/lineapy/graph_reader/graph_refactorer.py
+++ b/lineapy/graph_reader/graph_refactorer.py
@@ -78,7 +78,7 @@ class GraphSegment:
             ]
         )
         artifact_name = self.artifact_safename
-        args_string = ", ".join([v for v in self.input_variables])
+        args_string = ", ".join(sorted([v for v in self.input_variables]))
         return_string = ", ".join([v for v in self.return_variables])
 
         return f"def get_{artifact_name}({args_string}):\n{artifact_codeblock}\n{indentation_block}return {return_string}"
@@ -91,11 +91,15 @@ class GraphSegment:
         """
         indentation_block = " " * indentation
         return_string = ", ".join(self.return_variables)
-        args_string = ",".join(self.input_variables)
+        args_string = ", ".join(sorted([v for v in self.input_variables]))
 
         codeblock = f"{indentation_block}{return_string} = get_{self.artifact_safename}({args_string})"
-        if keep_lineapy_save:
-            codeblock += f"\n{indentation_block}lineapy.save({self.return_variables[0]}, '{self.artifact_name}')"
+        # print(self.artifact_safename, self.segment_type)
+        if (
+            keep_lineapy_save
+            and self.segment_type == GraphSegmentType.ARTIFACT
+        ):
+            codeblock += f"""\n{indentation_block}lineapy.save({self.return_variables[0]}, "{self.artifact_name}")"""
 
         return codeblock
 
@@ -499,6 +503,6 @@ def pipeline():
 {calculation_codeblock}
 {indentation_block}return {return_string}
 
-if __name__=='__main__':
+if __name__=="__main__":
 {indentation_block}pipeline()
 """

--- a/tests/unit/graph_reader/test_graph_refactorer.py
+++ b/tests/unit/graph_reader/test_graph_refactorer.py
@@ -4,7 +4,18 @@ from lineapy.utils.utils import prettify
 
 def test_refactor(execute):
     """
-    Tests a non-trivial examples
+    Tests the following non-trivial example: 
+    a0 --> (a0+=1) \                       /--> (f=c+7)
+                    \                     /
+                     >--> b=a*2+a0 --> (c=b+3) -------\ 
+                    /                                  \
+    (a=1) --> a+=1 /-----> d=a*4 --> e=d+5 --> (e+=6) --\
+                      \                                 \  
+                        \--> a+=1 ------------------------\--> (g = c+e*2)--\
+                                                      \                     \
+                                                        \---------------------\--> (h=a+g)
+
+    Node with parentheses are artifacts, 
     """
     code = """import lineapy
 art = {}
@@ -32,7 +43,7 @@ h = a+g
 art['h'] = lineapy.save(h,'h')
 """
 
-    expection_result = """def get_a():
+    expection_result_all = """def get_a():
   a = 1
   return a
 
@@ -99,4 +110,51 @@ if __name__=="__main__":
     refactor_code = sas.get_session_module_definition(
         indentation=2, keep_lineapy_save=True
     )
-    assert prettify(refactor_code) == prettify(expection_result)
+    assert prettify(refactor_code) == prettify(expection_result_all)
+
+    expection_result_a0_c_h = """def get_a0():
+  a0 = 0
+  a0 += 1
+  return a0
+
+def get_a_for_artifact_c_and_downstream():
+  a = 1
+  a += 1
+  return a
+
+def get_c(a, a0):
+  b = a * 2 + a0
+  c = b + 3
+  return c
+
+def get_h(a, c):
+  d = a * 4
+  e = d + 5
+  e += 6
+  a += 1
+  g = c + e * 2
+  h = a + g
+  return h
+
+def pipeline():
+  a0 = get_a0()
+  lineapy.save(a0, "a0")
+  a = get_a_for_artifact_c_and_downstream()
+  c = get_c(a, a0)
+  lineapy.save(c, "c")
+  h = get_h(a, c)
+  lineapy.save(h, "h")
+  return a0, c, h
+
+if __name__=="__main__":
+  pipeline()
+
+    """
+
+    sas = SessionArtifacts(
+        [a for i, a in enumerate(list(art.values())) if i in [0, 2, 6]]
+    )  # a0, c, h
+    refactor_code_a0_c_h = sas.get_session_module_definition(
+        indentation=2, keep_lineapy_save=True
+    )
+    assert prettify(refactor_code_a0_c_h) == prettify(expection_result_a0_c_h)

--- a/tests/unit/graph_reader/test_graph_refactorer.py
+++ b/tests/unit/graph_reader/test_graph_refactorer.py
@@ -3,16 +3,17 @@ from lineapy.utils.utils import prettify
 
 
 def test_refactor(execute):
-    #    Tests the following non-trivial example:
-    #    a0 --> (a0+=1) \                       /--> (f=c+7)
-    #                    \                     /
-    #                     >--> b=a*2+a0 --> (c=b+3) -------\
-    #                    /                                  \
-    #    (a=1) --> a+=1 /-----> d=a*4 --> e=d+5 --> (e+=6) --\
-    #                      \                                 \
-    #                        \--> a+=1 ------------------------\--> (g = c+e*2)--\
-    #                                                      \                     \
-    #                                                        \---------------------\--> (h=a+g)
+    # a0 --> (a0+=1) \                       /--> (f=c+7)
+    #                 \                     /
+    #                  >--> b=a*2+a0 --> (c=b+3) -------\
+    #                 /                                  \
+    # (a=1) --> a+=1 /-----> d=a*4 --> e=d+5 --> (e+=6) --\
+    #                    \                                 \
+    #                     \--> a+=1 ------------------------\--> (g = c+e*2)--\
+    #                                                    \                     \
+    #                                                     \---------------------\--> (h=a+g) --\
+    #                                                                                           >---> (z.append(h))
+    #                                                                                z = [1] --/
 
     """
     Node with parentheses are artifacts,
@@ -168,3 +169,141 @@ if __name__=="__main__":
         indentation=2, keep_lineapy_save=True
     )
     assert prettify(refactor_code_a0_c_h) == prettify(expection_result_a0_c_h)
+
+
+def test_module_import(execute):
+    code = """import lineapy
+art = {}
+import pandas
+df = pandas.DataFrame({'a':[1,2]})
+art['df'] = lineapy.save(df,'df')
+
+df2 = pandas.concat([df,df])
+art['df2'] = lineapy.save(df2,'df2')
+    """
+    expection_result_all = """import pandas
+
+def get_df():
+    df = pandas.DataFrame({"a": [1, 2]})
+    return df
+
+def get_df2(df):
+    df2 = pandas.concat([df, df])
+    return df2
+
+def pipeline():
+    df = get_df()
+    df2 = get_df2(df)
+    return df, df2
+
+if __name__=="__main__":
+    pipeline()
+"""
+
+    res = execute(code, snapshot=False)
+    art = res.values["art"]
+    assert len(res.values["art"]) == 2
+
+    sas = SessionArtifacts(list(art.values()))
+    refactor_code = sas.get_session_module_definition()
+    assert prettify(refactor_code) == prettify(expection_result_all)
+
+
+def test_module_import_alias(execute):
+    code = """import lineapy
+art = {}
+import pandas as pd
+df = pd.DataFrame({'a':[1,2]})
+art['df'] = lineapy.save(df,'df')
+
+df2 = pd.concat([df,df])
+art['df2'] = lineapy.save(df2,'df2')
+    """
+    expection_result_all = """import pandas as pd
+
+def get_df():
+    df = pd.DataFrame({"a": [1, 2]})
+    return df
+
+def get_df2(df):
+    df2 = pd.concat([df, df])
+    return df2
+
+def pipeline():
+    df = get_df()
+    df2 = get_df2(df)
+    return df, df2
+
+if __name__=="__main__":
+    pipeline()
+"""
+
+    res = execute(code, snapshot=False)
+    art = res.values["art"]
+    assert len(res.values["art"]) == 2
+
+    sas = SessionArtifacts(list(art.values()))
+    refactor_code = sas.get_session_module_definition()
+    assert prettify(refactor_code) == prettify(expection_result_all)
+
+
+def test_module_import_from(execute):
+    code = """import lineapy
+art = {}
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+# Load train data
+train_df = pd.read_csv("https://raw.githubusercontent.com/LineaLabs/lineapy/main/examples/tutorials/data/iris.csv")
+# Initiate the model
+mod = LinearRegression()
+# Fit the model
+mod.fit(
+    X=train_df[["petal.width"]],
+    y=train_df["petal.length"],
+)
+# Save the fitted model as an artifact
+art['model'] = lineapy.save(mod, "iris_model")
+# Load data to predict (assume it comes from a different source)
+pred_df = pd.read_csv("https://raw.githubusercontent.com/LineaLabs/lineapy/main/examples/tutorials/data/iris.csv")
+# Make predictions
+petal_length_pred =  mod.predict(X=pred_df[["petal.width"]])
+# Save the predictions
+art['pred'] = lineapy.save(petal_length_pred, "iris_petal_length_pred")
+    """
+    expection_result_all = """import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+def get_iris_model():
+    train_df = pd.read_csv(
+        "https://raw.githubusercontent.com/LineaLabs/lineapy/main/examples/tutorials/data/iris.csv"
+    )
+    mod = LinearRegression()
+    mod.fit(
+        X=train_df[["petal.width"]],
+        y=train_df["petal.length"],
+    )
+    return mod
+
+def get_iris_petal_length_pred(mod):
+    pred_df = pd.read_csv(
+        "https://raw.githubusercontent.com/LineaLabs/lineapy/main/examples/tutorials/data/iris.csv"
+    )
+    petal_length_pred = mod.predict(X=pred_df[["petal.width"]])
+    return petal_length_pred
+
+def pipeline():
+    mod = get_iris_model()
+    petal_length_pred = get_iris_petal_length_pred(mod)
+    return mod, petal_length_pred
+
+if __name__=="__main__":
+    pipeline()
+"""
+
+    res = execute(code, snapshot=False)
+    art = res.values["art"]
+    assert len(res.values["art"]) == 2
+
+    sas = SessionArtifacts(list(art.values()))
+    refactor_code = sas.get_session_module_definition()
+    assert prettify(refactor_code) == prettify(expection_result_all)

--- a/tests/unit/graph_reader/test_graph_refactorer.py
+++ b/tests/unit/graph_reader/test_graph_refactorer.py
@@ -1,0 +1,110 @@
+from lineapy.graph_reader.graph_refactorer import SessionArtifacts
+from lineapy.utils.utils import prettify
+
+
+def test_refactor(execute):
+    """
+    Tests that calling a mutate function in an exec properly tracks it.
+    """
+    code = """import lineapy
+art = {}
+a0 = 0
+a0 += 1
+art['a0'] = lineapy.save(a0,"a0")
+a=1
+art['a'] = lineapy.save(a, "a")
+
+a+=1
+b = a*2 + a0
+c = b+3
+d = a*4
+e = d+5
+e+=6
+art['c'] = lineapy.save(c, "c")
+art['e'] = lineapy.save(e, "e")
+
+f = c+7
+art['f'] = lineapy.save(f, "f")
+a+=1
+g = c+e *2
+art['g2'] = lineapy.save(g,'g2')
+h = a+g
+art['h'] = lineapy.save(h,'h')
+"""
+
+    expection_result = """def get_a():
+  a = 1
+  
+  return a
+
+def get_a0():
+  a0 = 0
+  a0 += 1
+  
+  return a0
+
+def get_a_for_artifact_c_and_downstream(a):
+  a += 1
+  
+  return a
+
+def get_c(a, a0):
+  b = a * 2 + a0
+  c = b + 3
+  
+  return c
+
+def get_f(c):
+  f = c + 7
+  
+  return f
+
+def get_e(a):
+  d = a * 4
+  e = d + 5
+  e += 6
+  
+  return e
+
+def get_g2(c, e):
+  g = c + e * 2
+  
+  return g
+
+def get_h(a, g):
+  a += 1
+  h = a + g
+  
+  return h
+
+def pipeline():
+  a = get_a()
+  lineapy.save(a, "a")
+  a0 = get_a0()
+  lineapy.save(a0, "a0")
+  a = get_a_for_artifact_c_and_downstream(a)
+  c = get_c(a, a0)
+  lineapy.save(c, "c")
+  f = get_f(c)
+  lineapy.save(f, "f")
+  e = get_e(a)
+  lineapy.save(e, "e")
+  g = get_g2(c, e)
+  lineapy.save(g, "g2")
+  h = get_h(a, g)
+  lineapy.save(h, "h")
+  return a, a0, c, f, e, g, h
+
+if __name__=="__main__":
+  pipeline()
+    """
+
+    res = execute(code, snapshot=False)
+    art = res.values["art"]
+    assert len(res.values["art"]) == 7
+
+    sas = SessionArtifacts(list(art.values()))
+    refactor_code = sas.get_session_module_definition(
+        indentation=2, keep_lineapy_save=True
+    )
+    assert prettify(refactor_code) == prettify(expection_result)

--- a/tests/unit/graph_reader/test_graph_refactorer.py
+++ b/tests/unit/graph_reader/test_graph_refactorer.py
@@ -4,7 +4,7 @@ from lineapy.utils.utils import prettify
 
 def test_refactor(execute):
     """
-    Tests that calling a mutate function in an exec properly tracks it.
+    Tests a non-trivial examples
     """
     code = """import lineapy
 art = {}
@@ -34,47 +34,39 @@ art['h'] = lineapy.save(h,'h')
 
     expection_result = """def get_a():
   a = 1
-  
   return a
 
 def get_a0():
   a0 = 0
   a0 += 1
-  
   return a0
 
 def get_a_for_artifact_c_and_downstream(a):
   a += 1
-  
   return a
 
 def get_c(a, a0):
   b = a * 2 + a0
   c = b + 3
-  
   return c
 
 def get_f(c):
   f = c + 7
-  
   return f
 
 def get_e(a):
   d = a * 4
   e = d + 5
   e += 6
-  
   return e
 
 def get_g2(c, e):
   g = c + e * 2
-  
   return g
 
 def get_h(a, g):
   a += 1
   h = a + g
-  
   return h
 
 def pipeline():

--- a/tests/unit/graph_reader/test_graph_refactorer.py
+++ b/tests/unit/graph_reader/test_graph_refactorer.py
@@ -3,19 +3,19 @@ from lineapy.utils.utils import prettify
 
 
 def test_refactor(execute):
-    """
-    Tests the following non-trivial example: 
-    a0 --> (a0+=1) \                       /--> (f=c+7)
-                    \                     /
-                     >--> b=a*2+a0 --> (c=b+3) -------\ 
-                    /                                  \
-    (a=1) --> a+=1 /-----> d=a*4 --> e=d+5 --> (e+=6) --\
-                      \                                 \  
-                        \--> a+=1 ------------------------\--> (g = c+e*2)--\
-                                                      \                     \
-                                                        \---------------------\--> (h=a+g)
+    #    Tests the following non-trivial example:
+    #    a0 --> (a0+=1) \                       /--> (f=c+7)
+    #                    \                     /
+    #                     >--> b=a*2+a0 --> (c=b+3) -------\
+    #                    /                                  \
+    #    (a=1) --> a+=1 /-----> d=a*4 --> e=d+5 --> (e+=6) --\
+    #                      \                                 \
+    #                        \--> a+=1 ------------------------\--> (g = c+e*2)--\
+    #                                                      \                     \
+    #                                                        \---------------------\--> (h=a+g)
 
-    Node with parentheses are artifacts, 
+    """
+    Node with parentheses are artifacts,
     """
     code = """import lineapy
 art = {}
@@ -41,6 +41,9 @@ g = c+e *2
 art['g2'] = lineapy.save(g,'g2')
 h = a+g
 art['h'] = lineapy.save(h,'h')
+z = [1]
+z.append(h)
+art['z'] = lineapy.save(z,'z')
 """
 
     expection_result_all = """def get_a():
@@ -80,6 +83,11 @@ def get_h(a, g):
   h = a + g
   return h
 
+def get_z(h):
+  z = [1]
+  z.append(h)
+  return z
+
 def pipeline():
   a = get_a()
   lineapy.save(a, "a")
@@ -96,7 +104,9 @@ def pipeline():
   lineapy.save(g, "g2")
   h = get_h(a, g)
   lineapy.save(h, "h")
-  return a, a0, c, f, e, g, h
+  z = get_z(h)
+  lineapy.save(z, "z")
+  return a, a0, c, f, e, g, h, z
 
 if __name__=="__main__":
   pipeline()
@@ -104,7 +114,7 @@ if __name__=="__main__":
 
     res = execute(code, snapshot=False)
     art = res.values["art"]
-    assert len(res.values["art"]) == 7
+    assert len(res.values["art"]) == 8
 
     sas = SessionArtifacts(list(art.values()))
     refactor_code = sas.get_session_module_definition(


### PR DESCRIPTION
# Description

Introduce two new LineaPy APIs(not finalized yet) related to parameter refactoring.

## A function that takes user-defined input parameters and returns a list of artifacts calculated by the same process

```
lineapy.get_function(
    artifact_list=[art_name1, art_name2, ...], 
    input_parameters=[var1, var2, ...]
) -> Callable
```

This return a python function that takes user-selected input variables and returns user-selected artifacts.

* Benefits
    + Easy to adjust input/return variables.
    + It is the same function used in `to_pipeline` and data scientists can validate the output pipeline in the notebook directly.
    + Extend LineaPy user base to everyone who writes a for-loop.

## Module definition 

```
lineapy.get_module_definition(
    artifact_list=[art_name1, art_name2, ...], 
    input_parameters=[var1, var2, ...]
) -> str
```

This returns the entire module definition as a string. 
Note, this should be the same as the `module.py` generated from the current `to_pipeline`.

* Benefits
    + Easily examine the output result directly in the notebook.
    + Export to the filesystem for other applications.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

No new tests have been added. Do not merge!
