### PR TITLE
Add annotation for statsforecast module

### DIFF
--- a/lineapy/annotations/external/statsforecast.annotations.yaml
+++ b/lineapy/annotations/external/statsforecast.annotations.yaml
@@ -1,0 +1,11 @@
+- module: statsforecast.models
+  annotations:
+    - criteria:
+        class_instance: _TS
+        class_method_name: fit
+      side_effects:
+        - mutated_value:
+            self_ref: SELF_REF 
+        - views:
+            - self_ref: SELF_REF
+            - result: RESULT


### PR DESCRIPTION
# Description

The `statsforecast` module has a similar structure to `scikit-learn`. Need to annotate the `_TS` class in `statsforecast.models` to allow lineapy capture the `model.fit` . 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Before adding annotation

```
train = region.query(f"week < '{cutoff_date}'")
m_aa = AutoARIMA()
```

After

```
train = region.query(f"week < '{cutoff_date}'")
m_aa = AutoARIMA()
m_aa.fit(train["log_price"].values)
```

where `AutoARIMA` is a derived class of `_TS` class