### PR TITLE
LIN-533 keep unsliced code

### DIFF
--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -373,6 +373,7 @@ def to_pipeline(
     reuse_pre_computed_artifacts: List[str] = [],
     generate_test: bool = False,
     pipeline_dag_config: Optional[AirflowDagConfig] = {},
+    include_non_slice_as_comment: bool = True,
 ) -> Path:
     """
     Writes the pipeline job to a path on disk.
@@ -446,6 +447,7 @@ def to_pipeline(
         reuse_pre_computed_artifacts=reuse_pre_computed_artifacts,
         generate_test=generate_test,
         pipeline_dag_config=pipeline_dag_config,
+        include_non_slice_as_comment=include_non_slice_as_comment,
     )
 
 

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -373,7 +373,7 @@ def to_pipeline(
     reuse_pre_computed_artifacts: List[str] = [],
     generate_test: bool = False,
     pipeline_dag_config: Optional[AirflowDagConfig] = {},
-    include_non_slice_as_comment: bool = True,
+    include_non_slice_as_comment: bool = False,
 ) -> Path:
     """
     Writes the pipeline job to a path on disk.

--- a/lineapy/api/models/linea_artifact.py
+++ b/lineapy/api/models/linea_artifact.py
@@ -16,9 +16,9 @@ from lineapy.data.types import LineaID
 from lineapy.db.db import ArtifactORM, RelationalLineaDB
 from lineapy.execution.executor import Executor
 from lineapy.graph_reader.program_slice import (
-    _get_preliminary_slice,
     get_slice_graph,
     get_source_code_from_graph,
+    get_subgraph_nodelist,
 )
 from lineapy.utils.analytics.event_schemas import (
     ErrorType,
@@ -157,7 +157,7 @@ class LineaArtifact:
         self, keep_lineapy_save: bool = False
     ) -> Set[LineaID]:
         session_graph = Graph.create_session_graph(self.db, self._session_id)
