### PR TITLE
add tagging for demo notebooks

### DIFF
--- a/lineapy/__init__.py
+++ b/lineapy/__init__.py
@@ -17,6 +17,7 @@ from lineapy.data.types import SessionType, ValueType
 from lineapy.editors.ipython import start, stop, visualize
 from lineapy.execution.context import get_context
 from lineapy.instrumentation.tracer import Tracer
+from lineapy.utils.analytics.usage_tracking import tag
 from lineapy.utils.config import options
 from lineapy.utils.lineabuiltins import db, file_system
 from lineapy.utils.version import __version__
@@ -41,8 +42,10 @@ __all__ = [
     "db",
     "file_system",
     "options",
+    "tag",
     "__version__",
 ]
+
 
 # Create an ipython extension that starts and stops tracing
 # https://ipython.readthedocs.io/en/stable/config/extensions/index.html#writing-extensions

--- a/lineapy/utils/analytics/event_schemas.py
+++ b/lineapy/utils/analytics/event_schemas.py
@@ -74,7 +74,12 @@ class CyclicGraphEvent:
     dummy_entry: str  # dummy entry, may populate with extra information later
 
 
-AllEvents = Union[
+@dataclass
+class TagEvent:
+    tag: str  # dummy entry, may populate with extra information later
+
+
+TrackingEvent = Union[
     CatalogEvent,
     LibImportEvent,
     ExceptionEvent,
@@ -85,4 +90,5 @@ AllEvents = Union[
     GetValueEvent,
     GetVersionEvent,
     CyclicGraphEvent,
+    TagEvent,
 ]

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -18,7 +18,7 @@ from functools import lru_cache
 import requests
 from IPython import get_ipython
 
-from lineapy.utils.analytics.event_schemas import AllEvents
+from lineapy.utils.analytics.event_schemas import TagEvent, TrackingEvent
 from lineapy.utils.config import options
 from lineapy.utils.version import __version__
 
@@ -116,7 +116,7 @@ def _send_amplitude_event(event_type: str, event_properties: dict):
         logger.debug(f"Tracking Error: {str(err)}")
 
 
-def track(event: AllEvents):
+def track(event: TrackingEvent):
     """ """
     if do_not_track():
         return
@@ -128,3 +128,14 @@ def track(event: AllEvents):
     event_properties["runtime"] = _runtime()
 
     return _send_amplitude_event(event.__class__.__name__, event_properties)
+
+
+def tag(tag_name: str):
+    # This can be used by adding `lineapy.tag('tag_name')` before do_not_track
+    # conditions are triggered, e.g., by `lineapy.options.set("is_demo", True)`
+    #
+    # Put these two lines at the top of demo notebooks:
+    # lineapy.tag("demo_name") # change "demo_name" with actual demo name.
+    # lineapy.options.set("is_demo", True)
+
+    track(TagEvent(tag_name))


### PR DESCRIPTION
But it can be used for tagging other stuff, too.

# Description

Introduced a tagging API to track demos.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Logged test events to Amplitude