### PR TITLE
LIN-579 Provide user with pipeline test skeleton

### DIFF
--- a/.colab/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
+++ b/.colab/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
@@ -670,6 +670,7 @@
                 }
             ],
             "source": [
+                "\n",
                 "lineapy.to_pipeline(\n",
                 "    artifacts=[\"iris_model\", \"iris_petal_length_pred\"],\n",
                 "    framework=\"SCRIPT\",\n",

--- a/.colab/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
+++ b/.colab/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
@@ -899,6 +899,7 @@
                 }
             ],
             "source": [
+                "\n",
                 "lineapy.to_pipeline(\n",
                 "    artifacts=[\"iris_model\", \"iris_petal_length_pred\"],\n",
                 "    framework=\"AIRFLOW\",\n",

--- a/examples/use_cases/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
+++ b/examples/use_cases/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
@@ -670,6 +670,7 @@
                 }
             ],
             "source": [
+                "#NBVAL_IGNORE_OUTPUT\n",
                 "lineapy.to_pipeline(\n",
                 "    artifacts=[\"iris_model\", \"iris_petal_length_pred\"],\n",
                 "    framework=\"SCRIPT\",\n",

--- a/examples/use_cases/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
+++ b/examples/use_cases/create_a_simple_pipeline/create_a_simple_pipeline.ipynb
@@ -899,6 +899,7 @@
                 }
             ],
             "source": [
+                "#NBVAL_IGNORE_OUTPUT\n",
                 "lineapy.to_pipeline(\n",
                 "    artifacts=[\"iris_model\", \"iris_petal_length_pred\"],\n",
                 "    framework=\"AIRFLOW\",\n",

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -1,13 +1,8 @@
-import os
-import pickle
 import unittest
-import warnings
-from pathlib import Path
-from typing import Callable
 
 from {{ MODULE_NAME }} import (
-{% for FUNC_NAME in FUNCTION_NAMES %}
-    {{ FUNC_NAME }},
+{% for func_data in FUNCTION_METADATA_LIST %}
+    {{ func_data.function_name }},
 {% endfor %}
 )
 
@@ -22,8 +17,11 @@ class {{ TEST_CLASS_NAME }}(unittest.TestCase):
         # Adjust as needed
         pass
 
-{% for TEST_NAME in TEST_CASE_NAMES %}
-    def {{ TEST_NAME }}(self) -> None:
-        # Add test logic
-        pass
+{% for func_data in FUNCTION_METADATA_LIST %}
+    def {{ func_data.test_case_name }}(self) -> None:
+        # Adjust as needed
+        try:
+            {{ func_data.function_name }}()
+        except Exception:
+            pass
 {% endfor %}

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -9,18 +9,26 @@ from {{ MODULE_NAME }} import (
 )
 
 class {{ TEST_CLASS_NAME }}(unittest.TestCase):
+    def setUp(self) -> None:
+        # Add any processes to execute before each test method
+        pass
+
+    def tearDown(self) -> None:
+        # Add any processes to execute after each test method
+        pass
+
     @classmethod
     def setUpClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute before each test class
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute after each test class
         pass
 
 {%- for func_data in FUNCTION_METADATA_LIST %}
-    def {{ func_data.test_case_name }}(self) -> None:
+    def {{ func_data.test_function_name }}(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
     {%- for arg_name in func_data.function_arg_names %}

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -10,25 +10,25 @@ from {{ MODULE_NAME }} import (
 
 class {{ TEST_CLASS_NAME }}(unittest.TestCase):
     def setUp(self) -> None:
-        # Add any processes to execute before each test method
+        # Add any processes to execute before each test in this class
         pass
 
     def tearDown(self) -> None:
-        # Add any processes to execute after each test method
+        # Add any processes to execute after each test in this class
         pass
 
     @classmethod
     def setUpClass(cls) -> None:
-        # Add any processes to execute before each test class
+        # Add any processes to execute once before all tests in this class run
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Add any processes to execute after each test class
+        # Add any processes to execute once after all tests in this class run
         pass
 
 {%- for func_data in FUNCTION_METADATA_LIST %}
-    def {{ func_data.test_function_name }}(self) -> None:
+    def test_{{ func_data.function_name }}(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
     {%- for arg_name in func_data.function_arg_names %}

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -1,9 +1,11 @@
 import unittest
+import warnings
+from typing import Any, Dict
 
 from {{ MODULE_NAME }} import (
-{% for func_data in FUNCTION_METADATA_LIST %}
+{%- for func_data in FUNCTION_METADATA_LIST %}
     {{ func_data.function_name }},
-{% endfor %}
+{%- endfor %}
 )
 
 class {{ TEST_CLASS_NAME }}(unittest.TestCase):
@@ -17,11 +19,18 @@ class {{ TEST_CLASS_NAME }}(unittest.TestCase):
         # Adjust as needed
         pass
 
-{% for func_data in FUNCTION_METADATA_LIST %}
+{%- for func_data in FUNCTION_METADATA_LIST %}
     def {{ func_data.test_case_name }}(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
+    {%- for arg_name in func_data.function_arg_names %}
+        sample_input["{{ arg_name }}"] = None
+    {%- endfor %}
         try:
-            {{ func_data.function_name }}()
+            {{ func_data.function_name }}(**sample_input)
         except Exception:
-            pass
-{% endfor %}
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )
+{%- endfor %}

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -1,0 +1,12 @@
+import os
+import pickle
+import unittest
+import warnings
+from pathlib import Path
+from typing import Callable
+
+from {{ MODULE_NAME }} import (
+{% for FUNC_NAME in FUNCTION_NAMES %}
+    {{ FUNC_NAME }},
+{% endfor %}
+)

--- a/lineapy/plugins/jinja_templates/module_test.jinja
+++ b/lineapy/plugins/jinja_templates/module_test.jinja
@@ -10,3 +10,20 @@ from {{ MODULE_NAME }} import (
     {{ FUNC_NAME }},
 {% endfor %}
 )
+
+class {{ TEST_CLASS_NAME }}(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+{% for TEST_NAME in TEST_CASE_NAMES %}
+    def {{ TEST_NAME }}(self) -> None:
+        # Add test logic
+        pass
+{% endfor %}

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -117,6 +117,10 @@ class BasePipelineWriter:
     def _write_module_test(self) -> None:
         """
         Write out test scaffolding for refactored code in module file.
+        The scaffolding contains placeholders for testing each function
+        in the module file and is meant to be fleshed out by the user
+        to suit their needs. When run out of the box, it simply tests
+        whether each function in the module runs without error.
         """
         # Format components to be passed into file template
         module_name = f"{self.pipeline_name}_module"
@@ -127,7 +131,7 @@ class BasePipelineWriter:
                 "function_arg_names": sorted(
                     [v for v in node_collection.input_variables]
                 ),
-                "test_case_name": f"test_{node_collection.safename}",
+                "test_function_name": f"test_get_{node_collection.safename}",
             }
             for session_artifacts in self.session_artifacts_sorted
             for node_collection in session_artifacts.artifact_nodecollections

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -123,6 +123,9 @@ class BasePipelineWriter:
         function_metadata_list = [
             {
                 "function_name": f"get_{node_collection.safename}",
+                "function_arg_names": sorted(
+                    [v for v in node_collection.input_variables]
+                ),
                 "test_case_name": f"test_{node_collection.safename}",
             }
             for session_artifacts in self.session_artifacts_sorted

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -142,6 +143,12 @@ class BasePipelineWriter:
         file = self.output_dir / f"test_{self.pipeline_name}.py"
         file.write_text(prettify(module_test_text))
         logger.info(f"Generated test scaffolding file: {file}")
+        warnings.warn(
+            "Generated tests are provided as template/scaffolding to start with only; "
+            "please modify them to suit your testing needs. "
+            "Also, tests may involve long compute and/or large storage, "
+            "so please take care in running them."
+        )
 
     def _write_dag(self) -> None:
         """

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -117,26 +117,24 @@ class BasePipelineWriter:
         """
         Write out test scaffolding for refactored code in module file.
         """
-        # Get elements necessary for test writing
-        node_collection_names = [
-            node_collection.safename
-            for session_artifacts in self.session_artifacts_sorted
-            for node_collection in session_artifacts.artifact_nodecollections
-        ]
-
         # Format components to be passed into file template
         module_name = f"{self.pipeline_name}_module"
         test_class_name = f"Test{self.pipeline_name.title().replace('_', '')}"
-        function_names = [f"get_{name}" for name in node_collection_names]
-        test_case_names = [f"test_{name}" for name in node_collection_names]
+        function_metadata_list = [
+            {
+                "function_name": f"get_{node_collection.safename}",
+                "test_case_name": f"test_{node_collection.safename}",
+            }
+            for session_artifacts in self.session_artifacts_sorted
+            for node_collection in session_artifacts.artifact_nodecollections
+        ]
 
         # Fill in file template and write it out
         MODULE_TEST_TEMPLATE = load_plugin_template("module_test.jinja")
         module_test_text = MODULE_TEST_TEMPLATE.render(
             MODULE_NAME=module_name,
-            FUNCTION_NAMES=function_names,
             TEST_CLASS_NAME=test_class_name,
-            TEST_CASE_NAMES=test_case_names,
+            FUNCTION_METADATA_LIST=function_metadata_list,
         )
         file = self.output_dir / f"test_{self.pipeline_name}.py"
         file.write_text(prettify(module_test_text))

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -117,10 +117,16 @@ class BasePipelineWriter:
         """
         Write out test scaffolding for refactored code in module file.
         """
+        node_collection_names = [
+            node_collection.safename
+            for session_artifacts in self.session_artifacts_sorted
+            for node_collection in session_artifacts.artifact_nodecollections
+        ]
+
         MODULE_TEST_TEMPLATE = load_plugin_template("module_test.jinja")
         module_test_text = MODULE_TEST_TEMPLATE.render(
             MODULE_NAME=self.pipeline_name + "_module",
-            FUNCTION_NAMES=["a", "b", "c"],
+            FUNCTION_NAMES=[f"get_{name}" for name in node_collection_names],
         )
         file = self.output_dir / f"test_{self.pipeline_name}.py"
         file.write_text(prettify(module_test_text))

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -117,16 +117,26 @@ class BasePipelineWriter:
         """
         Write out test scaffolding for refactored code in module file.
         """
+        # Get elements necessary for test writing
         node_collection_names = [
             node_collection.safename
             for session_artifacts in self.session_artifacts_sorted
             for node_collection in session_artifacts.artifact_nodecollections
         ]
 
+        # Format components to be passed into file template
+        module_name = f"{self.pipeline_name}_module"
+        test_class_name = f"Test{self.pipeline_name.title().replace('_', '')}"
+        function_names = [f"get_{name}" for name in node_collection_names]
+        test_case_names = [f"test_{name}" for name in node_collection_names]
+
+        # Fill in file template and write it out
         MODULE_TEST_TEMPLATE = load_plugin_template("module_test.jinja")
         module_test_text = MODULE_TEST_TEMPLATE.render(
-            MODULE_NAME=self.pipeline_name + "_module",
-            FUNCTION_NAMES=[f"get_{name}" for name in node_collection_names],
+            MODULE_NAME=module_name,
+            FUNCTION_NAMES=function_names,
+            TEST_CLASS_NAME=test_class_name,
+            TEST_CASE_NAMES=test_case_names,
         )
         file = self.output_dir / f"test_{self.pipeline_name}.py"
         file.write_text(prettify(module_test_text))

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -131,7 +131,6 @@ class BasePipelineWriter:
                 "function_arg_names": sorted(
                     [v for v in node_collection.input_variables]
                 ),
-                "test_function_name": f"test_get_{node_collection.safename}",
             }
             for session_artifacts in self.session_artifacts_sorted
             for node_collection in session_artifacts.artifact_nodecollections

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -15,7 +15,11 @@ from lineapy.plugins.task import (
     TaskGraph,
     TaskGraphEdge,
 )
-from lineapy.plugins.utils import PIP_PACKAGE_NAMES, load_plugin_template
+from lineapy.plugins.utils import (
+    PIP_PACKAGE_NAMES,
+    load_plugin_template,
+    slugify,
+)
 from lineapy.utils.logging_config import configure_logging
 from lineapy.utils.utils import get_system_python_version, prettify
 
@@ -43,7 +47,7 @@ class BasePipelineWriter:
     ) -> None:
         self.artifact_collection = artifact_collection
         self.keep_lineapy_save = keep_lineapy_save
-        self.pipeline_name = pipeline_name
+        self.pipeline_name = slugify(pipeline_name)
         self.output_dir = Path(output_dir)
         self.dag_config = dag_config or {}
 

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -113,6 +113,19 @@ class BasePipelineWriter:
         file.write_text(lib_names_text)
         logger.info(f"Generated requirements file: {file}")
 
+    def _write_module_test(self) -> None:
+        """
+        Write out test scaffolding for refactored code in module file.
+        """
+        MODULE_TEST_TEMPLATE = load_plugin_template("module_test.jinja")
+        module_test_text = MODULE_TEST_TEMPLATE.render(
+            MODULE_NAME=self.pipeline_name + "_module",
+            FUNCTION_NAMES=["a", "b", "c"],
+        )
+        file = self.output_dir / f"test_{self.pipeline_name}.py"
+        file.write_text(prettify(module_test_text))
+        logger.info(f"Generated test scaffolding file: {file}")
+
     def _write_dag(self) -> None:
         """
         Write out framework-specific DAG file
@@ -137,6 +150,7 @@ class BasePipelineWriter:
         """
         self._write_module()
         self._write_requirements()
+        self._write_module_test()
         self._write_dag()
         self._write_docker()
 

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
@@ -1,4 +1,6 @@
 import unittest
+import warnings
+from typing import Any, Dict
 
 from script_pipeline_a0_b0_dependencies_module import get_a0, get_b0
 
@@ -16,14 +18,22 @@ class TestScriptPipelineA0B0Dependencies(unittest.TestCase):
 
     def test_b0(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
         try:
-            get_b0()
+            get_b0(**sample_input)
         except Exception:
-            pass
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )
 
     def test_a0(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
         try:
-            get_a0()
+            get_a0(**sample_input)
         except Exception:
-            pass
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
@@ -6,17 +6,25 @@ from script_pipeline_a0_b0_dependencies_module import get_a0, get_b0
 
 
 class TestScriptPipelineA0B0Dependencies(unittest.TestCase):
+    def setUp(self) -> None:
+        # Add any processes to execute before each test method
+        pass
+
+    def tearDown(self) -> None:
+        # Add any processes to execute after each test method
+        pass
+
     @classmethod
     def setUpClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute before each test class
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute after each test class
         pass
 
-    def test_b0(self) -> None:
+    def test_get_b0(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
         try:
@@ -27,7 +35,7 @@ class TestScriptPipelineA0B0Dependencies(unittest.TestCase):
                 "Please adapt the test as needed."
             )
 
-    def test_a0(self) -> None:
+    def test_get_a0(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
         try:

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
@@ -7,21 +7,21 @@ from script_pipeline_a0_b0_dependencies_module import get_a0, get_b0
 
 class TestScriptPipelineA0B0Dependencies(unittest.TestCase):
     def setUp(self) -> None:
-        # Add any processes to execute before each test method
+        # Add any processes to execute before each test in this class
         pass
 
     def tearDown(self) -> None:
-        # Add any processes to execute after each test method
+        # Add any processes to execute after each test in this class
         pass
 
     @classmethod
     def setUpClass(cls) -> None:
-        # Add any processes to execute before each test class
+        # Add any processes to execute once before all tests in this class run
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Add any processes to execute after each test class
+        # Add any processes to execute once after all tests in this class run
         pass
 
     def test_get_b0(self) -> None:

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/test_script_pipeline_a0_b0_dependencies.py
@@ -1,0 +1,29 @@
+import unittest
+
+from script_pipeline_a0_b0_dependencies_module import get_a0, get_b0
+
+
+class TestScriptPipelineA0B0Dependencies(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+    def test_b0(self) -> None:
+        # Adjust as needed
+        try:
+            get_b0()
+        except Exception:
+            pass
+
+    def test_a0(self) -> None:
+        # Adjust as needed
+        try:
+            get_a0()
+        except Exception:
+            pass

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
@@ -10,17 +10,25 @@ from script_pipeline_housing_w_dependencies_module import (
 
 
 class TestScriptPipelineHousingWDependencies(unittest.TestCase):
+    def setUp(self) -> None:
+        # Add any processes to execute before each test method
+        pass
+
+    def tearDown(self) -> None:
+        # Add any processes to execute after each test method
+        pass
+
     @classmethod
     def setUpClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute before each test class
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Adjust as needed
+        # Add any processes to execute after each test class
         pass
 
-    def test_assets_for_artifact_y_and_downstream(self) -> None:
+    def test_get_assets_for_artifact_y_and_downstream(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
         try:
@@ -31,7 +39,7 @@ class TestScriptPipelineHousingWDependencies(unittest.TestCase):
                 "Please adapt the test as needed."
             )
 
-    def test_y(self) -> None:
+    def test_get_y(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
         sample_input["assets"] = None
@@ -43,7 +51,7 @@ class TestScriptPipelineHousingWDependencies(unittest.TestCase):
                 "Please adapt the test as needed."
             )
 
-    def test_p_value(self) -> None:
+    def test_get_p_value(self) -> None:
         # Adjust as needed
         sample_input: Dict[str, Any] = {}
         sample_input["assets"] = None

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
@@ -1,4 +1,6 @@
 import unittest
+import warnings
+from typing import Any, Dict
 
 from script_pipeline_housing_w_dependencies_module import (
     get_assets_for_artifact_y_and_downstream,
@@ -20,21 +22,36 @@ class TestScriptPipelineHousingWDependencies(unittest.TestCase):
 
     def test_assets_for_artifact_y_and_downstream(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
         try:
-            get_assets_for_artifact_y_and_downstream()
+            get_assets_for_artifact_y_and_downstream(**sample_input)
         except Exception:
-            pass
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )
 
     def test_y(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
+        sample_input["assets"] = None
         try:
-            get_y()
+            get_y(**sample_input)
         except Exception:
-            pass
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )
 
     def test_p_value(self) -> None:
         # Adjust as needed
+        sample_input: Dict[str, Any] = {}
+        sample_input["assets"] = None
+        sample_input["y"] = None
         try:
-            get_p_value()
+            get_p_value(**sample_input)
         except Exception:
-            pass
+            warnings.warn(
+                "Test failed, but this may be due to our limited templating. "
+                "Please adapt the test as needed."
+            )

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
@@ -11,21 +11,21 @@ from script_pipeline_housing_w_dependencies_module import (
 
 class TestScriptPipelineHousingWDependencies(unittest.TestCase):
     def setUp(self) -> None:
-        # Add any processes to execute before each test method
+        # Add any processes to execute before each test in this class
         pass
 
     def tearDown(self) -> None:
-        # Add any processes to execute after each test method
+        # Add any processes to execute after each test in this class
         pass
 
     @classmethod
     def setUpClass(cls) -> None:
-        # Add any processes to execute before each test class
+        # Add any processes to execute once before all tests in this class run
         pass
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Add any processes to execute after each test class
+        # Add any processes to execute once after all tests in this class run
         pass
 
     def test_get_assets_for_artifact_y_and_downstream(self) -> None:

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/test_script_pipeline_housing_w_dependencies.py
@@ -1,0 +1,40 @@
+import unittest
+
+from script_pipeline_housing_w_dependencies_module import (
+    get_assets_for_artifact_y_and_downstream,
+    get_p_value,
+    get_y,
+)
+
+
+class TestScriptPipelineHousingWDependencies(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Adjust as needed
+        pass
+
+    def test_assets_for_artifact_y_and_downstream(self) -> None:
+        # Adjust as needed
+        try:
+            get_assets_for_artifact_y_and_downstream()
+        except Exception:
+            pass
+
+    def test_y(self) -> None:
+        # Adjust as needed
+        try:
+            get_y()
+        except Exception:
+            pass
+
+    def test_p_value(self) -> None:
+        # Adjust as needed
+        try:
+            get_p_value()
+        except Exception:
+            pass


### PR DESCRIPTION
# Summary

As a first story of the `Enable Pipeline Testing` epic, this PR implements a bare minimal scaffolding for pipeline testing, where:

- Each function in the module gets a corresponding test case
- Each test case simply calls the tested function within a try-catch block
- Comments are provided to instruct the user to adjust test logic as needed

Though very simple, this bare minimal templating may still deliver some value to the user as it provides them a starting point for pipeline testing (better to have something than nothing). Again, this is a first story for the epic, and the plan is to improve on it with subsequent stories.

# Changes

- [x] Add a new Jinja template for rudimentary scaffolding of pipeline testing
- [x] Add a new (hidden) method to `BasePipelineWriter` to fill in the Jinja template
- [x] Add new unit tests for the pipeline test scaffolding

# Testing

Unit tests were added to cover the new functionality.

# Ticket(s)

- [LIN-579](https://linea.atlassian.net/browse/LIN-579)