### PR TITLE
LIN-619 Fix imports in requirements.txt

### DIFF
--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -87,13 +87,10 @@ class BasePipelineWriter:
         """
         Write out requirements file.
         """
-        # TODO: Filter relevant imports only (i.e., those "touched" by artifacts in pipeline)
         libraries = dict()
         for session_artifacts in self.session_artifacts_sorted:
-            session_libs = self.db.get_libraries_for_session(
-                session_artifacts.session_id
-            )
-            for lib in session_libs:
+            session_artifact_libs = session_artifacts.get_libraries()
+            for lib in session_artifact_libs:
                 if isinstance(lib.package_name, str):
                     lib_name = PIP_PACKAGE_NAMES.get(
                         lib.package_name, lib.package_name

--- a/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_complex_h_perart/airflow_complex_h_perart_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0/airflow_pipeline_a0_b0_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_a0_b0_dependencies/airflow_pipeline_a0_b0_dependencies_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_a_b0_inputpar/airflow_pipeline_a_b0_inputpar_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_a_b0_inputpar/airflow_pipeline_a_b0_inputpar_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_a_b0_inputpar_session/airflow_pipeline_a_b0_inputpar_session_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_a_b0_inputpar_session/airflow_pipeline_a_b0_inputpar_session_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_multiple/airflow_pipeline_housing_multiple_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_simple/airflow_pipeline_housing_simple_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_housing_w_dependencies/airflow_pipeline_housing_w_dependencies_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy

--- a/tests/unit/plugins/expected/airflow_pipeline_two_input_parameter/airflow_pipeline_two_input_parameter_requirements.txt
+++ b/tests/unit/plugins/expected/airflow_pipeline_two_input_parameter/airflow_pipeline_two_input_parameter_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_requirements.txt
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0/script_pipeline_a0_b0_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_requirements.txt
+++ b/tests/unit/plugins/expected/script_pipeline_a0_b0_dependencies/script_pipeline_a0_b0_dependencies_requirements.txt
@@ -1,1 +1,0 @@
-lineapy

--- a/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_requirements.txt
+++ b/tests/unit/plugins/expected/script_pipeline_housing_multiple/script_pipeline_housing_multiple_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy

--- a/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_requirements.txt
+++ b/tests/unit/plugins/expected/script_pipeline_housing_simple/script_pipeline_housing_simple_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy

--- a/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_requirements.txt
+++ b/tests/unit/plugins/expected/script_pipeline_housing_w_dependencies/script_pipeline_housing_w_dependencies_requirements.txt
@@ -1,5 +1,2 @@
-altair==4.2.0
 pandas==1.3.5
-seaborn==0.11.2
 scikit-learn==1.0.2
-lineapy


### PR DESCRIPTION
# Description

Currently, the requirements.txt is generated from the entire session graph(s if multiple sessions). This is more than the pipeline need. 

This is fixed by giving session artifacts a `get_libraries` method. This will go through and match session libraries with import_nodes that form the ImportNodeCollection to ensure that libraries not in the slice are not included.

Fixes LIN-619

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`tests/unit/plugins/expected/<framework>_pipeline_housing * .ipynb` test cases contain examples where the 
Specifically in these examples `lineapy`, `seaborn` and `altair` were libraries only used during EDA and not actually needed for the artifact. 