### PR TITLE
Adjust get_function/to_pipeline input parameter order as user's input.

### DIFF
--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -275,6 +275,15 @@ class ArtifactCollection:
                 f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}"
             )
 
+        # Sort input parameter for the run_all in the module as the same order
+        # of user's input parameter
+        user_input_parameters_ordering = {
+            var: i for i, var in enumerate(self.input_parameters)
+        }
+        module_input_parameters.sort(
+            key=lambda x: user_input_parameters_ordering[x.variable_name]
+        )
+
         # Put all together to generate module text
         MODULE_TEMPLATE = load_plugin_template("module.jinja")
         module_text = MODULE_TEMPLATE.render(

--- a/tests/unit/plugins/expected/airflow_pipeline_two_input_parameter/airflow_pipeline_two_input_parameter_module.py
+++ b/tests/unit/plugins/expected/airflow_pipeline_two_input_parameter/airflow_pipeline_two_input_parameter_module.py
@@ -22,8 +22,8 @@ def run_session_including_pn(
 
 
 def run_all_sessions(
-    p="p",
     n=5,
+    p="p",
 ):
     artifacts = dict()
     artifacts.update(run_session_including_pn(p, n))
@@ -33,11 +33,11 @@ def run_all_sessions(
 if __name__ == "__main__":
     # Edit this section to customize the behavior of artifacts
     parser = argparse.ArgumentParser()
-    parser.add_argument("--p", type=str, default="p")
     parser.add_argument("--n", type=int, default=5)
+    parser.add_argument("--p", type=str, default="p")
     args = parser.parse_args()
     artifacts = run_all_sessions(
-        p=args.p,
         n=args.n,
+        p=args.p,
     )
     print(artifacts)


### PR DESCRIPTION
# Description

Originally, the order is based on the appearance of the session code. It is actually not very desirable, especially in multiple sessions cases.

Basically, if we ran

```
lineapy.get_function(['a'], input_parameters=['x','y'])
```
we might get 
```
def run_all_sessions(x, y)
```
or 
```
def run_all_sessions(y, x)
```
depending on the ordering of variable x and y appearance in the session code.

This PR will make it always in the order of the user's input; i.e., 
```
def run_all_sessions(x,y)
```


Fixes # (issue)

LIN-611

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Update the test result of the existing test case.

The modified existing test case is an example of the user's input does not agree with what the appearance order in the original code, so we need to modify the case.