### PR TITLE
Pin SQLAlchemy to at least v1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ VERSION = version("lineapy/__init__.py")
 minimal_requirement = [
     "click>=8.0.0",
     "pydantic",
-    "SQLAlchemy",
+    "SQLAlchemy>=1.4",
     "networkx",
     "rich",
     "pyyaml",


### PR DESCRIPTION
Fix LIN-496

`Inspector.has_table` doesn't exist until version 1.4.

(note: on versions below 1.4 we could use `Engine.has_table` instead)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
