### PR TITLE
LIN-656, LIN-640: Refactor Artifact Collection

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -12,7 +12,10 @@ from typing import Callable, List, Optional, Tuple, Union
 import fsspec
 from pandas.io.pickle import to_pickle
 
-from lineapy.api.models.linea_artifact import LineaArtifact
+from lineapy.api.models.linea_artifact import (
+    LineaArtifact,
+    get_lineaartifactdef,
+)
 from lineapy.api.models.linea_artifact_store import LineaArtifactStore
 from lineapy.api.models.pipeline import Pipeline
 from lineapy.data.types import Artifact, LineaID, NodeValue
@@ -499,11 +502,18 @@ def get_function(
         within the same session.
     """
     execution_context = get_context()
+    artifact_defs = [
+        get_lineaartifactdef(art_entry=art_entry) for art_entry in artifacts
+    ]
+    reuse_pre_computed_artifact_defs = [
+        get_lineaartifactdef(art_entry=art_entry)
+        for art_entry in reuse_pre_computed_artifacts
+    ]
     art_collection = ArtifactCollection(
         execution_context.executor.db,
-        artifacts,
+        artifact_defs,
         input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
+        reuse_pre_computed_artifacts=reuse_pre_computed_artifact_defs,
     )
     writer = BasePipelineWriter(art_collection)
     module = load_as_module(writer)
@@ -536,11 +546,18 @@ def get_module_definition(
         as `run_all_sessions`.
     """
     execution_context = get_context()
+    artifact_defs = [
+        get_lineaartifactdef(art_entry=art_entry) for art_entry in artifacts
+    ]
+    reuse_pre_computed_artifact_defs = [
+        get_lineaartifactdef(art_entry=art_entry)
+        for art_entry in reuse_pre_computed_artifacts
+    ]
     art_collection = ArtifactCollection(
         execution_context.executor.db,
-        artifacts,
+        artifact_defs,
         input_parameters=input_parameters,
-        reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
+        reuse_pre_computed_artifacts=reuse_pre_computed_artifact_defs,
     )
     writer = BasePipelineWriter(art_collection)
     return writer._compose_module()

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -22,6 +22,8 @@ from lineapy.exceptions.user_exception import UserException
 from lineapy.execution.context import get_context
 from lineapy.graph_reader.artifact_collection import ArtifactCollection
 from lineapy.instrumentation.annotation_spec import ExternalState
+from lineapy.plugins.loader import load_as_module
+from lineapy.plugins.pipeline_writers import BasePipelineWriter
 from lineapy.plugins.task import AirflowDagConfig, TaskGraphEdge
 from lineapy.plugins.utils import slugify
 from lineapy.utils.analytics.event_schemas import (
@@ -503,7 +505,9 @@ def get_function(
         input_parameters=input_parameters,
         reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
-    return art_collection.get_module().run_all_sessions
+    writer = BasePipelineWriter(art_collection)
+    module = load_as_module(writer)
+    return module.run_all_sessions
 
 
 def get_module_definition(
@@ -538,4 +542,5 @@ def get_module_definition(
         input_parameters=input_parameters,
         reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
     )
-    return art_collection.generate_module_text()
+    writer = BasePipelineWriter(art_collection)
+    return writer._compose_module()

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 
 from lineapy.api.api_utils import extract_taskgraph
 from lineapy.data.types import PipelineType
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class Pipeline:
     def __init__(
         self,
-        artifacts: List[str],
+        artifacts: List[Union[str, Tuple[str, int]]],
         name: Optional[str] = None,
         dependencies: TaskGraphEdge = {},
     ):
@@ -43,7 +43,7 @@ class Pipeline:
             artifacts, dependencies
         )
         self.name = name or "_".join(self.artifact_safe_names)
-        self.artifact_names: List[str] = artifacts
+        self.artifact_names: List[Union[str, Tuple[str, int]]] = artifacts
         self.id = get_new_id()
 
     def export(
@@ -51,7 +51,7 @@ class Pipeline:
         framework: str = "SCRIPT",
         output_dir: str = ".",
         input_parameters: List[str] = [],
-        reuse_pre_computed_artifacts: List[str] = [],
+        reuse_pre_computed_artifacts: List[Union[str, Tuple[str, int]]] = [],
         pipeline_dag_config: Optional[AirflowDagConfig] = {},
     ) -> Path:
         # Create artifact collection

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from lineapy.api.api_utils import extract_taskgraph
+from lineapy.api.models.linea_artifact import get_lineaartifactdef
 from lineapy.data.types import PipelineType
 from lineapy.db.relational import (
     ArtifactDependencyORM,
@@ -56,11 +57,19 @@ class Pipeline:
     ) -> Path:
         # Create artifact collection
         execution_context = get_context()
+        artifact_defs = [
+            get_lineaartifactdef(art_entry=art_entry)
+            for art_entry in self.artifact_names
+        ]
+        reuse_pre_computed_artifact_defs = [
+            get_lineaartifactdef(art_entry=art_entry)
+            for art_entry in reuse_pre_computed_artifacts
+        ]
         artifact_collection = ArtifactCollection(
             db=execution_context.executor.db,
-            target_artifacts=self.artifact_names,
+            target_artifacts=artifact_defs,
             input_parameters=input_parameters,
-            reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
+            reuse_pre_computed_artifacts=reuse_pre_computed_artifact_defs,
         )
 
         # Check if the specified framework is a supported/valid one

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional
 
 from lineapy.api.api_utils import extract_taskgraph
 from lineapy.data.types import PipelineType
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class Pipeline:
     def __init__(
         self,
-        artifacts: List[Union[str, Tuple[str, int]]],
+        artifacts: List[str],
         name: Optional[str] = None,
         dependencies: TaskGraphEdge = {},
     ):
@@ -43,7 +43,7 @@ class Pipeline:
             artifacts, dependencies
         )
         self.name = name or "_".join(self.artifact_safe_names)
-        self.artifact_names: List[Union[str, Tuple[str, int]]] = artifacts
+        self.artifact_names: List[str] = artifacts
         self.id = get_new_id()
 
     def export(
@@ -51,7 +51,7 @@ class Pipeline:
         framework: str = "SCRIPT",
         output_dir: str = ".",
         input_parameters: List[str] = [],
-        reuse_pre_computed_artifacts: List[Union[str, Tuple[str, int]]] = [],
+        reuse_pre_computed_artifacts: List[str] = [],
         pipeline_dag_config: Optional[AirflowDagConfig] = {},
     ) -> Path:
         # Create artifact collection

--- a/lineapy/cli/cli.py
+++ b/lineapy/cli/cli.py
@@ -25,7 +25,10 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from rich.console import Console
 from rich.progress import Progress
 
-from lineapy.api.models.linea_artifact import LineaArtifact
+from lineapy.api.models.linea_artifact import (
+    LineaArtifact,
+    get_lineaartifactdef,
+)
 from lineapy.data.types import SessionType
 from lineapy.db.db import RelationalLineaDB
 from lineapy.exceptions.excepthook import set_custom_excepthook
@@ -430,8 +433,10 @@ def python_cli(
 
         # TODO: Use `Pipeline` object as an entry point (LIN-319 needs
         # to be tackled first to define/refine expected behavior for CLI).
-
-        artifact_collection = ArtifactCollection(db, slice)
+        art_slice_defs = [
+            get_lineaartifactdef(art_entry=art_entry) for art_entry in slice
+        ]
+        artifact_collection = ArtifactCollection(db, art_slice_defs)
         task_dependencies = ast.literal_eval(airflow_task_dependencies or "{}")
 
         # Construct pipeline writer

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -73,10 +73,6 @@ class ArtifactCollection:
             )
         )
 
-        # TODO: LIN-653, LIN-640
-        # Add some type of validation that all re-use compute artifacts can be matched to
-        # a target artifact.
-
         # For each session, construct SessionArtifacts object
         self.session_artifacts: Dict[LineaID, SessionArtifacts] = {}
         for (
@@ -95,6 +91,29 @@ class ArtifactCollection:
                 input_parameters=input_parameters,
                 reuse_pre_computed_artifacts=pre_calculated_artifacts,
             )
+
+        # TODO: LIN-653, LIN-640
+        # Add some type of validation that all re-use compute artifacts can be matched to
+        # a target artifact before the creation of SessionArtifacts.
+        # Check all reuse_pre_computed artifacts is used
+        all_sessions_artifacts = []
+        for sa in self.session_artifacts.values():
+            all_sessions_artifacts += [
+                art.name for art in sa.all_session_artifacts.values()
+            ]
+        pre_calculated_artifacts = sum(
+            self.pre_computed_artifacts_by_session.values(), []
+        )
+        for reuse_art in pre_calculated_artifacts:
+            reuse_name = reuse_art.name
+            if reuse_name not in all_sessions_artifacts:
+                msg = (
+                    f"Artifact {reuse_name} cannot be reused since it is not "
+                    + "used to calculate artifacts "
+                    + f"{', '.join([str(art) for art in target_artifacts])}. "
+                    + "Try to remove it from the reuse list."
+                )
+                raise KeyError(msg)
 
     def _get_artifacts_grouped_by_session(
         self, artifact_entries: List[LineaArtifactDef]

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -57,7 +57,7 @@ class SessionArtifacts:
         db: RelationalLineaDB,
         target_artifacts: List[LineaArtifact],
         input_parameters: List[str] = [],
-        reuse_pre_computed_artifacts: Dict[str, LineaArtifact] = {},
+        reuse_pre_computed_artifacts: List[LineaArtifact] = [],
     ) -> None:
         self.db = db
         self.target_artifacts = target_artifacts
@@ -82,7 +82,9 @@ class SessionArtifacts:
         self.artifact_nodecollections = []
         self.node_context = OrderedDict()
         self.input_parameters = input_parameters
-        self.reuse_pre_computed_artifacts = reuse_pre_computed_artifacts
+        self.reuse_pre_computed_artifacts = {
+            art.name: art for art in reuse_pre_computed_artifacts
+        }
 
         # Retrive all artifacts within the subgraph of target artifacts
         self._retrive_all_session_artifacts()

--- a/lineapy/plugins/loader.py
+++ b/lineapy/plugins/loader.py
@@ -1,0 +1,34 @@
+import importlib.util
+import sys
+import tempfile
+from importlib.abc import Loader
+from pathlib import Path
+
+from lineapy.plugins.pipeline_writers import BasePipelineWriter
+from lineapy.utils.utils import prettify
+
+
+def load_as_module(writer: BasePipelineWriter):
+    """
+    Writing module text to a temp file and load module with names of
+    ``session_art1_art2_...```
+    """
+
+    module_name = f"session_{'_'.join(writer.artifact_collection.session_artifacts.keys())}"
+    temp_folder = tempfile.mkdtemp()
+    temp_module_path = Path(temp_folder, f"{module_name}.py")
+
+    with open(temp_module_path, "w") as f:
+        f.writelines(prettify(writer._compose_module()))
+
+    spec = importlib.util.spec_from_file_location(
+        module_name, temp_module_path
+    )
+    if spec is not None:
+        session_module = importlib.util.module_from_spec(spec)
+        assert isinstance(spec.loader, Loader)
+        sys.modules["module.name"] = session_module
+        spec.loader.exec_module(session_module)
+        return session_module
+    else:
+        raise Exception("LineaPy cannot retrive a module.")

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import warnings
 from pathlib import Path
@@ -9,6 +10,7 @@ from lineapy.graph_reader.artifact_collection import (
     SessionArtifacts,
 )
 from lineapy.graph_reader.node_collection import NodeCollectionType
+from lineapy.graph_reader.types import InputVariable
 from lineapy.plugins.task import (
     AirflowDagConfig,
     AirflowDagFlavor,
@@ -53,19 +55,16 @@ class BasePipelineWriter:
         self.pipeline_name = slugify(pipeline_name)
         self.output_dir = Path(output_dir)
         self.dag_config = dag_config or {}
+        self.dependencies = dependencies
 
-        # Sort sessions topologically (applicable if artifacts come from multiple sessions)
         self.session_artifacts_sorted = (
-            artifact_collection.sort_session_artifacts(
+            self.artifact_collection.sort_session_artifacts(
                 dependencies=dependencies
             )
         )
 
         # Create output directory folder(s) if nonexistent
         self.output_dir.mkdir(exist_ok=True, parents=True)
-
-        # We assume there is at least one SessionArtifacts object
-        self.db = self.session_artifacts_sorted[0].db
 
     @property
     def docker_template_name(self) -> str:
@@ -82,13 +81,117 @@ class BasePipelineWriter:
         """
         Write out module file containing refactored code.
         """
-        module_text = self.artifact_collection._compose_module(
-            session_artifacts_sorted=self.session_artifacts_sorted,
+        module_text = self._compose_module(
             indentation=4,
         )
         file = self.output_dir / f"{self.pipeline_name}_module.py"
         file.write_text(prettify(module_text))
         logger.info(f"Generated module file: {file}")
+
+    def _compose_module(
+        self,
+        indentation: int = 4,
+        return_dict_name="artifacts",
+    ) -> str:
+        """
+        Generate a Python module that calculates artifacts
+        in the given artifact collection.
+        """
+
+        # Sort sessions topologically (applicable if artifacts come from multiple sessions)
+
+        indentation_block = " " * indentation
+
+        module_imports = "\n".join(
+            [
+                sa.get_session_module_imports()
+                for sa in self.session_artifacts_sorted
+            ]
+        )
+
+        artifact_function_definition = "\n".join(
+            list(
+                itertools.chain.from_iterable(
+                    [
+                        sa.get_session_artifact_function_definitions(
+                            indentation=indentation
+                        )
+                        for sa in self.session_artifacts_sorted
+                    ]
+                )
+            )
+        )
+
+        session_functions = "\n".join(
+            [
+                sa.get_session_function(indentation=indentation)
+                for sa in self.session_artifacts_sorted
+            ]
+        )
+
+        module_function_body = "\n".join(
+            [
+                f"{indentation_block}{return_dict_name}.update({sa.get_session_function_callblock()})"
+                for sa in self.session_artifacts_sorted
+            ]
+        )
+
+        module_input_parameters: List[InputVariable] = []
+        for sa in self.session_artifacts_sorted:
+            module_input_parameters += list(
+                sa.get_session_input_parameters_spec().values()
+            )
+
+        module_input_parameters_list = [
+            param.variable_name for param in module_input_parameters
+        ]
+        if len(module_input_parameters_list) != len(
+            set(module_input_parameters_list)
+        ):
+            raise ValueError(
+                f"Duplicated input parameters {module_input_parameters_list} across multiple sessions"
+            )
+        elif set(module_input_parameters_list) != set(
+            self.artifact_collection.input_parameters
+        ):
+            missing_parameters = set(
+                self.artifact_collection.input_parameters
+            ) - set(module_input_parameters_list)
+            raise ValueError(
+                f"Detected input parameters {module_input_parameters_list} do not agree with user input {self.artifact_collection.input_parameters}. "
+                + f"The following variables do not have references in any session code: {missing_parameters}."
+            )
+
+        # Sort input parameter for the run_all in the module as the same order
+        # of user's input parameter
+        user_input_parameters_ordering = {
+            var: i
+            for i, var in enumerate(self.artifact_collection.input_parameters)
+        }
+        module_input_parameters.sort(
+            key=lambda x: user_input_parameters_ordering[x.variable_name]
+        )
+
+        # Put all together to generate module text
+        MODULE_TEMPLATE = load_plugin_template("module.jinja")
+        module_text = MODULE_TEMPLATE.render(
+            indentation_block=indentation_block,
+            module_imports=module_imports,
+            artifact_functions=artifact_function_definition,
+            session_functions=session_functions,
+            module_function_body=module_function_body,
+            default_input_parameters=[
+                param.default_args for param in module_input_parameters
+            ],
+            parser_input_parameters=[
+                param.parser_args for param in module_input_parameters
+            ],
+            parser_blocks=[
+                param.parser_body for param in module_input_parameters
+            ],
+        )
+
+        return prettify(module_text)
 
     def _write_requirements(self) -> None:
         """

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -56,7 +56,7 @@ class BasePipelineWriter:
 
         # Sort sessions topologically (applicable if artifacts come from multiple sessions)
         self.session_artifacts_sorted = (
-            artifact_collection._sort_session_artifacts(
+            artifact_collection.sort_session_artifacts(
                 dependencies=dependencies
             )
         )
@@ -505,7 +505,7 @@ class AirflowCodeGenerator:
 
     def get_params_args(self) -> str:
         input_parameters_dict = dict()
-        for sa in self.artifact_collection._sort_session_artifacts():
+        for sa in self.artifact_collection.sort_session_artifacts():
             for input_spec in sa.get_session_input_parameters_spec().values():
                 input_parameters_dict[
                     input_spec.variable_name
@@ -514,7 +514,7 @@ class AirflowCodeGenerator:
 
     def get_session_function_params_args(self) -> Dict[str, str]:
         session_function_input_parameters = dict()
-        for sa in self.artifact_collection._sort_session_artifacts():
+        for sa in self.artifact_collection.sort_session_artifacts():
             session_input_parameters = list(sa.input_parameters_node.keys())
             if len(session_input_parameters) > 0:
                 session_function_input_parameters[
@@ -531,7 +531,7 @@ class AirflowCodeGenerator:
         self, artifact_function_definitions: Dict[str, TaskDefinition]
     ) -> Dict[str, str]:
         artifact_function_input_parameters = dict()
-        for sa in self.artifact_collection._sort_session_artifacts():
+        for sa in self.artifact_collection.sort_session_artifacts():
             session_input_parameters = set(sa.input_parameters_node.keys())
             for nc in sa.artifact_nodecollections:
                 user_input_variables = artifact_function_definitions[

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -197,7 +197,7 @@ lineapy.save(c,'c')
         reuse_pre_computed_artifacts=["b"],
         input_parameters=["a"],
     )
-    ac._sort_session_artifacts(dependencies={"c": {"b"}})
+    ac.sort_session_artifacts(dependencies={"c": {"b"}})
     module = ac.get_module()
     assert not hasattr(module, "get_a")
     assert hasattr(module, "get_b")

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 
 from lineapy.graph_reader.artifact_collection import ArtifactCollection
+from lineapy.plugins.loader import load_as_module
+from lineapy.plugins.pipeline_writers import BasePipelineWriter
 
 
 @pytest.mark.parametrize(
@@ -69,7 +71,8 @@ def test_one_session(linea_db, execute, input_script, artifact_list):
 
     execute(code, snapshot=False)
     ac = ArtifactCollection(linea_db, artifact_list)
-    module = ac.get_module()
+    writer = BasePipelineWriter(ac, {})
+    module = load_as_module(writer)
     # Check there is a get_{artifact} function in the module for all artifacts
     assert all(
         [
@@ -139,7 +142,8 @@ def test_two_sessions(
     code = session2_code
     execute(code, snapshot=False)
     ac = ArtifactCollection(linea_db, artifact_list)
-    module = ac.get_module()
+    writer = BasePipelineWriter(ac, {})
+    module = load_as_module(writer)
     # Check there is a get_{artifact} function in the module for all artifacts
     assert all(
         [
@@ -151,7 +155,8 @@ def test_two_sessions(
     # If dependencies have been set, check whether the run_session_including_{art}
     # show up in correct order
     if len(dependencies) > 0:
-        moduletext = ac.generate_module_text(dependencies)
+        writer = BasePipelineWriter(ac, dependencies)
+        moduletext = writer._compose_module()
         first_artifact_in_session = {}
         for sa in ac.session_artifacts.values():
             for nodecollection in sa.artifact_nodecollections:
@@ -197,8 +202,8 @@ lineapy.save(c,'c')
         reuse_pre_computed_artifacts=["b"],
         input_parameters=["a"],
     )
-    ac.sort_session_artifacts(dependencies={"c": {"b"}})
-    module = ac.get_module()
+    writer = BasePipelineWriter(ac, dependencies={"c": {"b"}})
+    module = load_as_module(writer)
     assert not hasattr(module, "get_a")
     assert hasattr(module, "get_b")
     assert hasattr(module, "get_c")
@@ -242,9 +247,10 @@ lineapy.save(b,'prod_p')
     ac = ArtifactCollection(
         linea_db, artifact_list, input_parameters=input_parameters
     )
+    writer = BasePipelineWriter(ac, {})
     temp_module_path = pathlib.Path(tmpdir, "artifactcollection_module.py")
     with open(temp_module_path, "w") as f:
-        f.writelines(ac.generate_module_text())
+        f.writelines(writer._compose_module())
 
     cmds = ["python", str(temp_module_path)]
     # Add input parameter values if specified in cmds

--- a/tests/unit/plugins/test_writer.py
+++ b/tests/unit/plugins/test_writer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from lineapy.api.models.linea_artifact import get_lineaartifactdef
 from lineapy.data.types import PipelineType
 from lineapy.graph_reader.artifact_collection import ArtifactCollection
 from lineapy.plugins.pipeline_writers import PipelineWriterFactory
@@ -210,8 +211,9 @@ def test_pipeline_generation(
         ).read_text()
         execute(code2, snapshot=False)
 
+    artifact_def_list = [get_lineaartifactdef(art) for art in artifact_list]
     artifact_collection = ArtifactCollection(
-        linea_db, artifact_list, input_parameters=input_parameters
+        linea_db, artifact_def_list, input_parameters=input_parameters
     )
 
     # Construct pipeline writer
@@ -304,7 +306,8 @@ def test_pipeline_test_generation(
         ).read_text()
         execute(code2, snapshot=False)
 
-    artifact_collection = ArtifactCollection(linea_db, artifact_list)
+    artifact_def_list = [get_lineaartifactdef(art) for art in artifact_list]
+    artifact_collection = ArtifactCollection(linea_db, artifact_def_list)
 
     # Construct pipeline writer
     pipeline_writer = PipelineWriterFactory.get(


### PR DESCRIPTION
# Description

Refactor internal Artifact Collection class.

- Move `_compose_module` to BasePipelineWriter, since it does not modify the Artifact Collection but returns a string representation that can be parametrized which is more suitable for Writer classes.
- `generate_module_text` refactored out. Sorting session artifacts is now done in constructor and prettify is in `_compose_modules`. All external references replaced with `_compose_module`. 
- Move `get_module`, which requires a written version of the module to a utility function and rename to `load_as_module` in `lineapy.plugins.loader`. Since the desired use case is to run a function/module, this should be replaced by proper execution of a module through the LineaGraph in the future. 
- Cleanup constructor for ArtifactCollection. Grouping artifacts by session is now refactored into a helper function `_get_artifacts_grouped_by_session` and applied to both target and reuse-precomputed artifact lists. 
- Added Todos add better checks to validate reuse-precomputed artifacts by their Session to keep SessionArtifact contained to only operate within a single Session as much as possible.
- `sort_session_artifacts` broken down into `validate_dependencies` helper and `create_inter_session_taskgraph` before sorting the session graph. 
- Changed API for ArtifactCollection, which is internal, to only accept LineaArtifactDefs, and move the conversion to ArtifactDefs to layer between user facing UI before creation of ArtifactCollection. 
- Other minor changes with naming, deleting unused variables, type hinting, fixing tests to use newly refactored methods. 

## Fixes
LIN-656, Refactor Artifact Collection

## Type of change

- [ X ] Refactor, should not change behavior.

# How Has This Been Tested?

Run all current pytests.