### PR TITLE
Make try_to_write_to_pickle private

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -99,7 +99,7 @@ def save(reference: object, name: str) -> LineaArtifact:
         # TODO add version or timestamp to allow saving of multiple pickle files for the same node id
         # pickles value of artifact and saves to filesystem
         pickle_name = _pickle_name(value_node_id, execution_id)
-        try_write_to_pickle(reference, pickle_name)
+        _try_write_to_pickle(reference, pickle_name)
 
         # adds reference to pickled file inside database
         db.write_node_value(
@@ -206,7 +206,7 @@ def _pickle_name(node_id: LineaID, execution_id: LineaID) -> str:
     return f"pre-{slugify(hash(node_id + execution_id))}-post.pkl"
 
 
-def try_write_to_pickle(value: object, filename: str) -> None:
+def _try_write_to_pickle(value: object, filename: str) -> None:
     """
     Saves the value to a random file inside linea folder. This file path is returned and eventually saved to the db.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,7 +340,7 @@ def move_artifact_storage_dir():
 
 
 @pytest.fixture
-@patch("lineapy.api.api.try_write_to_pickle", return_value=None)
+@patch("lineapy.api.api._try_write_to_pickle", return_value=None)
 @patch("lineapy.api.api._pickle_name", return_value="pickle-sample.pkl")
 def housing_tracer(_pickle_name, try_write_to_pickle, execute):
     tests_dir = Path(__file__).parent

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import pickle
 from pathlib import Path
 
-from lineapy.api.api import try_write_to_pickle
+from lineapy.api.api import _try_write_to_pickle
 from lineapy.api.api_classes import LineaArtifact
 from lineapy.utils.config import options
 
@@ -40,7 +40,7 @@ if True:
 
 
 def test_write_to_pickle():
-    try_write_to_pickle(42, "test_pickle")
+    _try_write_to_pickle(42, "test_pickle")
     pickle_path = (
         Path(options.safe_get("artifact_storage_dir")) / "test_pickle"
     )

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -42,7 +42,7 @@ def test_slice_artifact_inline(run_cell):
 
 
 @pytest.mark.slow
-@patch("lineapy.api.api.try_write_to_pickle", return_value=None)
+@patch("lineapy.api.api._try_write_to_pickle", return_value=None)
 @patch("lineapy.api.api._pickle_name", return_value="pickle-sample.pkl")
 def test_to_airflow_pymodule(
     _pickle_name, try_write_to_pickle, python_snapshot, run_cell
@@ -67,7 +67,7 @@ def test_to_airflow_dagmodule(python_snapshot, run_cell):
 
 
 @pytest.mark.slow
-@patch("lineapy.api.api.try_write_to_pickle", return_value=None)
+@patch("lineapy.api.api._try_write_to_pickle", return_value=None)
 @patch("lineapy.api.api._pickle_name", return_value="pickle-sample.pkl")
 def test_to_airflow_with_config_pymodule(
     _pickle_name, try_write_to_pickle, python_snapshot, run_cell


### PR DESCRIPTION
# Description

Make try_write_to_pickle in api.py a private method as it is not meant to be user-facing.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
pre-commit checks all passed.