### PR TITLE
Fix obtaining version in usage_tracking

### DIFF
--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -19,6 +19,7 @@ from lineapy.execution.context import get_context
 from lineapy.instrumentation.tracer import Tracer
 from lineapy.utils.config import options
 from lineapy.utils.lineabuiltins import db, file_system
+from lineapy.utils.version import __version__
 
 __all__ = [
     "Graph",
@@ -42,8 +43,6 @@ __all__ = [
     "options",
     "__version__",
 ]
-
-__version__ = "0.1.4"
 
 # Create an ipython extension that starts and stops tracing
 # https://ipython.readthedocs.io/en/stable/config/extensions/index.html#writing-extensions

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -2,9 +2,11 @@
 
 try:
     import importlib.metadata as importlib_metadata
+    from importlib.metadata import PackageNotFoundError
 except ModuleNotFoundError:
     # this is for python 3.7
     import importlib_metadata  # type: ignore
+    from importlib_metadata import PackageNotFoundError  # type: ignore
 
 import json
 import logging
@@ -18,11 +20,14 @@ from IPython import get_ipython
 
 from lineapy.utils.analytics.event_schemas import AllEvents
 from lineapy.utils.config import options
+from lineapy.utils.version import __version__
 
 logger = logging.getLogger(__name__)
 
-
-LINEAPY_VERSION: str = importlib_metadata.version("lineapy")
+try:
+    LINEAPY_VERSION: str = importlib_metadata.version("lineapy")
+except PackageNotFoundError:
+    LINEAPY_VERSION = __version__
 
 
 @lru_cache(maxsize=1)

--- a/lineapy/utils/version.py
+++ b/lineapy/utils/version.py
@@ -1,0 +1,5 @@
+# This file contains the package version for Lineapy
+# all other references to the package version should read
+# from this file.
+
+__version__ = "0.1.4"

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ def read(path, encoding="utf-8"):
 
 
 def version(path):
-    """Obtain the package version from a python file e.g. pkg/__init__.py
-    See <https://packaging.python.org/en/latest/single_source_version.html>.
+    """Obtain the package version from a python file
+    See <https://packaging.python.org/en/latest/guides/single-sourcing-package-version/>.
+    Option 3: "Set the value to a __version__ global variable in a dedicated module in your project"
     """
     version_file = read(path)
     version_match = re.search(
@@ -38,7 +39,7 @@ def version(path):
 
 DOWNLOAD_URL = "https://github.com/LineaLabs/lineapy/"
 LICENSE = "Apache License 2.0"
-VERSION = version("lineapy/__init__.py")
+VERSION = version("lineapy/utils/version.py")
 
 minimal_requirement = [
     "click>=8.0.0",


### PR DESCRIPTION
# Description

This diff fixes the acquiring of lineapy version in `usage_tracking.py`. The original method uses `importlib_metadata` which will error out in cases where the module is no installed but is instead being used from source as a library. This is because the environment will not have lineapy installed and is not discoverable by importlib, but is discoverable as a module in `sys.path`. 

If this is the case, any script calling `import lineapy` will fail with 
```
importlib.metadata.PackageNotFoundError: lineapy
```

This PR fixes the issue by adding a try except to read the version directly from the modules internal `__version__` if lineapy is not installed.

This fix required moving the definition of version to its own file to avoid circular dependency.  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Import lineapy in an environment where lineapy is not installed through `sys.path`. 
```
# Line should fail since lineapy is not installed in this test venv
# import lineapy

import sys
sys.path.insert(1, '/Users/andrewcui/.../lineapy')

# Line should work if sys.path is pointed correctly
import lineapy
```

Test version is still picked up correctly by setup.py
Use `python setup.py bdist_wheel` to build wheel. Change version in `version.py`, rebuild and reinstall wheel to verify the version is updated correctly. 