### PR TITLE
Make Lineapy runnable as python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ lineapy python --help
 
 to see available options.
 
+#### Python Module
+
+Lineapy is also a runnable python module. 
+
+```bash
+python -m lineapy --help
+```
+
+and works the same as using the CLI.
+
 ## Usage Reporting
 
 LineaPy collects anonymous usage data that helps our team to improve the product.

--- a/docs/source/fundamentals/interfaces.rst
+++ b/docs/source/fundamentals/interfaces.rst
@@ -79,3 +79,15 @@ We can also use LineaPy as a CLI command. Run:
     $ lineapy python --help
 
 to see available options.
+
+
+Python Module
+-------------
+
+Lineapy is also a runnable python module. 
+
+.. code:: bash
+
+    $ python -m lineapy --help
+
+and works the same as using the CLI.

--- a/lineapy/__main__.py
+++ b/lineapy/__main__.py
@@ -1,0 +1,4 @@
+from lineapy.cli.cli import python
+
+if __name__ == "__main__":
+    python()


### PR DESCRIPTION
# Description

Add `__main__.py` so that lineapy can be run as a module. 

`python -m lineapy <args>` now works the same as `lineapy python <args>`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Run locally
```
python -m lineapy --help
python -m lineapy --slice "p value" tests/housing.py
```