### PR TITLE
LIN-565 Add parametrization and artifact reuse to pipeline API and DB

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -399,6 +399,10 @@ def to_pipeline(
     dependencies: TaskGraphEdge
         Task dependencies in graphlib format, e.g., ``{"B": {"A", "C"}}``
         means task A and C are prerequisites for task B.
+        LineaPy is smart enough to figure out dependency relations *within*
+        the same session, so there is no need to specify this type of dependency
+        information; instead, the user is expected to provide dependency information
+        among artifacts across different sessions.
 
     output_dir: str
         Directory path to save DAG and other pipeline files.

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -374,13 +374,13 @@ def artifact_store() -> LineaArtifactStore:
 # we need to ensure all the required files (python module and the dag file) get written to the right place.
 def to_pipeline(
     artifacts: List[str],
-    input_parameters: List[str] = [],
-    reuse_pre_computed_artifacts: List[str] = [],
     framework: str = "SCRIPT",
     pipeline_name: Optional[str] = None,
     dependencies: TaskGraphEdge = {},
-    pipeline_dag_config: Optional[AirflowDagConfig] = {},
     output_dir: str = ".",
+    input_parameters: List[str] = [],
+    reuse_pre_computed_artifacts: List[str] = [],
+    pipeline_dag_config: Optional[AirflowDagConfig] = {},
 ) -> Path:
     """
     Writes the pipeline job to a path on disk.
@@ -389,6 +389,19 @@ def to_pipeline(
     ----------
     artifacts: List[str]
         Names of artifacts to be included in the pipeline.
+
+    framework: str
+        "AIRFLOW" or "SCRIPT". Defaults to "SCRIPT" if not specified.
+
+    pipeline_name: Optional[str]
+        Name of the pipeline.
+
+    dependencies: TaskGraphEdge
+        Task dependencies in graphlib format, e.g., ``{"B": {"A", "C"}}``
+        means task A and C are prerequisites for task B.
+
+    output_dir: str
+        Directory path to save DAG and other pipeline files.
 
     input_parameters: List[str]
         Names of variables to be used as parameters in the pipeline.
@@ -405,24 +418,11 @@ def to_pipeline(
         Names of artifacts in the pipeline for which pre-computed value
         is to be used (rather than recomputing the value).
 
-    framework: str
-        "AIRFLOW" or "SCRIPT". Defaults to "SCRIPT" if not specified.
-
-    pipeline_name: Optional[str]
-        Name of the pipeline.
-
-    dependencies: TaskGraphEdge
-        Task dependencies in graphlib format, e.g., ``{"B": {"A", "C"}}``
-        means task A and C are prerequisites for task B.
-
     pipeline_dag_config: Optional[AirflowDagConfig]
         A dictionary of parameters to configure DAG file to be generated.
         Not applicable for "SCRIPT" framework as it does not generate a separate
         DAG file. For "AIRFLOW" framework, Airflow-native config params such as
         "retries" and "schedule_interval" can be passed in.
-
-    output_dir: str
-        Directory path to save DAG and other pipeline files.
 
     Returns
     -------
@@ -430,30 +430,34 @@ def to_pipeline(
         Directory path where DAG and other pipeline files are saved.
     """
     pipeline = Pipeline(
-        artifacts,
-        input_parameters,
-        reuse_pre_computed_artifacts,
-        pipeline_name,
-        dependencies,
+        artifacts=artifacts,
+        name=pipeline_name,
+        dependencies=dependencies,
+        input_parameters=input_parameters,
+        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
     pipeline.save()
-    return pipeline.export(framework, output_dir, pipeline_dag_config)
+    return pipeline.export(
+        framework=framework,
+        output_dir=output_dir,
+        pipeline_dag_config=pipeline_dag_config,
+    )
 
 
 def create_pipeline(
     artifacts: List[str],
-    input_parameters: List[str] = [],
-    reuse_pre_computed_artifacts: List[str] = [],
     pipeline_name: Optional[str] = None,
     dependencies: TaskGraphEdge = {},
+    input_parameters: List[str] = [],
+    reuse_pre_computed_artifacts: List[str] = [],
     persist: bool = False,
 ) -> Pipeline:
     pipeline = Pipeline(
         artifacts=artifacts,
-        input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
         name=pipeline_name,
         dependencies=dependencies,
+        input_parameters=input_parameters,
+        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
     if persist:
         pipeline.save()

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -32,10 +32,10 @@ class Pipeline:
     def __init__(
         self,
         artifacts: List[str],
-        input_parameters: List[str] = [],
-        reuse_pre_computed_artifacts: List[str] = [],
         name: Optional[str] = None,
         dependencies: TaskGraphEdge = {},
+        input_parameters: List[str] = [],
+        reuse_pre_computed_artifacts: List[str] = [],
     ):
         if len(artifacts) == 0:
             raise ValueError(
@@ -149,8 +149,8 @@ class Pipeline:
         pipeline_to_write = PipelineORM(
             name=self.name,
             artifacts=set(artifacts_to_save.values()),
+            dependencies=art_deps_to_save,
             input_parameters=input_params_to_save,
             precomputed_artifacts=set(precomputed_artifacts_to_save),
-            dependencies=art_deps_to_save,
         )
         db.write_pipeline(art_deps_to_save, pipeline_to_write)

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 from typing import List, Optional
 
@@ -81,6 +82,17 @@ class Pipeline:
 
         # Write out pipeline files
         pipeline_writer.write_pipeline_files()
+
+        # Provide user warning about currently unsupported functionality
+        if (
+            len(self.reuse_pre_computed_artifacts) > 0
+            and framework == "AIRFLOW"
+        ):
+            warnings.warn(
+                "Reuse of pre-computed artifacts is currently NOT supported "
+                "for Airflow DAGs. Hence, the generated Airflow DAG file would "
+                "recompute all artifacts in the pipeline."
+            )
 
         # Track the event
         track(

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 
 from lineapy.api.api_utils import extract_taskgraph
 from lineapy.data.types import PipelineType
@@ -30,6 +30,8 @@ class Pipeline:
     def __init__(
         self,
         artifacts: List[str],
+        input_parameters: List[str] = [],
+        reuse_pre_computed_artifacts: List[Union[str, Tuple[str, int]]] = [],
         name: Optional[str] = None,
         dependencies: TaskGraphEdge = {},
     ):
@@ -43,6 +45,8 @@ class Pipeline:
         )
         self.name = name or "_".join(self.artifact_safe_names)
         self.artifact_names: List[str] = artifacts
+        self.input_parameters = input_parameters
+        self.reuse_pre_computed_artifacts = reuse_pre_computed_artifacts
         self.id = get_new_id()
 
     def export(
@@ -54,7 +58,10 @@ class Pipeline:
         # Create artifact collection
         execution_context = get_context()
         artifact_collection = ArtifactCollection(
-            execution_context.executor.db, self.artifact_names
+            db=execution_context.executor.db,
+            target_artifacts=self.artifact_names,
+            input_parameters=self.input_parameters,
+            reuse_pre_computed_artifacts=self.reuse_pre_computed_artifacts,
         )
 
         # Check if the specified framework is a supported/valid one

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -75,6 +75,13 @@ artifact_to_pipeline_table = Table(
     Column("artifact_id", ForeignKey("artifact.id")),
 )
 
+precomputed_artifact_to_pipeline_table = Table(
+    "precomputed_artifact_to_pipeline",
+    Base.metadata,
+    Column("pipeline_id", ForeignKey("pipeline.id")),
+    Column("artifact_id", ForeignKey("artifact.id")),
+)
+
 dependency_to_artifact_table = Table(
     "dependency_to_artifact_table",
     Base.metadata,
@@ -131,10 +138,29 @@ class PipelineORM(Base):
     artifacts = relationship(
         ArtifactORM, secondary=artifact_to_pipeline_table, collection_class=set
     )
+    input_parameters: List[InputParameterORM] = relationship(
+        "InputParameterORM",
+        back_populates="pipeline",
+    )
+    precomputed_artifacts = relationship(
+        ArtifactORM,
+        secondary=precomputed_artifact_to_pipeline_table,
+        collection_class=set,
+    )
     dependencies: List[ArtifactDependencyORM] = relationship(
         "ArtifactDependencyORM",
         back_populates="pipeline",
     )
+
+
+class InputParameterORM(Base):
+    __tablename__ = "parameter"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    pipeline_id = Column(Integer, ForeignKey("pipeline.id"), nullable=False)
+    pipeline = relationship(
+        PipelineORM, back_populates="input_parameters", uselist=False
+    )
+    variable_name = Column(String, nullable=True)
 
 
 class ArtifactDependencyORM(Base):

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -138,6 +138,10 @@ class PipelineORM(Base):
     artifacts = relationship(
         ArtifactORM, secondary=artifact_to_pipeline_table, collection_class=set
     )
+    dependencies: List[ArtifactDependencyORM] = relationship(
+        "ArtifactDependencyORM",
+        back_populates="pipeline",
+    )
     input_parameters: List[InputParameterORM] = relationship(
         "InputParameterORM",
         back_populates="pipeline",
@@ -147,20 +151,6 @@ class PipelineORM(Base):
         secondary=precomputed_artifact_to_pipeline_table,
         collection_class=set,
     )
-    dependencies: List[ArtifactDependencyORM] = relationship(
-        "ArtifactDependencyORM",
-        back_populates="pipeline",
-    )
-
-
-class InputParameterORM(Base):
-    __tablename__ = "parameter"
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    pipeline_id = Column(Integer, ForeignKey("pipeline.id"), nullable=False)
-    pipeline = relationship(
-        PipelineORM, back_populates="input_parameters", uselist=False
-    )
-    variable_name = Column(String, nullable=True)
 
 
 class ArtifactDependencyORM(Base):
@@ -183,6 +173,16 @@ class ArtifactDependencyORM(Base):
         secondary=dependency_to_artifact_table,
         collection_class=set,
     )
+
+
+class InputParameterORM(Base):
+    __tablename__ = "parameter"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    pipeline_id = Column(Integer, ForeignKey("pipeline.id"), nullable=False)
+    pipeline = relationship(
+        PipelineORM, back_populates="input_parameters", uselist=False
+    )
+    variable_name = Column(String, nullable=True)
 
 
 class ExecutionORM(Base):

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -49,7 +49,9 @@ class ArtifactCollection:
             List[str], List[Tuple[str, int]], List[Union[str, Tuple[str, int]]]
         ],
         input_parameters: List[str] = [],
-        reuse_pre_computed_artifacts: List[Union[str, Tuple[str, int]]] = [],
+        reuse_pre_computed_artifacts: Union[
+            List[str], List[Tuple[str, int]], List[Union[str, Tuple[str, int]]]
+        ] = [],
     ) -> None:
         self.db: RelationalLineaDB = db
         self.session_artifacts: Dict[LineaID, SessionArtifacts] = {}

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -51,7 +51,7 @@ class ArtifactCollection:
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: Union[
             List[str], List[Tuple[str, int]], List[Union[str, Tuple[str, int]]]
-        ] = [],
+        ] = [],  # type: ignore
     ) -> None:
         self.db: RelationalLineaDB = db
         self.session_artifacts: Dict[LineaID, SessionArtifacts] = {}

--- a/tests/end_to_end/test_linea_api.py
+++ b/tests/end_to_end/test_linea_api.py
@@ -283,3 +283,35 @@ x = lineapy.get_pipeline("x")"""
     assert len(dep_x["b"]) == 2
     assert "c" in dep_x["b"]
     assert "a" in dep_x["b"]
+
+
+def test_pipeline_input_params_pre_overlap(execute):
+    c = """import lineapy
+a = 10
+b = 20
+lineapy.save(a, "a")
+lineapy.save(b, "b")
+input_params_x = {"b"}
+lineapy.create_pipeline(["a", "b"], "x", persist=True, input_parameters=input_params_x)
+x = lineapy.get_pipeline("x")"""
+    res = execute(c, snapshot=False)
+    x = res.values["x"]
+    assert x.name == "x"
+    assert len(x.input_parameters) == 1
+    assert "b" in x.input_parameters
+
+
+def test_pipeline_precomputed_arts_pre_overlap(execute):
+    c = """import lineapy
+a = 10
+b = 20
+lineapy.save(a, "a")
+lineapy.save(b, "b")
+precomputed_arts_x = {"b"}
+lineapy.create_pipeline(["a", "b"], "x", persist=True, reuse_pre_computed_artifacts=precomputed_arts_x)
+x = lineapy.get_pipeline("x")"""
+    res = execute(c, snapshot=False)
+    x = res.values["x"]
+    assert x.name == "x"
+    assert len(x.reuse_pre_computed_artifacts) == 1
+    assert "b" in x.reuse_pre_computed_artifacts


### PR DESCRIPTION
# Summary

Expose parametrization and artifact reuse to pipeline-related APIs.

# Changes

- [x] Add `input_parameters` and `reuse_pre_computed_artifact` args to pipeline-related APIs
- [x] Update existing pipeline-related tests
- [x] Update DB schema to store related metadata (so the user can replicate a pipeline with parametrization and artifact reuse)
- [x] Add tests that examine storage and retrieval of the new pipeline metadata
- [x] Raise warning when parametrizing Airflow pipeline (it cannot be supported for now)
- [ ] Update user-facing documentation involving pipelines

# Testing

Test cases have been added to cover DB schema update.

# Ticket(s)

- [LIN-565](https://linea.atlassian.net/browse/LIN-565)