### PR TITLE
LIN-597 Make `Pipeline.export()` handle parametrization

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -306,18 +306,6 @@ def get_pipeline(name: str) -> Pipeline:
         if artifact.name is not None
     ]
 
-    input_parameters = [
-        input_param_orm.variable_name
-        for input_param_orm in pipeline_orm.input_parameters
-        if input_param_orm.variable_name is not None
-    ]
-
-    precomputed_artifact_names = [
-        artifact.name
-        for artifact in pipeline_orm.precomputed_artifacts
-        if artifact.name is not None
-    ]
-
     dependencies = dict()
     for dep_orm in pipeline_orm.dependencies:
         post_artifact = dep_orm.post_artifact
@@ -337,8 +325,6 @@ def get_pipeline(name: str) -> Pipeline:
         dependencies[post_name] = pre_names
     return Pipeline(
         artifacts=artifact_names,
-        input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=precomputed_artifact_names,
         name=name,
         dependencies=dependencies,
     )
@@ -437,13 +423,13 @@ def to_pipeline(
         artifacts=artifacts,
         name=pipeline_name,
         dependencies=dependencies,
-        input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
     pipeline.save()
     return pipeline.export(
         framework=framework,
         output_dir=output_dir,
+        input_parameters=input_parameters,
+        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
         pipeline_dag_config=pipeline_dag_config,
     )
 
@@ -452,16 +438,12 @@ def create_pipeline(
     artifacts: List[str],
     pipeline_name: Optional[str] = None,
     dependencies: TaskGraphEdge = {},
-    input_parameters: List[str] = [],
-    reuse_pre_computed_artifacts: List[str] = [],
     persist: bool = False,
 ) -> Pipeline:
     pipeline = Pipeline(
         artifacts=artifacts,
         name=pipeline_name,
         dependencies=dependencies,
-        input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
     if persist:
         pipeline.save()

--- a/lineapy/db/relational.py
+++ b/lineapy/db/relational.py
@@ -75,13 +75,6 @@ artifact_to_pipeline_table = Table(
     Column("artifact_id", ForeignKey("artifact.id")),
 )
 
-precomputed_artifact_to_pipeline_table = Table(
-    "precomputed_artifact_to_pipeline",
-    Base.metadata,
-    Column("pipeline_id", ForeignKey("pipeline.id")),
-    Column("artifact_id", ForeignKey("artifact.id")),
-)
-
 dependency_to_artifact_table = Table(
     "dependency_to_artifact_table",
     Base.metadata,
@@ -142,15 +135,6 @@ class PipelineORM(Base):
         "ArtifactDependencyORM",
         back_populates="pipeline",
     )
-    input_parameters: List[InputParameterORM] = relationship(
-        "InputParameterORM",
-        back_populates="pipeline",
-    )
-    precomputed_artifacts = relationship(
-        ArtifactORM,
-        secondary=precomputed_artifact_to_pipeline_table,
-        collection_class=set,
-    )
 
 
 class ArtifactDependencyORM(Base):
@@ -173,16 +157,6 @@ class ArtifactDependencyORM(Base):
         secondary=dependency_to_artifact_table,
         collection_class=set,
     )
-
-
-class InputParameterORM(Base):
-    __tablename__ = "parameter"
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    pipeline_id = Column(Integer, ForeignKey("pipeline.id"), nullable=False)
-    pipeline = relationship(
-        PipelineORM, back_populates="input_parameters", uselist=False
-    )
-    variable_name = Column(String, nullable=True)
 
 
 class ExecutionORM(Base):

--- a/tests/end_to_end/test_linea_api.py
+++ b/tests/end_to_end/test_linea_api.py
@@ -283,35 +283,3 @@ x = lineapy.get_pipeline("x")"""
     assert len(dep_x["b"]) == 2
     assert "c" in dep_x["b"]
     assert "a" in dep_x["b"]
-
-
-def test_pipeline_input_params_pre_overlap(execute):
-    c = """import lineapy
-a = 10
-b = 20
-lineapy.save(a, "a")
-lineapy.save(b, "b")
-input_params_x = {"b"}
-lineapy.create_pipeline(["a", "b"], "x", persist=True, input_parameters=input_params_x)
-x = lineapy.get_pipeline("x")"""
-    res = execute(c, snapshot=False)
-    x = res.values["x"]
-    assert x.name == "x"
-    assert len(x.input_parameters) == 1
-    assert "b" in x.input_parameters
-
-
-def test_pipeline_precomputed_arts_pre_overlap(execute):
-    c = """import lineapy
-a = 10
-b = 20
-lineapy.save(a, "a")
-lineapy.save(b, "b")
-precomputed_arts_x = {"b"}
-lineapy.create_pipeline(["a", "b"], "x", persist=True, reuse_pre_computed_artifacts=precomputed_arts_x)
-x = lineapy.get_pipeline("x")"""
-    res = execute(c, snapshot=False)
-    x = res.values["x"]
-    assert x.name == "x"
-    assert len(x.reuse_pre_computed_artifacts) == 1
-    assert "b" in x.reuse_pre_computed_artifacts


### PR DESCRIPTION
# Summary

For better reusability of `Pipeline` objects, use `input_parameters` and `reuse_pre_computed_artifacts` flags in `Pipeline.export()` instead of `Pipeline.__init__()`. This involves unrolling DB schema updates (which have not yet been release yet, so it’s okay!).

# Changes

- [x] Move `input_parameters` and `reuse_pre_computed_artifacts` flags under `Pipeline.export()`
- [x] Adapt parts of codebase that use `Pipeline`
- [x] Unroll DB schema updates

# Testing

CI ensures integrity of the codebase after the edits.

# Ticket(s)

- https://linea.atlassian.net/browse/LIN-597