### PR TITLE
Fix tests/test_script.py::test_config_order

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -119,6 +119,7 @@ def test_config_order():
     assert generated_config["logging_level"] == "NOTSET"
 
     # Reset to original env variables
+    clean_lineapy_env_var()
     for k, v in existing_lineapy_env.items():
         os.environ[k] = v
 


### PR DESCRIPTION
# Description

Fix tests/test_script.py::test_config_order which did not reset the environment variables correctly causing multiple following tests to fail.

Adding `clean_lineapy_env_var` line before function resets env variables using `existing_lineapy_env` prevents env variables set from the test from carrying over and affecting subsequent tests. 

## Type of change

- [X] Test fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run pytests
