### PR TITLE
LIN-577 fix parameterized script framework dockerfile

### DIFF
--- a/lineapy/plugins/jinja_templates/script_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/script_dockerfile.jinja
@@ -12,4 +12,4 @@ RUN pip install -r ./{{ pipeline_name }}_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/{{ pipeline_name }}_module.py" ]
+ENTRYPOINT [ "python", "/home/{{ pipeline_name }}_module.py" ]

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_Dockerfile
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./script_pipeline_a0_b0_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/script_pipeline_a0_b0_module.py" ]
+ENTRYPOINT [ "python", "/home/script_pipeline_a0_b0_module.py" ]

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_Dockerfile
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./script_pipeline_a0_b0_dependencies_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/script_pipeline_a0_b0_dependencies_module.py" ]
+ENTRYPOINT [ "python", "/home/script_pipeline_a0_b0_dependencies_module.py" ]

--- a/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_Dockerfile
+++ b/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./script_pipeline_housing_multiple_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/script_pipeline_housing_multiple_module.py" ]
+ENTRYPOINT [ "python", "/home/script_pipeline_housing_multiple_module.py" ]

--- a/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_Dockerfile
+++ b/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./script_pipeline_housing_simple_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/script_pipeline_housing_simple_module.py" ]
+ENTRYPOINT [ "python", "/home/script_pipeline_housing_simple_module.py" ]

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_Dockerfile
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./script_pipeline_housing_w_dependencies_requirements.txt
 WORKDIR /home
 COPY . .
 
-CMD [ "python", "/home/script_pipeline_housing_w_dependencies_module.py" ]
+ENTRYPOINT [ "python", "/home/script_pipeline_housing_w_dependencies_module.py" ]


### PR DESCRIPTION
# Description

The existing Dockerfile for `framework='SCRIPT'` does not support passing parameters into `docker run` . Change from `CMD` to `ENTRYPOINT` can resolve this issue easily.

Reference
https://docs.docker.com/engine/reference/builder/#entrypoint

Fixes # (issue)

LIN-577

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local docker build/docker run

![image](https://user-images.githubusercontent.com/1090270/191051404-3bacf478-b069-45d9-b746-8ffd802d418b.png)
