### PR TITLE
Add annotation for sklearn.BaseEstimator.fit_transform

### DIFF
--- a/lineapy/annotations/external/sklearn.annotations.yaml
+++ b/lineapy/annotations/external/sklearn.annotations.yaml
@@ -9,3 +9,12 @@
         - views:
             - self_ref: SELF_REF
             - result: RESULT
+    - criteria:
+        class_instance: BaseEstimator
+        class_method_name: fit_transform
+      side_effects:
+        - mutated_value:
+            self_ref: SELF_REF
+        - views:
+            - self_ref: SELF_REF
+            - result: RESULT


### PR DESCRIPTION
# Description

Add annotation for `sklearn.BaseEstimator.fit_transform` to fix incorrect sliced result for `pipeline` object in following example

```
import pandas as pd
from sklearn.pipeline import Pipeline
from sklearn.preprocessing import OneHotEncoder

data = pd.DataFrame({"a": ["a", "a", "A"], "b": ["b", "BB", "B"]})   # ignored before new annotation
pipeline = Pipeline([("one_hot_cat", OneHotEncoder())])
pipelineddata = pipeline.fit_transform(data)                         # ignored before new annotation
```

Two lines described in the example are missing from the `get_code` if we save `pipeline` as an artifact.

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pass all existing tests.