### PR TITLE
Add Django License information

### DIFF
--- a/lineapy/plugins/utils.py
+++ b/lineapy/plugins/utils.py
@@ -29,12 +29,17 @@ def load_plugin_template(template_name: str) -> Template:
 
 def slugify(value, allow_unicode=False):
     """
-    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    Taken from
+    https://github.com/django/django/blob/master/django/utils/text.py
 
     Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
     dashes to single dashes. Remove characters that aren't alphanumerics,
     underscores, or hyphens. Convert to lowercase. Also strip leading and
-    trailing whitespace, dashes, and underscores. Lastly, replace all dashes with underscores.
+    trailing whitespace, dashes, and underscores.
+    Lastly, replace all dashes with underscores.
+
+    Copyright (c) Django Software Foundation and individual contributors.
+    All rights reserved.
     """
     value = str(value)
     if allow_unicode:


### PR DESCRIPTION
# Description

In order to reuse slugify from the Django codebase, the copyright
notice must be redistributed as well.
