### PR TITLE
LIN-628 fix-error-handling-around-input-params-plut-function-def

### DIFF
--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -276,7 +276,7 @@ class ArtifactCollection:
             )
             raise ValueError(
                 f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}. "
-                + f"The following parameters are missing {missing_parameters}."
+                + f"The following variables do not have references in any session code: {missing_parameters}."
             )
 
         # Sort input parameter for the run_all in the module as the same order

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -22,7 +22,7 @@ from lineapy.db.db import RelationalLineaDB
 from lineapy.graph_reader.session_artifacts import SessionArtifacts
 from lineapy.graph_reader.types import InputVariable
 from lineapy.plugins.task import TaskGraphEdge
-from lineapy.plugins.utils import load_plugin_template
+from lineapy.plugins.utils import load_plugin_template, slugify
 from lineapy.utils.logging_config import configure_logging
 from lineapy.utils.utils import prettify
 
@@ -83,7 +83,7 @@ class ArtifactCollection:
             artifacts_by_session[art._session_id].append(art)
             # Record session_id of an artifact
             self.artifact_session[art.name] = art._session_id
-            self.artifact_session[art.name.replace(" ", "_")] = art._session_id
+            self.artifact_session[slugify(art.name)] = art._session_id
 
         pre_calculated_artifacts: Dict[str, LineaArtifact] = {}
         for art_entry in reuse_pre_computed_artifacts:
@@ -155,7 +155,7 @@ class ArtifactCollection:
         task_dependency_edges = list(
             chain.from_iterable(
                 (
-                    (artname.replace(" ", "_"), to_artname.replace(" ", "_"))
+                    (slugify(artname), slugify(to_artname))
                     for artname in from_artname
                 )
                 for to_artname, from_artname in dependencies.items()

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -271,8 +271,12 @@ class ArtifactCollection:
                 f"Duplicated input parameters {module_input_parameters_list} across multiple sessions"
             )
         elif set(module_input_parameters_list) != set(self.input_parameters):
+            missing_parameters = set(self.input_parameters) - set(
+                module_input_parameters_list
+            )
             raise ValueError(
-                f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}"
+                f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.input_parameters}. "
+                + f"The following parameters are missing {missing_parameters}."
             )
 
         # Sort input parameter for the run_all in the module as the same order

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -108,6 +108,7 @@ class NodeCollection:
         """
         Update variable information based on node_list
         """
+        print(input_parameters_node)
         self.dependent_variables = self.dependent_variables.union(
             *[node_context[nid].dependent_variables for nid in self.node_list]
         )
@@ -122,14 +123,15 @@ class NodeCollection:
         # required input variables
         self.input_variables = self.all_variables - self.assigned_variables
         # Add user defined parameter in to input variables list
+        user_input_parameters = set(
+            [
+                var
+                for var, nid in input_parameters_node.items()
+                if nid in self.node_list
+            ]
+        )
         self.input_variables = self.input_variables.union(
-            set(
-                [
-                    input_parameters_node[nid]
-                    for nid in self.node_list
-                    if nid in input_parameters_node.keys()
-                ]
-            )
+            user_input_parameters
         )
 
     def _update_graph(self, graph: Graph) -> None:

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -108,7 +108,6 @@ class NodeCollection:
         """
         Update variable information based on node_list
         """
-        print(input_parameters_node)
         self.dependent_variables = self.dependent_variables.union(
             *[node_context[nid].dependent_variables for nid in self.node_list]
         )

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -308,9 +308,12 @@ class SessionArtifacts:
 
         for var, node_id in self.input_parameters_node.items():
             if len(self.node_context[node_id].dependent_variables) > 0:
+                dep_vars = ", ".join(
+                    sorted(list(self.node_context[node_id].dependent_variables))
+                )
                 raise ValueError(
-                    f"LineaPy only supports literal value as input parameters for now. "
-                    f"{var} only has non-literal values in this Session."
+                    f"LineaPy only supports input parameters without dependent variables for now. "
+                    f"{var} has dependent variables: {dep_vars}."
                 )
 
     def _get_subgraph_from_node_list(self, node_list: List[LineaID]) -> Graph:
@@ -705,6 +708,16 @@ class SessionArtifacts:
                 variable_name = variable_def.split("=")[0].strip(" ")
                 value = eval(variable_def.split("=")[1].strip(" "))
                 value_type = type(value)
