### PR TITLE
Add mkdir step before cp

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: "Copy demo notebooks to top level demos folder"
-        run: cp -R examples/use_cases/* demos/ && cp examples/tutorials/00_api_basics.ipynb demos/
+        run: mkdir demos/ && cp -R examples/use_cases/* demos/ && cp examples/tutorials/00_api_basics.ipynb demos/
 
       - name: "Regex out the NBVAL_SKIP and NBVAL_IGNORE_OUTPUT comments"
         run: |


### PR DESCRIPTION
# Description

Address error in https://github.com/LineaLabs/lineapy/actions/runs/3159242653/jobs/5142227673

```
Run cp -R examples/use_cases/* demos/ && cp examples/tutorials/00_api_basics.ipynb demos/
  cp -R examples/use_cases/* demos/ && cp examples/tutorials/00_api_basics.ipynb demos/
  shell: /usr/bin/bash -e {0}
cp: target 'demos/' is not a directory
Error: Process completed with exit code 1.
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

