### PR TITLE
Fix error while running a pure comment cell

### DIFF
--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -45,24 +45,27 @@ def transform(
         ASTTokens(code, parse=False, tree=tree)
         SourceGiver().transform(tree)
 
-    for stmt in tree.body:
-        res = None
-        for trans in transformers:
-            # print(ast.dump(stmt))
-            res = trans.visit(stmt)
-            # or some other statement to figure out whether the node is properly processed or not
-            if res is not None:
-                stmt = res  # swap the node with the output of previous transformer and use that for further calls
-        # if no transformers can process it - we'll change node transformer to not throw not implemented exception
-        # so that it can be extended and move it here.
-        if isinstance(res, ast.AST):
-            raise NotImplementedError(
-                f"Don't know how to transform {type(stmt).__name__}"
-            )
-        # FIXME - this is needed for jupyter, will revisit this after prototype phase.
-        last_statement_result = res  # type: ignore
-    # replaced by the for loop above
-    # node_transformer.visit(tree)
+    if len(tree.body) > 0:
+        for stmt in tree.body:
+            res = None
+            for trans in transformers:
+                # print(ast.dump(stmt))
+                res = trans.visit(stmt)
+                # or some other statement to figure out whether the node is properly processed or not
+                if res is not None:
+                    stmt = res  # swap the node with the output of previous transformer and use that for further calls
+            # if no transformers can process it - we'll change node transformer to not throw not implemented exception
+            # so that it can be extended and move it here.
+            if isinstance(res, ast.AST):
+                raise NotImplementedError(
+                    f"Don't know how to transform {type(stmt).__name__}"
+                )
+            # FIXME - this is needed for jupyter, will revisit this after prototype phase.
+            last_statement_result = res  # type: ignore
+        # replaced by the for loop above
+        # node_transformer.visit(tree)
 
-    tracer.db.commit()
-    return last_statement_result  # type: ignore
+        tracer.db.commit()
+        return last_statement_result  # type: ignore
+
+    return None


### PR DESCRIPTION
# Description

Fix the following error while you run a cell with only comment in Jupyter Notebooks.

The `ast.parse` object is an empty list if there are only comments in the cell. That's why you see 

```
UnboundLocalError: local variable 'last_statement_result' referenced before assignment
```

Fixes # (issue)

Quick fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pass all existing tests and validate the result(no error for a comment-only cell) in the Jupyter notebook.