### PR TITLE
Fix Exception raising in Lineapy

### DIFF
--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -188,7 +188,10 @@ class NodeTransformer(ast.NodeTransformer):
             return self.tracer.literal(node.value, self.get_source(node))
 
     def visit_Raise(self, node: ast.Raise) -> None:
-        return super().visit_Raise(node)
+        try:
+            return super().visit_Raise(node)
+        except AttributeError:
+            self._exec_statement(node)
 
     def visit_Module(self, node: ast.Module) -> Any:
         for stmt in node.body:

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -187,9 +187,6 @@ class NodeTransformer(ast.NodeTransformer):
         else:
             return self.tracer.literal(node.value, self.get_source(node))
 
-    def visit_Raise(self, node: ast.Raise) -> None:
-        self._exec_statement(node)
-
     def visit_Module(self, node: ast.Module) -> Any:
         for stmt in node.body:
             self.last_statement_result = self.visit(stmt)

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -188,9 +188,10 @@ class NodeTransformer(ast.NodeTransformer):
             return self.tracer.literal(node.value, self.get_source(node))
 
     def visit_Raise(self, node: ast.Raise) -> None:
-        try:
+        if sys.version_info >= (3, 9):
+            print(super().visit_Raise)
             return super().visit_Raise(node)
-        except AttributeError:
+        else:
             self._exec_statement(node)
 
     def visit_Module(self, node: ast.Module) -> Any:

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -188,11 +188,7 @@ class NodeTransformer(ast.NodeTransformer):
             return self.tracer.literal(node.value, self.get_source(node))
 
     def visit_Raise(self, node: ast.Raise) -> None:
-        if sys.version_info >= (3, 9):
-            print(super().visit_Raise)
-            return super().visit_Raise(node)
-        else:
-            self._exec_statement(node)
+        self._exec_statement(node)
 
     def visit_Module(self, node: ast.Module) -> Any:
         for stmt in node.body:

--- a/tests/end_to_end/test_misc.py
+++ b/tests/end_to_end/test_misc.py
@@ -124,8 +124,8 @@ class TestEndToEnd:
         # Shows up twice due to re-exeuction
         assert captured.out == "10\n10\n"
 
-    def test_raise(self, execute, capsys):
-        with pytest.raises(UserException):
+    def test_raise(self, execute):
+        with pytest.raises(UserException, match="OSError"):
             RAISE_CODE = "raise OSError()"
             execute(RAISE_CODE)
 

--- a/tests/end_to_end/test_misc.py
+++ b/tests/end_to_end/test_misc.py
@@ -123,6 +123,14 @@ class TestEndToEnd:
         # Shows up twice due to re-exeuction
         assert captured.out == "10\n10\n"
 
+    def test_raise(self, execute, capsys):
+        RAISE_CODE = "raise Exception()"
+        execute(RAISE_CODE)
+        captured = capsys.readouterr()
+        last_line = "\n".split(captured)[-1].strip()
+
+        assert last_line == "Exception:"
+
     def test_chained_attributes(self, execute):
         """
         https://github.com/LineaLabs/lineapy/issues/161

--- a/tests/end_to_end/test_misc.py
+++ b/tests/end_to_end/test_misc.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from lineapy.api.api import save
+from lineapy.exceptions.user_exception import UserException
 from tests.util import CSV_CODE, IMAGE_CODE
 
 publish_name = "testing artifact publish"
@@ -124,12 +125,9 @@ class TestEndToEnd:
         assert captured.out == "10\n10\n"
 
     def test_raise(self, execute, capsys):
-        RAISE_CODE = "raise Exception()"
-        execute(RAISE_CODE)
-        captured = capsys.readouterr()
-        last_line = "\n".split(captured)[-1].strip()
-
-        assert last_line == "Exception:"
+        with pytest.raises(UserException):
+            RAISE_CODE = "raise OSError()"
+            execute(RAISE_CODE)
 
     def test_chained_attributes(self, execute):
         """


### PR DESCRIPTION
# Description

When the user attempts to raise an exception, `visit_Raise` raises an attribute error. This
causes the original exception type to be lost.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`test_raises` has been added