-        return _get_preliminary_slice(
+        return get_subgraph_nodelist(
             session_graph, [self._node_id], keep_lineapy_save
         )
 
@@ -166,6 +166,7 @@ class LineaArtifact:
         self,
         use_lineapy_serialization: bool = True,
         keep_lineapy_save: bool = False,
+        include_non_slice_as_comment: bool = False,
     ) -> str:
         """
         Return the slices code for the artifact
@@ -191,6 +192,7 @@ class LineaArtifact:
                 session_graph=Graph.create_session_graph(
                     self.db, self._session_id
                 ),
+                include_non_slice_as_comment=include_non_slice_as_comment,
             )
         )
         if not use_lineapy_serialization:

--- a/lineapy/api/models/linea_artifact.py
+++ b/lineapy/api/models/linea_artifact.py
@@ -153,11 +153,11 @@ class LineaArtifact:
         )
 
     @lru_cache(maxsize=None)
-    def _get_subgraph_nodelist(
+    def _get_sessiongraph_and_subgraph_nodelist(
         self, keep_lineapy_save: bool = False
-    ) -> Set[LineaID]:
+    ) -> Tuple[Graph, Set[LineaID]]:
         session_graph = Graph.create_session_graph(self.db, self._session_id)
-        return get_subgraph_nodelist(
+        return session_graph, get_subgraph_nodelist(
             session_graph, [self._node_id], keep_lineapy_save
         )
 
@@ -186,12 +186,14 @@ class LineaArtifact:
                 is_session_code=False,
             )
         )
+        (
+            sessiongraph,
+            subgraph_nodelist,
+        ) = self._get_sessiongraph_and_subgraph_nodelist(keep_lineapy_save)
         code = str(
             get_source_code_from_graph(
-                self._get_subgraph_nodelist(keep_lineapy_save),
-                session_graph=Graph.create_session_graph(
-                    self.db, self._session_id
-                ),
+                subgraph_nodelist,
+                session_graph=sessiongraph,
                 include_non_slice_as_comment=include_non_slice_as_comment,
             )
         )

--- a/lineapy/api/models/linea_artifact.py
+++ b/lineapy/api/models/linea_artifact.py
@@ -176,7 +176,12 @@ class LineaArtifact:
             )
         )
         code = str(
-            get_source_code_from_graph(self._get_subgraph(keep_lineapy_save))
+            get_source_code_from_graph(
+                self._get_subgraph(keep_lineapy_save),
+                session_graph=Graph.create_session_graph(
+                    self.db, self._session_id
+                ),
+            )
         )
         if not use_lineapy_serialization:
             code = de_lineate_code(code, self.db)

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -55,6 +55,7 @@ class Pipeline:
         reuse_pre_computed_artifacts: List[str] = [],
         generate_test: bool = False,
         pipeline_dag_config: Optional[AirflowDagConfig] = {},
+        include_non_slice_as_comment=True,
     ) -> Path:
         # Create artifact collection
         execution_context = get_context()
@@ -71,6 +72,7 @@ class Pipeline:
             target_artifacts=artifact_defs,
             input_parameters=input_parameters,
             reuse_pre_computed_artifacts=reuse_pre_computed_artifact_defs,
+            include_non_slice_as_comment=include_non_slice_as_comment,
         )
 
         # Check if the specified framework is a supported/valid one

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -55,7 +55,7 @@ class Pipeline:
         reuse_pre_computed_artifacts: List[str] = [],
         generate_test: bool = False,
         pipeline_dag_config: Optional[AirflowDagConfig] = {},
-        include_non_slice_as_comment=True,
+        include_non_slice_as_comment=False,
     ) -> Path:
         # Create artifact collection
         execution_context = get_context()

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -38,7 +38,7 @@ class ArtifactCollection:
         target_artifacts: List[LineaArtifactDef],
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: List[LineaArtifactDef] = [],
-        include_non_slice_as_comment=True,
+        include_non_slice_as_comment=False,
     ) -> None:
         self.db: RelationalLineaDB = db
 

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -38,10 +38,12 @@ class ArtifactCollection:
         target_artifacts: List[LineaArtifactDef],
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: List[LineaArtifactDef] = [],
+        include_non_slice_as_comment=True,
     ) -> None:
         self.db: RelationalLineaDB = db
 
         self.input_parameters = input_parameters
+        self.include_non_slice_as_comment = include_non_slice_as_comment
         if len(input_parameters) != len(set(input_parameters)):
             raise ValueError(
                 f"Duplicated input parameters detected in {input_parameters}"
@@ -76,6 +78,7 @@ class ArtifactCollection:
                 session_artifacts,
                 input_parameters=input_parameters,
                 reuse_pre_computed_artifacts=pre_calculated_artifacts,
+                include_non_slice_as_comment=include_non_slice_as_comment,
             )
 
         # TODO: LIN-653, LIN-640

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -67,7 +67,7 @@ class NodeCollection:
 
     For all code generating purpose, it need to initiate a real graph objects by::
 
-        seg._update_graph()
+        seg.update_raw_codeblock()
 
     Then, it provide following method to generat different codeblock for different
     purpose.
@@ -133,7 +133,7 @@ class NodeCollection:
             user_input_parameters
         )
 
-    def _update_graph(
+    def update_raw_codeblock(
         self, graph: Graph, include_non_slice_as_comment=True
     ) -> None:
         """

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -134,7 +134,7 @@ class NodeCollection:
         )
 
     def update_raw_codeblock(
-        self, graph: Graph, include_non_slice_as_comment=True
+        self, graph: Graph, include_non_slice_as_comment=False
     ) -> None:
         """
         Update graph_segment class member based on node_list
@@ -142,7 +142,7 @@ class NodeCollection:
         Need to manually run this function at least once if you need the graph
         object for code generation.
         """
-        # self.graph_segment = graph.get_subgraph_from_id(list(self.node_list))
+        self.graph_segment = graph.get_subgraph_from_id(list(self.node_list))
         self.raw_codeblock = get_source_code_from_graph(
             self.node_list, graph, include_non_slice_as_comment
         ).__str__()

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -133,16 +133,18 @@ class NodeCollection:
             user_input_parameters
         )
 
-    def _update_graph(self, graph: Graph) -> None:
+    def _update_graph(
+        self, graph: Graph, include_non_slice_as_comment=True
+    ) -> None:
         """
         Update graph_segment class member based on node_list
 
         Need to manually run this function at least once if you need the graph
         object for code generation.
         """
-        self.graph_segment = graph.get_subgraph_from_id(list(self.node_list))
+        # self.graph_segment = graph.get_subgraph_from_id(list(self.node_list))
         self.raw_codeblock = get_source_code_from_graph(
-            self.graph_segment
+            self.node_list, graph, include_non_slice_as_comment
         ).__str__()
         self.is_empty = self.raw_codeblock == ""
 

--- a/lineapy/graph_reader/program_slice.py
+++ b/lineapy/graph_reader/program_slice.py
@@ -269,25 +269,15 @@ def get_source_code_from_graph(
                 )
             )
 
-    # print(slice_nodes)
-    # for n in slice_nodes:
-    #     nn = session_graph.ids[n]
-    #     print(n, nn.node_type)
-    #     if hasattr(nn, "name"):
-    #         print(nn.name)
     for n in session_graph.nodes:
