### PR TITLE
LIN-559 Fix storage_options and artifact_store_dir config update order

### DIFF
--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -70,13 +70,13 @@ class lineapy_config:
             logging_level = logging._levelToName[int(logging_level)]
 
         self.home_dir = Path(home_dir).expanduser()
+        self.storage_options = storage_options
         self.database_url = database_url
         self.artifact_storage_dir = artifact_storage_dir
         self.customized_annotation_folder = customized_annotation_folder
         self.do_not_track = do_not_track
         self.logging_level = logging_level
         self.logging_file = logging_file
-        self.storage_options = storage_options
         self.is_demo = is_demo
 
         # config file
@@ -108,6 +108,9 @@ class lineapy_config:
             config_value = _read_config.get(key, None)
             # set config value based on environ -> config  -> default
             if env_var_value is not None:
+                # special logic to handle serialization of storage options
+                if key == "storage_options":
+                    env_var_value = json.loads(env_var_value)
                 self.set(key, env_var_value, verbose=False)
             elif config_value is not None:
                 self.set(key, config_value, verbose=False)
@@ -145,14 +148,24 @@ class lineapy_config:
                     )
             else:
                 self.__dict__[key] = value
-                os.environ[f"LINEAPY_{key.upper()}"] = str(value)
+                # special logic to handle serialization of storage options
+                if key == "storage_options":
+                    os.environ[f"LINEAPY_{key.upper()}"] = json.dumps(value)
+                else:
+                    os.environ[f"LINEAPY_{key.upper()}"] = str(value)
 
             # Send a heartbeat to artifact_storage_dir
             if key == "artifact_storage_dir":
+                storage_options = (
+                    {}
+                    if self.storage_options is None
+                    else self.storage_options
+                )
                 with fsspec.open(
                     str(self.safe_get("artifact_storage_dir")).rstrip("/")
                     + "/heartbeat",
                     "w",
+                    **storage_options,
                 ) as f:
                     f.write(
                         datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")


### PR DESCRIPTION
# Description

Fixes connection errors using `storage_options` and `artifact_store_dir` configured to remote directories. 
Changes

- Move `self.storage_options` up in the list of config attributes. This is to guarantee that it is updated before `artifact_store_dir` which requires it as a dependency. This move fixes the issue because Config updates using `self.__dict__` which goes through attributes in order of definition [documented here PEP 520](https://peps.python.org/pep-0520/ ) 
- Add storage option to `fsspec.open` when writing a heartbeat when `artifact_storage_dir` is first specified. This is so that the newly set storage options apply. 
- Fix setting env variables on lineapy config `set` for `storage_options` and loading from env variables to serialize the storage options to string correctly. The code originally would load `storage_options` as a string in jupyter and ipython environments which use environment variables, and connecting to remote directories would not work. 

Fixes LIN-559

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in linea-platform data-science-sandbox demo environment with minio hosted remote storage
