### PR TITLE
LIN-592 Update NodeCollection dependencies with reuse_pre_calculated_artifact…

### DIFF
--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -606,6 +606,7 @@ class SessionArtifacts:
                 for art in self.artifact_nodecollections
                 if art.name in nc_graph.nodes
             ]
+            self.nodecollection_dependencies.graph = nc_graph
 
     def _get_first_artifact_name(self) -> Optional[str]:
         """

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -177,6 +177,33 @@ def test_two_sessions(
                 assert art_pred_session_line_index < art_session_line_index
 
 
+def test_dependencies(linea_db, execute):
+    """
+    Check sort_session_artifacts withing artifactcollection
+    """
+    code = """\n
+import lineapy
+a = 1
+b = 2
+c = a+b
+lineapy.save(a,'a')
+lineapy.save(b,'b')
+lineapy.save(c,'c')
+"""
+    execute(code, snapshot=False)
+    ac = ArtifactCollection(
+        linea_db,
+        target_artifacts=["b", "c"],
+        reuse_pre_computed_artifacts=["b"],
+        input_parameters=["a"],
+    )
+    ac._sort_session_artifacts(dependencies={"c": {"b"}})
+    module = ac.get_module()
+    assert not hasattr(module, "get_a")
+    assert hasattr(module, "get_b")
+    assert hasattr(module, "get_c")
+
+
 @pytest.mark.parametrize(
     "input_parameters, input_values, expected_values",
     [


### PR DESCRIPTION
# Description

When specify `dependencies` and `reuse_pre_computed_artifacts`, we get error.

The root cause is we forget to update the artifact calculation dependency graph in the case of `reuse_pre_computed_artifacts`

Fixes # (issue)

LIN-592

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New tests were added.