### PR TITLE
Lin 586 slicing error with multi line parenthesis block

### DIFF
--- a/lineapy/editors/ipython.py
+++ b/lineapy/editors/ipython.py
@@ -5,6 +5,7 @@ https://ipython.readthedocs.io/en/stable/config/inputtransforms.html
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
@@ -102,6 +103,14 @@ def input_transformer_post(
             "input_transformer_post shouldn't be called when we don't have an active tracer"
         )
     code = "".join(lines)
+
+    # This is a dirty fix for our code slicing mechanism within multiple line
+    # parentheses code block. This might break if the closing parenthesis is
+    # moved behind a comment
+    while re.search(r"\([ \t]*\n", code) is not None:
+        code = re.sub(r"\([ \t]*\n", "(", code)
+    while re.search(r"\n[ \t]*\)", code) is not None:
+        code = re.sub(r"\n[ \t]*\)", ")", code)
 
     # If we have just started, first start everything up
     if isinstance(STATE, StartedState):


### PR DESCRIPTION
# Description

Multi-line statements are causing a slicing error. A temporary solution is wrapping each statement into online, so our code slice mechanism should work. Especially when we have meaningless parentheses.

Consider following code

```
x = 1
y = 2
a = (
    x+y
)
arta = lineapy.save(a,'a')
arta.get_code()
```

currently, we will see error because we only slice out 

```
x = 1
y = 2
    x+y
```
and the indentation is not correct.

This PR is modifying the user code as

```
x = 1
y = 2
a = x+y
arta = lineapy.save(a,'a')
arta.get_code()
```

before it goes to the tracer; so we can get the following sliced code

```
x = 1
y = 2
a = x+y
```


This will not affect end code generation result, since it is running through black before return.

Some edge cases to consider
* The cell end semicolon is removed by `black`, need to add it back; otherwise might see unexpected cell output in the notebook.
* Comment-only lines within the code block might prevent `black` to collapse the entire statement into one line, need to move these comment lines to the end of the next non-comment line.

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pass all existing tests