### PR TITLE
LIN-628: Fix error handling around input_parameter variable

### DIFF
--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -276,7 +276,7 @@ class ArtifactCollection:
             )
             raise ValueError(
                 f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}. "
-                + f"The following parameters are missing {missing_parameters}."
+                + f"The following variables do not have references in any session code: {missing_parameters}."
             )
 
         # Sort input parameter for the run_all in the module as the same order

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -271,8 +271,12 @@ class ArtifactCollection:
                 f"Duplicated input parameters {module_input_parameters_list} across multiple sessions"
             )
         elif set(module_input_parameters_list) != set(self.input_parameters):
+            missing_parameters = set(self.input_parameters) - set(
+                module_input_parameters_list
+            )
             raise ValueError(
-                f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}"
+                f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}. "
+                + f"The following parameters are missing {missing_parameters}."
             )
 
         # Sort input parameter for the run_all in the module as the same order

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -265,6 +265,12 @@ class SessionArtifacts:
         # the literal assignment only happen once in the entire session at this
         # moment. If there is a way to specify which literal assignment to use
         # as an input parameter. We can relax this restriction.
+        # We allow multiple assignments to non-literals to handle common cases like the
+        # following:
+        # x = 1
+        # x = x + 1
+        # input_parameters = [x]
+        # In this case, the original definition of x = 1 will be parametrized.
         for var, node_ids in input_parameters_assignment_nodes.items():
             for node_id in node_ids:
                 if node_id in self.node_context.keys():

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -82,28 +82,32 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
 
 
 @pytest.mark.parametrize(
-    "code",
+    "code, message",
     [
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','a'])",
+            "Duplicated input parameters detected in ['a', 'a']",
             id="duplicated_input_vars",
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','x'])",
+            "The following parameters are missing {'x'}",
             id="nonexisting_input_vars",
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['b'], input_parameters=['b'])",
+            "LineaPy only supports literal value as input parameters for now. b only has non-literal values in this Session.",
             id="non_literal_assignment",
         ),
         pytest.param(
             # Variable c will affect both artifact b and c
             "import lineapy\nft = lineapy.get_function(['b','c'], input_parameters=['c'])",
+            "Variable c, is defined more than once",
             id="duplicated_literal_assignment",
         ),
     ],
 )
-def test_get_function_error(execute, code):
+def test_get_function_error(execute, code, message):
     """
     Sanity check for lineapy.get_function
     """
@@ -121,3 +125,4 @@ lineapy.save(c,'c')
     res = execute(art_code, snapshot=False)
     with pytest.raises(UserException) as e_info:
         res = execute(code, snapshot=False)
+    assert message in str(e_info.value)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -105,6 +105,12 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
             "Variable c, is defined more than once",
             id="duplicated_literal_assignment",
         ),
+        pytest.param(
+            # Variable d has a literal and non-literal assignment, code should default correctly to literal, does not error
+            "import lineapy\nft = lineapy.get_function(['b','d'], input_parameters=['d'])",
+            "",
+            id="default_to_literal_assignment",
+        ),
     ],
 )
 def test_get_function_error(execute, code, message):
@@ -121,8 +127,16 @@ lineapy.save(b,'b')
 c = 2
 c = 3
 lineapy.save(c,'c')
+d = 1
+d = d + 1
+lineapy.save(d, 'd')
 """
     res = execute(art_code, snapshot=False)
-    with pytest.raises(UserException) as e_info:
+    # Check exception is raised and error message matches
+    if message:
+        with pytest.raises(UserException) as e_info:
+            res = execute(code, snapshot=False)
+        assert message in str(e_info.value)
+    # Run as is, no error message expected
+    else:
         res = execute(code, snapshot=False)
-    assert message in str(e_info.value)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -91,7 +91,7 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','x'])",
-            "The following parameters are missing {'x'}",
+            "The following variables do not have references in any session code: {'x'}",
             id="nonexisting_input_vars",
         ),
         pytest.param(


### PR DESCRIPTION
# Description

Better error handling of the following cases. 
- A parameter is missing from the resulting modules. 
- A variable is defined as a literal more than once within a slice. 
- A variable has _only_ non literal assignments. 

Error messages should contain the parameter in question.

Last case of only non literal assignments fixed. The old error message was unreachable. 

Tests updated to check the error message.

Fixes # LIN-628

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`test_function` has been updated to check the error message being returned in each case as well.
