### PR TITLE
LIN-588 Add prophet annotations

### DIFF
--- a/lineapy/annotations/external/prophet.annotations.yaml
+++ b/lineapy/annotations/external/prophet.annotations.yaml
@@ -1,0 +1,11 @@
+- module: prophet
+  annotations:
+    - criteria:
+        class_instance: Prophet
+        class_method_name: fit
+      side_effects:
+        - mutated_value:
+            self_ref: SELF_REF
+        - views:
+            - self_ref: SELF_REF
+            - result: RESULT


### PR DESCRIPTION
# Description

Add annotations for `prophet`

Only annotate `prophet.Prophet.fit`

Fixes # (issue)

LIN-588

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Following code(from prophet official website) works

```
%load_ext lineapy

import pandas as pd
from prophet import Prophet

# Python
df = pd.read_csv('https://raw.githubusercontent.com/facebook/prophet/main/examples/example_wp_log_peyton_manning.csv')
df.head()

# Python
m = Prophet()
m.fit(df)

# Python
future = m.make_future_dataframe(periods=365)
future.tail()

# Python
forecast = m.predict(future)
forecast[['ds', 'yhat', 'yhat_lower', 'yhat_upper']].tail()

art = dict()
art['model'] = lineapy.save(m,'prophet_model')
art['future'] = lineapy.save(future, 'prophet_future')
art['forecast'] = lineapy.save(forecast,'prophet_forecast')

print(art['forecast'].get_code())
```

returns 

```
import pandas as pd
from prophet import Prophet

df = pd.read_csv(
    "https://raw.githubusercontent.com/facebook/prophet/main/examples/example_wp_log_peyton_manning.csv"
)
m = Prophet()
m.fit(df)
future = m.make_future_dataframe(periods=365)
forecast = m.predict(future)
```