-        # print(n.id)
         if n.source_location is None:
-            # print("no source", n.id, n.node_type)
             continue
         # ignore the code cells that have no part in the slice at all
         if (
             not include_non_slice_as_comment
             and n.source_location.source_code not in source_code_to_lines
         ):
-            # print("not including", n.id)
             continue
-        # print("including", n.id)
         session_src[n.source_location.source_code] |= set([n.id])
 
     logger.debug("Source code to lines: %s", source_code_to_lines)
@@ -300,10 +290,6 @@ def get_source_code_from_graph(
         # then there are pieces of the codecell in the final slice.
         lines = source_code_to_lines.get(source_code, set())
         source_code_lines = source_code.code.split("\n")
-        # print("raw code")
-        # print(source_code.code)
-        # print("lines to print")
-        # print(lines)
         if not include_non_slice_as_comment:
             for line in sorted(lines):
                 body_code.append(source_code_lines[line - 1])

--- a/lineapy/graph_reader/program_slice.py
+++ b/lineapy/graph_reader/program_slice.py
@@ -30,7 +30,7 @@ def get_slice_graph(
     :return: A subgraph extracted (i.e., sliced) for the desired node IDs.
 
     """
-    ancestors = _get_preliminary_slice(graph, sinks, keep_lineapy_save)
+    ancestors = get_subgraph_nodelist(graph, sinks, keep_lineapy_save)
 
     ancestors = _include_dependencies_for_indirectly_included_nodes_in_slice(
         graph, ancestors
@@ -41,7 +41,7 @@ def get_slice_graph(
     return subgraph
 
 
-def _get_preliminary_slice(
+def get_subgraph_nodelist(
     graph: Graph, sinks: List[LineaID], keep_lineapy_save: bool
 ) -> Set[LineaID]:
     """
@@ -360,9 +360,7 @@ def get_program_slice(
 
     """
     logger.debug("Slicing graph %s", graph)
-    # subgraph = get_slice_graph(graph, sinks, keep_lineapy_save)
-    subgraph_nodes = _get_preliminary_slice(graph, sinks, keep_lineapy_save)
-    # logger.debug("Subgraph for %s: %s", sinks, subgraph)
+    subgraph_nodes = get_subgraph_nodelist(graph, sinks, keep_lineapy_save)
     return get_source_code_from_graph(subgraph_nodes, graph)
 
 

--- a/lineapy/graph_reader/program_slice.py
+++ b/lineapy/graph_reader/program_slice.py
@@ -361,6 +361,11 @@ def get_program_slice(
     """
     logger.debug("Slicing graph %s", graph)
     subgraph_nodes = get_subgraph_nodelist(graph, sinks, keep_lineapy_save)
+    subgraph_nodes = (
+        _include_dependencies_for_indirectly_included_nodes_in_slice(
+            graph, subgraph_nodes
+        )
+    )
     return get_source_code_from_graph(subgraph_nodes, graph)
 
 

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -532,7 +532,7 @@ class SessionArtifacts:
                         common_nodecollectioninfo._update_variable_info(
                             self.node_context, self.input_parameters_node
                         )
-                        common_nodecollectioninfo._update_graph(
+                        common_nodecollectioninfo.update_raw_codeblock(
                             self._session_graph,
                             include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
@@ -548,7 +548,7 @@ class SessionArtifacts:
                         remaining_nodecollectioninfo._update_variable_info(
                             self.node_context, self.input_parameters_node
                         )
-                        remaining_nodecollectioninfo._update_graph(
+                        remaining_nodecollectioninfo.update_raw_codeblock(
                             self._session_graph,
                             include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
@@ -570,7 +570,7 @@ class SessionArtifacts:
                     nodecollectioninfo.node_list
                     - set(self.input_parameters_node.values())
                 )
-                nodecollectioninfo._update_graph(
+                nodecollectioninfo.update_raw_codeblock(
                     self._session_graph,
                     include_non_slice_as_comment=self.include_non_slice_as_comment,
                 )
@@ -582,7 +582,7 @@ class SessionArtifacts:
             node_list=self.import_nodes,
         )
         # TODO: dont comment unsliced code here as well since we dont care about imports
-        self.import_nodecollection._update_graph(
+        self.import_nodecollection.update_raw_codeblock(
             self.graph, include_non_slice_as_comment=False
         )
 
@@ -595,7 +595,7 @@ class SessionArtifacts:
             self.node_context, self.input_parameters_node
         )
         # TODO: change here to not include raw code since this is generated bits
-        self.input_parameters_nodecollection._update_graph(
+        self.input_parameters_nodecollection.update_raw_codeblock(
             self.graph, include_non_slice_as_comment=False
         )
 

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -59,7 +59,7 @@ class SessionArtifacts:
         target_artifacts: List[LineaArtifact],
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: List[LineaArtifact] = [],
-        include_non_slice_as_comment: bool = True,
+        include_non_slice_as_comment: bool = False,
     ) -> None:
         self.db = db
         self.target_artifacts = target_artifacts

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -714,6 +714,8 @@ class SessionArtifacts:
         session_input_variables: Dict[str, InputVariable] = dict()
         for line in self.get_session_input_parameters_lines().split("\n"):
             variable_def = line.strip(" ").rstrip(",")
+            if variable_def.startswith("#"):
+                continue
             if len(variable_def) > 0:
                 variable_name = variable_def.split("=")[0].strip(" ")
                 value = eval(variable_def.split("=")[1].strip(" "))

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -529,7 +529,9 @@ class SessionArtifacts:
                         common_nodecollectioninfo._update_variable_info(
                             self.node_context, self.input_parameters_node
                         )
-                        common_nodecollectioninfo._update_graph(self.graph)
+                        common_nodecollectioninfo._update_graph(
+                            self._session_graph
+                        )
 
                         remaining_nodes = source_info.node_list - common_nodes
                         remaining_nodecollectioninfo = NodeCollection(
@@ -542,7 +544,9 @@ class SessionArtifacts:
                         remaining_nodecollectioninfo._update_variable_info(
                             self.node_context, self.input_parameters_node
                         )
-                        remaining_nodecollectioninfo._update_graph(self.graph)
+                        remaining_nodecollectioninfo._update_graph(
+                            self._session_graph
+                        )
 
                         self.artifact_nodecollections = (
                             self.artifact_nodecollections[:source_id]
@@ -561,7 +565,7 @@ class SessionArtifacts:
                     nodecollectioninfo.node_list
                     - set(self.input_parameters_node.values())
                 )
-                nodecollectioninfo._update_graph(self.graph)
+                nodecollectioninfo._update_graph(self._session_graph)
                 self.artifact_nodecollections.append(nodecollectioninfo)
 
         # NodeCollection for import
@@ -569,7 +573,8 @@ class SessionArtifacts:
             collection_type=NodeCollectionType.IMPORT,
             node_list=self.import_nodes,
         )
-        self.import_nodecollection._update_graph(self.graph)
+        # TODO: dont comment unsliced code here as well since we dont care about imports
+        self.import_nodecollection._update_graph(self.graph, include_non_slice_as_comment=False)
 
         # NodeCollection for input parameters
         self.input_parameters_nodecollection = NodeCollection(
@@ -579,7 +584,8 @@ class SessionArtifacts:
         self.input_parameters_nodecollection._update_variable_info(
             self.node_context, self.input_parameters_node
         )
-        self.input_parameters_nodecollection._update_graph(self.graph)
+        # TODO: change here to not include raw code since this is generated bits
+        self.input_parameters_nodecollection._update_graph(self.graph, include_non_slice_as_comment=False)
 
     def _update_nodecollection_dependencies(self):
         """

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -51,6 +51,7 @@ class SessionArtifacts:
     all_session_artifacts: Dict[LineaID, LineaArtifact]
     input_parameters: List[str]
     nodecollection_dependencies: TaskGraph
+    include_non_slice_as_comment: bool
 
     def __init__(
         self,
@@ -58,6 +59,7 @@ class SessionArtifacts:
         target_artifacts: List[LineaArtifact],
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: List[LineaArtifact] = [],
+        include_non_slice_as_comment: bool = True,
     ) -> None:
         self.db = db
         self.target_artifacts = target_artifacts
@@ -68,6 +70,7 @@ class SessionArtifacts:
         self._session_graph = Graph.create_session_graph(
             self.db, self._session_id
         )
+        self.include_non_slice_as_comment = include_non_slice_as_comment
         # Only interested union of sliced graph of each artifacts
         self.graph = self._get_subgraph_from_node_list(
             list(
@@ -530,7 +533,8 @@ class SessionArtifacts:
                             self.node_context, self.input_parameters_node
                         )
                         common_nodecollectioninfo._update_graph(
-                            self._session_graph
+                            self._session_graph,
+                            include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
 
                         remaining_nodes = source_info.node_list - common_nodes
@@ -545,7 +549,8 @@ class SessionArtifacts:
                             self.node_context, self.input_parameters_node
                         )
                         remaining_nodecollectioninfo._update_graph(
-                            self._session_graph
+                            self._session_graph,
+                            include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
 
                         self.artifact_nodecollections = (
@@ -565,7 +570,10 @@ class SessionArtifacts:
                     nodecollectioninfo.node_list
                     - set(self.input_parameters_node.values())
                 )
-                nodecollectioninfo._update_graph(self._session_graph)
+                nodecollectioninfo._update_graph(
+                    self._session_graph,
+                    include_non_slice_as_comment=self.include_non_slice_as_comment,
+                )
                 self.artifact_nodecollections.append(nodecollectioninfo)
 
         # NodeCollection for import

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -574,7 +574,9 @@ class SessionArtifacts:
             node_list=self.import_nodes,
         )
         # TODO: dont comment unsliced code here as well since we dont care about imports
-        self.import_nodecollection._update_graph(self.graph, include_non_slice_as_comment=False)
+        self.import_nodecollection._update_graph(
+            self.graph, include_non_slice_as_comment=False
+        )
 
         # NodeCollection for input parameters
         self.input_parameters_nodecollection = NodeCollection(
@@ -585,7 +587,9 @@ class SessionArtifacts:
             self.node_context, self.input_parameters_node
         )
         # TODO: change here to not include raw code since this is generated bits
-        self.input_parameters_nodecollection._update_graph(self.graph, include_non_slice_as_comment=False)
+        self.input_parameters_nodecollection._update_graph(
+            self.graph, include_non_slice_as_comment=False
+        )
 
     def _update_nodecollection_dependencies(self):
         """

--- a/tests/unit/graph_reader/test_program_slice.py
+++ b/tests/unit/graph_reader/test_program_slice.py
@@ -11,8 +11,8 @@ from lineapy.data.types import (
     SourceLocation,
 )
 from lineapy.graph_reader.program_slice import (
-    _get_preliminary_slice,
     _include_dependencies_for_indirectly_included_nodes_in_slice,
+    get_subgraph_nodelist,
 )
 
 source_1 = SourceCode(
@@ -53,14 +53,14 @@ def test_include_dependencies_for_indirectly_included_nodes_in_slice():
     # If _include_dependencies_for_indirectly_included_nodes_in_slice was not
     # present, we would include Instruction 1 and Instruction 3, which means
     # lines 1 and 2 both get included, which indirectly includes Instruction 2,
-    # but the _get_preliminary_slice would not include Instruction 2's node.
+    # but the get_subgraph_nodelist would not include Instruction 2's node.
     nodes = [
         get_dummy_node("1", 1, None),
         get_dummy_node("2", 2, None),
         get_dummy_node("3", 2, "1"),
     ]
     graph = Graph(list(nodes), mocked_session)
-    ancestors = _get_preliminary_slice(graph, [LineaID("3")], False)
+    ancestors = get_subgraph_nodelist(graph, [LineaID("3")], False)
     assert ancestors == {"1", "3"}
     ancestors = _include_dependencies_for_indirectly_included_nodes_in_slice(
         graph, ancestors
@@ -85,7 +85,7 @@ def test_include_dependencies_for_indirectly_included_nodes_in_slice_recursive()
     # If _include_dependencies_for_indirectly_included_nodes_in_slice was not
     # present, we would include Instruction 1 and Instruction 5, which means
     # lines 1 and 4 both get included, which indirectly includes Instruction 6,
-    # but the _get_preliminary_slice would not include Instruction 2's node.
+    # but the get_subgraph_nodelist would not include Instruction 2's node.
     #
     # If _include_dependencies_for_indirectly_included_nodes_in_slice was not
     # recursive, the process would stop after including line 3, but due to
@@ -100,7 +100,7 @@ def test_include_dependencies_for_indirectly_included_nodes_in_slice_recursive()
         get_dummy_node("6", 4, "4"),
     ]
     graph = Graph(list(nodes), mocked_session)
-    ancestors = _get_preliminary_slice(graph, [LineaID("5")], False)
+    ancestors = get_subgraph_nodelist(graph, [LineaID("5")], False)
     assert ancestors == {"1", "5"}
     ancestors = _include_dependencies_for_indirectly_included_nodes_in_slice(
         graph, ancestors


### PR DESCRIPTION
# Description

With the goal of letting users edit the sliced code that made it to the pipeline, we decided that it's easiest if we include the sliced-away bits so that the user can easily add the parts that they want to keep. This adds a cleanup step for them but will be more flexible til we add more magic and fine-tune what the user needs.

Fixes LIN-533

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update

# How Has This Been Tested?
existing tests, pending adding new tests if required.