### PR TITLE
Lin 545 parameterize the python module for framework script pipeline

### DIFF
--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -365,29 +365,29 @@ class ArtifactCollection:
             for x in input_parameters_body
         ]
 
-        module_input_parameters_body = (
-            ""
-            if len(module_input_parameters) == 0
-            else module_input_parameters[0].default_args
-            if len(module_input_parameters) == 1
-            else f"\n{indentation_block}"
-            + f",\n{indentation_block}".join(
-                [param.default_args for param in module_input_parameters]
+        if len(module_input_parameters) == 0:
+            module_input_parameters_body = ""
+            parser_input_parameters = ""
+        elif len(module_input_parameters) == 1:
+            module_input_parameters_body = module_input_parameters[
+                0
+            ].default_args
+            parser_input_parameters = module_input_parameters[0].parser_args
+        else:
+            module_input_parameters_body = (
+                f"\n{indentation_block}"
+                + f",\n{indentation_block}".join(
+                    [param.default_args for param in module_input_parameters]
+                )
+                + ",\n"
             )
-            + ",\n"
-        )
-
-        parser_input_parameters = (
-            ""
-            if len(module_input_parameters) == 0
-            else module_input_parameters[0].parser_args
-            if len(module_input_parameters) == 1
-            else f"\n{indentation_block}"
-            + f",\n{indentation_block}".join(
-                [param.parser_args for param in module_input_parameters]
+            parser_input_parameters = (
+                f"\n{indentation_block}"
+                + f",\n{indentation_block}".join(
+                    [param.parser_args for param in module_input_parameters]
+                )
+                + ",\n"
             )
-            + ",\n"
-        )
 
         module_input_parameters_list = [
             param.variable_name for param in module_input_parameters

--- a/lineapy/plugins/jinja_templates/module.jinja
+++ b/lineapy/plugins/jinja_templates/module.jinja
@@ -24,4 +24,5 @@ if __name__ == "__main__":
 {{indentation_block}}artifacts = run_all_sessions({{parser_input_parameters}})
 {% else %}
 {{indentation_block}}artifacts = run_all_sessions()
-{% endif %}
+{% endif -%}
+{{indentation_block}}print(artifacts)

--- a/lineapy/plugins/jinja_templates/module.jinja
+++ b/lineapy/plugins/jinja_templates/module.jinja
@@ -1,3 +1,7 @@
+{% if module_input_parameters != '' %}
+import argparse
+{% endif %}
+
 {{module_imports}}
 
 {{artifact_functions}}
@@ -10,4 +14,15 @@ def run_all_sessions({{module_input_parameters}}):
 {{indentation_block}}return artifacts
 
 if __name__ == "__main__":
-{{indentation_block}}run_all_sessions()
+{% if module_input_parameters != '' -%}
+{{indentation_block}}parser = argparse.ArgumentParser()
+{% for parser_block in parser_blocks -%}
+{{indentation_block}}{{parser_block}}
+{% endfor -%}
+{{indentation_block}}args = parser.parse_args()
+{{indentation_block}}artifacts = run_all_sessions({{parser_input_parameters}})
+{% else %}
+{{indentation_block}}artifacts = run_all_sessions()
+{% endif %}
+{{indentation_block}}print(artifacts)
+

--- a/lineapy/plugins/jinja_templates/module.jinja
+++ b/lineapy/plugins/jinja_templates/module.jinja
@@ -14,7 +14,8 @@ def run_all_sessions({{module_input_parameters}}):
 {{indentation_block}}return artifacts
 
 if __name__ == "__main__":
-{% if module_input_parameters != '' -%}
+{{indentation_block}}# Edit this section to customize the behavior of artifacts
+{%- if module_input_parameters != '' -%}
 {{indentation_block}}parser = argparse.ArgumentParser()
 {% for parser_block in parser_blocks -%}
 {{indentation_block}}{{parser_block}}
@@ -24,5 +25,3 @@ if __name__ == "__main__":
 {% else %}
 {{indentation_block}}artifacts = run_all_sessions()
 {% endif %}
-{{indentation_block}}print(artifacts)
-

--- a/lineapy/plugins/jinja_templates/module.jinja
+++ b/lineapy/plugins/jinja_templates/module.jinja
@@ -15,14 +15,14 @@ def run_all_sessions({{module_input_parameters}}):
 
 if __name__ == "__main__":
 {{indentation_block}}# Edit this section to customize the behavior of artifacts
-{%- if module_input_parameters != '' -%}
+{% if module_input_parameters != '' -%}
 {{indentation_block}}parser = argparse.ArgumentParser()
 {% for parser_block in parser_blocks -%}
 {{indentation_block}}{{parser_block}}
 {% endfor -%}
 {{indentation_block}}args = parser.parse_args()
 {{indentation_block}}artifacts = run_all_sessions({{parser_input_parameters}})
-{% else %}
+{% else -%}
 {{indentation_block}}artifacts = run_all_sessions()
 {% endif -%}
 {{indentation_block}}print(artifacts)

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,6 +36,7 @@ addopts =
     --ignore-glob "lineapy/_alembic/env.py"
     --ignore-glob "tests/unit/graph_reader/expected/*"
     --ignore-glob "tests/unit/plugins/expected/*"
+    --ignore-glob "tests/pipeline_*.py"    
     -m "not airflow and not integration"
     --nbval
     --doctest-modules

--- a/tests/__snapshots__/test_ipython/test_to_airflow_pymodule.py
+++ b/tests/__snapshots__/test_ipython/test_to_airflow_pymodule.py
@@ -22,4 +22,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/__snapshots__/test_ipython/test_to_airflow_pymodule.py
+++ b/tests/__snapshots__/test_ipython/test_to_airflow_pymodule.py
@@ -24,3 +24,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/__snapshots__/test_ipython/test_to_airflow_with_config_pymodule.py
+++ b/tests/__snapshots__/test_ipython/test_to_airflow_with_config_pymodule.py
@@ -22,4 +22,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/__snapshots__/test_ipython/test_to_airflow_with_config_pymodule.py
+++ b/tests/__snapshots__/test_ipython/test_to_airflow_with_config_pymodule.py
@@ -24,3 +24,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -1,6 +1,5 @@
 import pathlib
 import subprocess
-import tempfile
 
 import pytest
 
@@ -192,7 +191,12 @@ def test_two_sessions(
     ],
 )
 def test_module_run(
-    linea_db, execute, input_parameters, input_values, expected_values
+    tmpdir,
+    linea_db,
+    execute,
+    input_parameters,
+    input_values,
+    expected_values,
 ):
     """
     Test the module generated from ArtifactCollection can run with/without
@@ -211,10 +215,7 @@ lineapy.save(b,'add_p')
     ac = ArtifactCollection(
         linea_db, artifact_list, input_parameters=input_parameters
     )
-    temp_folder = tempfile.mkdtemp()
-    temp_module_path = pathlib.Path(
-        temp_folder, "artifactcollection_module.py"
-    )
+    temp_module_path = pathlib.Path(tmpdir, "artifactcollection_module.py")
     with open(temp_module_path, "w") as f:
         f.writelines(ac.generate_module_text())
 

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -1,4 +1,6 @@
 import pathlib
+import subprocess
+import tempfile
 
 import pytest
 
@@ -174,3 +176,55 @@ def test_two_sessions(
                 assert art_pred_session_line_index >= 0
                 # required art session is in from of art session
                 assert art_pred_session_line_index < art_session_line_index
+
+
+@pytest.mark.parametrize(
+    "input_parameters, input_values, expected_values",
+    [
+        pytest.param([], dict(), {"add_p": "ap"}, id="no_input"),
+        pytest.param(["a", "p"], dict(), {"add_p": "ap"}, id="default_value"),
+        pytest.param(
+            ["a", "p"],
+            {"a": "A", "p": "P"},
+            {"add_p": "AP"},
+            id="overriding_value",
+        ),
+    ],
+)
+def test_module_run(
+    linea_db, execute, input_parameters, input_values, expected_values
+):
+    """
+    Test the module generated from ArtifactCollection can run with/without
+    input parameters
+    """
+
+    code = """\n
+import lineapy
+a = "a"
+p = "p"
+b = a+p
+lineapy.save(b,'add_p')
+"""
+    execute(code, snapshot=False)
+    artifact_list = ["add_p"]
+    ac = ArtifactCollection(
+        linea_db, artifact_list, input_parameters=input_parameters
+    )
+    temp_folder = tempfile.mkdtemp()
+    temp_module_path = pathlib.Path(
+        temp_folder, "artifactcollection_module.py"
+    )
+    with open(temp_module_path, "w") as f:
+        f.writelines(ac.generate_module_text())
+
+    cmds = ["python", str(temp_module_path)]
+    # Add input parameter values if specified in cmds
+    for par, val in input_values.items():
+        cmds += [f"--{par}", val]
+
+    p = subprocess.run(cmds, capture_output=True, text=True)
+    assert p.returncode == 0
+    module_run_result = eval(p.stdout)
+    assert all([art in module_run_result.keys() for art in artifact_list])
+    assert all([module_run_result[k] == v for k, v in expected_values.items()])

--- a/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_module.py
+++ b/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_module.py
@@ -45,4 +45,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_module.py
+++ b/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_module.py
@@ -47,3 +47,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_module.py
@@ -43,3 +43,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_module.py
@@ -41,4 +41,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_module.py
@@ -43,3 +43,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_module.py
@@ -41,4 +41,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_module.py
@@ -49,4 +49,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_module.py
@@ -51,3 +51,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_module.py
@@ -40,3 +40,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_module.py
@@ -38,4 +38,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_module.py
@@ -49,4 +49,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_module.py
@@ -51,3 +51,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_module.py
@@ -43,3 +43,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_module.py
@@ -41,4 +41,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_module.py
@@ -43,3 +43,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_module.py
@@ -41,4 +41,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_module.py
@@ -49,4 +49,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_module.py
@@ -51,3 +51,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_module.py
@@ -40,3 +40,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)

--- a/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_module.py
@@ -38,4 +38,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_module.py
@@ -49,4 +49,5 @@ def run_all_sessions():
 
 
 if __name__ == "__main__":
-    run_all_sessions()
+    # Edit this section to customize the behavior of artifacts
+    artifacts = run_all_sessions()

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_module.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_module.py
@@ -51,3 +51,4 @@ def run_all_sessions():
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     artifacts = run_all_sessions()
+    print(artifacts)


### PR DESCRIPTION
# Description

Modify the `module.jinja` to wrap with `argparse`  when input parameters are detected. 


Fixes # (issue)

LIN-545

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Pass all existing tests(with update some snapshot)
- Execute the output module from cli directly, and validate it produce expected value
