### PR TITLE
Fix error with same artifact name in a session

### DIFF
--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -174,11 +174,11 @@ class SessionArtifacts:
                 )
 
         # Check only one artifact in the session with the name within reuse_pre_computed_artifacts
-        pre_computed_artifacts_name_count = Counter(
+        session_artifacts_name_count = Counter(
             [art.name for nodeid, art in self.all_session_artifacts.items()]
         )
-        for art_name, ct in pre_computed_artifacts_name_count.items():
-            if ct > 1:
+        for art_name in self.reuse_pre_computed_artifacts.keys():
+            if session_artifacts_name_count[art_name] > 1:
                 raise ValueError(
                     f"More than one artifacts with the same name {art_name} in the session."
                     + "Please remove it from reuse_pre_computed_artifacts."
@@ -259,19 +259,21 @@ class SessionArtifacts:
         # as an input parameter. We can relax this restriction.
         for var, node_ids in input_parameters_assignment_nodes.items():
             for node_id in node_ids:
-                is_literal_assignment = (
-                    len(self.node_context[node_id].dependent_variables) == 0
-                )
-                has_assigned_before = (
-                    self.input_parameters_node.get(var, None) is not None
-                )
-                if is_literal_assignment:
-                    if has_assigned_before:
-                        raise ValueError(
-                            "Variable %s, is defined more than once", var
-                        )
-                    else:
-                        self.input_parameters_node[var] = node_id
+                if node_id in self.node_context.keys():
+                    is_literal_assignment = (
+                        len(self.node_context[node_id].dependent_variables)
+                        == 0
+                    )
+                    has_assigned_before = (
+                        self.input_parameters_node.get(var, None) is not None
+                    )
+                    if is_literal_assignment:
+                        if has_assigned_before:
+                            raise ValueError(
+                                "Variable %s, is defined more than once", var
+                            )
+                        else:
+                            self.input_parameters_node[var] = node_id
 
         for var, node_id in self.input_parameters_node.items():
             if len(self.node_context[node_id].dependent_variables) > 0:

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -97,7 +97,8 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
             id="non_literal_assignment",
         ),
         pytest.param(
-            "import lineapy\nft = lineapy.get_function(['c'], input_parameters=['c'])",
+            # Variable c will affect both artifact b and c
+            "import lineapy\nft = lineapy.get_function(['b','c'], input_parameters=['c'])",
             id="duplicated_literal_assignment",
         ),
     ],
@@ -110,7 +111,8 @@ def test_get_function_error(execute, code):
 import lineapy
 a = 1
 lineapy.save(a,'a')
-b = a
+c = 1
+b = c+a
 lineapy.save(b,'b')
 c = 2
 c = 3


### PR DESCRIPTION
# Description

Fix `to_pipeline`  and `get_function` errors if multiple artifacts have the same name in a session.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Modify existing test case to cover the scenario