+                if not (
+                    isinstance(value, int)
+                    or isinstance(value, float)
+                    or isinstance(value, str)
+                    or isinstance(value, bool)
+                ):
+                    raise ValueError(
+                        f"LineaPy only supports primitive types as input parameters for now. "
+                        f"{variable_name} in {variable_def} is a {value_type}."
+                    )
                 if ":" in variable_name:
                     variable_name = variable_def.split(":")[0]
                     session_input_variables[variable_name] = InputVariable(

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -265,6 +265,12 @@ class SessionArtifacts:
         # the literal assignment only happen once in the entire session at this
         # moment. If there is a way to specify which literal assignment to use
         # as an input parameter. We can relax this restriction.
+        # We allow multiple assignments to non-literals to handle common cases like the
+        # following:
+        # x = 1
+        # x = x + 1
+        # input_parameters = [x]
+        # In this case, the original definition of x = 1 will be parametrized.
         for var, node_ids in input_parameters_assignment_nodes.items():
             for node_id in node_ids:
                 if node_id in self.node_context.keys():

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -309,7 +309,9 @@ class SessionArtifacts:
         for var, node_id in self.input_parameters_node.items():
             if len(self.node_context[node_id].dependent_variables) > 0:
                 dep_vars = ", ".join(
-                    sorted(list(self.node_context[node_id].dependent_variables))
+                    sorted(
+                        list(self.node_context[node_id].dependent_variables)
+                    )
                 )
                 raise ValueError(
                     f"LineaPy only supports input parameters without dependent variables for now. "

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -547,12 +547,12 @@ class SessionArtifacts:
                         )
 
                 # Remove input parameter node
+                nodecollectioninfo._update_variable_info(
+                    self.node_context, self.input_parameters_node
+                )
                 nodecollectioninfo.node_list = (
                     nodecollectioninfo.node_list
                     - set(self.input_parameters_node.values())
-                )
-                nodecollectioninfo._update_variable_info(
-                    self.node_context, self.input_parameters_node
                 )
                 nodecollectioninfo._update_graph(self.graph)
                 self.artifact_nodecollections.append(nodecollectioninfo)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -82,28 +82,32 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
 
 
 @pytest.mark.parametrize(
-    "code",
+    "code, message",
     [
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','a'])",
+            "Duplicated input parameters detected in ['a', 'a']",
             id="duplicated_input_vars",
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','x'])",
+            "The following parameters are missing {'x'}",
             id="nonexisting_input_vars",
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['b'], input_parameters=['b'])",
+            "LineaPy only supports literal value as input parameters for now. b only has non-literal values in this Session.",
             id="non_literal_assignment",
         ),
         pytest.param(
             # Variable c will affect both artifact b and c
             "import lineapy\nft = lineapy.get_function(['b','c'], input_parameters=['c'])",
+            "Variable c, is defined more than once",
             id="duplicated_literal_assignment",
         ),
     ],
 )
-def test_get_function_error(execute, code):
+def test_get_function_error(execute, code, message):
     """
     Sanity check for lineapy.get_function
     """
@@ -121,3 +125,4 @@ lineapy.save(c,'c')
     res = execute(art_code, snapshot=False)
     with pytest.raises(UserException) as e_info:
         res = execute(code, snapshot=False)
+    assert message in str(e_info.value)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -105,6 +105,12 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
             "Variable c, is defined more than once",
             id="duplicated_literal_assignment",
         ),
+        pytest.param(
+            # Variable d has a literal and non-literal assignment, code should default correctly to literal, does not error
+            "import lineapy\nft = lineapy.get_function(['b','d'], input_parameters=['d'])",
+            "",
+            id="default_to_literal_assignment",
+        ),
     ],
 )
 def test_get_function_error(execute, code, message):
@@ -121,8 +127,16 @@ lineapy.save(b,'b')
 c = 2
 c = 3
 lineapy.save(c,'c')
+d = 1
+d = d + 1
+lineapy.save(d, 'd')
 """
     res = execute(art_code, snapshot=False)
-    with pytest.raises(UserException) as e_info:
+    # Check exception is raised and error message matches
+    if message:
+        with pytest.raises(UserException) as e_info:
+            res = execute(code, snapshot=False)
+        assert message in str(e_info.value)
+    # Run as is, no error message expected
+    else:
         res = execute(code, snapshot=False)
-    assert message in str(e_info.value)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -8,17 +8,17 @@ from lineapy.exceptions.user_exception import UserException
     [
         pytest.param(
             "import lineapy\nx = 1\nlineapy.save(x,'x')\nft = lineapy.get_function(['x'], input_parameters=['x'])",
-            {'x':1},
+            {"x": 1},
             1,
             id="identity",
         ),
         pytest.param(
             "import lineapy\nx = 1\nx = x+1\nlineapy.save(x,'x')\nft = lineapy.get_function(['x'], input_parameters=['x'])",
-            {'x':1},
+            {"x": 1},
             2,
             id="mutated",
         ),
-    ]
+    ],
 )
 def test_same_name_for_artifact_and_input(execute, code, input, expected):
     """
@@ -26,7 +26,8 @@ def test_same_name_for_artifact_and_input(execute, code, input, expected):
     """
     res = execute(code, snapshot=False)
     ft = res.values["ft"]
-    assert ft(**input)["x"] == expected # x==x
+    assert ft(**input)["x"] == expected  # x==x
+
 
 def test_get_function(execute):
     """

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -91,7 +91,7 @@ ft_with_old_multiplier = ft(a=5)["prod_p"]
         ),
         pytest.param(
             "import lineapy\nft = lineapy.get_function(['a'], input_parameters=['a','x'])",
-            "The following parameters are missing {'x'}",
+            "The following variables do not have references in any session code: {'x'}",
             id="nonexisting_input_vars",
         ),
         pytest.param(


### PR DESCRIPTION
# Description

Continue the work in https://github.com/LineaLabs/lineapy/pull/808.

* Separate warnings for input parameters with dependent variables and non-primitive input parameters.
* Fix error in following code
```
x = 1
x = x+1
lineapy.save(x, 'x')
ft = lineapy.get_function(['x'], input_parameters=['x'])
ft(1) 
```
This is due to the input parameter being incorrect in the artifact calculation function definition

Fixes # (issue)

LIN-628

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing test + new tests