### PR TITLE
LIN-640, LIN-667, Refactor NodeCollection and _slice_session_artifacts

### DIFF
--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -72,7 +72,6 @@ class Pipeline:
             target_artifacts=artifact_defs,
             input_parameters=input_parameters,
             reuse_pre_computed_artifacts=reuse_pre_computed_artifact_defs,
-            include_non_slice_as_comment=include_non_slice_as_comment,
         )
 
         # Check if the specified framework is a supported/valid one
@@ -88,6 +87,7 @@ class Pipeline:
             output_dir=output_dir,
             generate_test=generate_test,
             dag_config=pipeline_dag_config,
+            include_non_slice_as_comment=include_non_slice_as_comment,
         )
 
         # Write out pipeline files

--- a/lineapy/graph_reader/artifact_collection.py
+++ b/lineapy/graph_reader/artifact_collection.py
@@ -38,12 +38,10 @@ class ArtifactCollection:
         target_artifacts: List[LineaArtifactDef],
         input_parameters: List[str] = [],
         reuse_pre_computed_artifacts: List[LineaArtifactDef] = [],
-        include_non_slice_as_comment=False,
     ) -> None:
         self.db: RelationalLineaDB = db
 
         self.input_parameters = input_parameters
-        self.include_non_slice_as_comment = include_non_slice_as_comment
         if len(input_parameters) != len(set(input_parameters)):
             raise ValueError(
                 f"Duplicated input parameters detected in {input_parameters}"
@@ -78,7 +76,6 @@ class ArtifactCollection:
                 session_artifacts,
                 input_parameters=input_parameters,
                 reuse_pre_computed_artifacts=pre_calculated_artifacts,
-                include_non_slice_as_comment=include_non_slice_as_comment,
             )
 
         # TODO: LIN-653, LIN-640

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -1,8 +1,8 @@
 import logging
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set
 
+from lineapy.api.models.linea_artifact import LineaArtifactDef
 from lineapy.data.graph import Graph
 from lineapy.data.types import LineaID
 from lineapy.graph_reader.program_slice import get_source_code_from_graph
@@ -13,49 +13,37 @@ logger = logging.getLogger(__name__)
 configure_logging()
 
 
-class NodeCollectionType(Enum):
+@dataclass
+class BaseNodeCollection:
     """
-    NodeCollection type to identify the purpose of the node collection
+    BaseNodeCollection represents a collection of Nodes in a Graph.
 
-    :ARTIFACT: node collection for artifact calculation
-    :COMMON_VARIABLE: node collection for calculating variables used in multiple artifacts
-    :IMPORT: node collection for module import
-    :INPUT_VARIABLE: node collection for input variables
+    Used for defining modules and functions.
     """
 
-    ARTIFACT = 1
-    COMMON_VARIABLE = 2
-    IMPORT = 3
-    INPUT_PARAMETERS = 4
+    node_list: Set[LineaID]
+    graph: Graph
+    name: str
+
+    def __post_init__(self):
+        self.safename = slugify(self.name)
+
+    def _get_graph_segment(self) -> Graph:
+        return self.graph.get_subgraph_from_id(list(self.node_list))
+
+    def _get_raw_codeblock(self, include_non_slice_as_comment=False) -> str:
+        graph_segment = self._get_graph_segment()
+        return get_source_code_from_graph(
+            graph_segment, include_non_slice_as_comment
+        ).__str__()
 
 
 @dataclass
-class NodeInfo:
+class UserCodeNodeCollection(BaseNodeCollection):
     """
-    :assigned_variables: variables assigned at this node
-    :assigned_artifact: this node is pointing to some artifact
-    :dependent_variables: union of if any variable is assigned at predecessor node,
-     use the assigned variables. otherwise, use the dependent_variables
-    :tracked_variables: variables that this node is point to
-    :predecessors: predecessors of the node
-    :module_import: module name/alias that this node is point to
-    :artifact_name: this node belong to which artifact calculating block
-    """
+    This class is used for holding a set of node(as a subgraph)
+    corresponding to user code that can be sliced on.
 
-    assigned_variables: Set[str] = field(default_factory=set)
-    assigned_artifact: Optional[str] = field(default=None)
-    dependent_variables: Set[str] = field(default_factory=set)
-    predecessors: Set[LineaID] = field(default_factory=set)
-    tracked_variables: Set[str] = field(default_factory=set)
-    module_import: Set[str] = field(default_factory=set)
-    artifact_name: Optional[str] = field(default=None)
-
-
-@dataclass
-class NodeCollection:
-    """
-    This class is used for holding a set of node(as a subgraph) with same purpose;
-    for instance, calculating some variables, module import, variable assignments.
     It is initiated with list of nodes::
 
         seg = NodeCollection(node_list)
@@ -68,45 +56,39 @@ class NodeCollection:
     For all code generating purpose, it need to initiate a real graph objects by::
 
         seg.update_raw_codeblock()
-
-    Then, it provide following method to generat different codeblock for different
-    purpose.
     """
-
-    collection_type: NodeCollectionType
-    node_list: Set[LineaID]
-
-    name: str = field(default="")
 
     assigned_variables: Set[str] = field(default_factory=set)
     dependent_variables: Set[str] = field(default_factory=set)
     all_variables: Set[str] = field(default_factory=set)
     input_variables: Set[str] = field(default_factory=set)
     tracked_variables: Set[str] = field(default_factory=set)
+    predecessor_nodes: Set[LineaID] = field(default_factory=set)
     # Need to be a list to keep return order
     return_variables: List[str] = field(default_factory=list)
 
-    artifact_node_id: Optional[LineaID] = field(default=None)
-    predecessor_nodes: Set[LineaID] = field(default_factory=set)
-    predecessor_artifact: Set[str] = field(default_factory=set)
-    input_variable_sources: Dict[str, Set[str]] = field(default_factory=dict)
-    safename: str = field(default="")
-    graph_segment: Optional[Graph] = field(default=None)
-    sliced_nodes: Set[LineaID] = field(default_factory=set)
-    raw_codeblock: str = field(default="")
-    is_empty: bool = field(default=True)
-    pre_computed_artifact: Union[None, Tuple[str, Optional[int]]] = field(
-        default=None
-    )
-    is_pre_computed_artifact: bool = field(default=False)
-
-    def __post_init__(self):
-        self.safename = slugify(self.name)
-        self.is_pre_computed_artifact = self.pre_computed_artifact is not None
-
-    def _update_variable_info(self, node_context, input_parameters_node):
+    def get_input_variable_sources(self, node_context) -> Dict[str, Set[str]]:
         """
-        Update variable information based on node_list
+        Get information about which input variable is originated from which artifact.
+        """
+        input_variable_sources: Dict[str, Set[str]] = dict()
+        for pred_id in self.predecessor_nodes:
+            pred_variables = (
+                node_context[pred_id].assigned_variables
+                if len(node_context[pred_id].assigned_variables) > 0
+                else node_context[pred_id].tracked_variables
+            )
+            pred_art = node_context[pred_id].artifact_name
+            assert isinstance(pred_art, str)
+            if pred_art != "module_import":
+                input_variable_sources[pred_art] = input_variable_sources.get(
+                    pred_art, set()
+                ).union(pred_variables)
+        return input_variable_sources
+
+    def update_variable_info(self, node_context, input_parameters_node):
+        """
+        Update variable information to add user defined input parameters.
         """
         self.dependent_variables = self.dependent_variables.union(
             *[node_context[nid].dependent_variables for nid in self.node_list]
@@ -133,113 +115,80 @@ class NodeCollection:
             user_input_parameters
         )
 
-    def update_raw_codeblock(
-        self, graph: Graph, include_non_slice_as_comment=False
-    ) -> None:
-        """
-        Update graph_segment class member based on node_list
-
-        Need to manually run this function at least once if you need the graph
-        object for code generation.
-        """
-        self.graph_segment = graph.get_subgraph_from_id(list(self.node_list))
-        self.raw_codeblock = get_source_code_from_graph(
-            self.node_list, graph, include_non_slice_as_comment
-        ).__str__()
-        self.is_empty = self.raw_codeblock == ""
-
     def get_function_definition(self, indentation=4) -> str:
         """
-        Return a codeblock to define the function of the graph segment. If
-        self.is_pre_computed_artifact is True, will replace the calculation
-        block with lineapy.get().get_value()
+        Return a codeblock to define the function of the graph segment.
         """
-
         indentation_block = " " * indentation
         name = self.safename
         return_string = ", ".join([v for v in self.return_variables])
-        if not self.is_pre_computed_artifact:
-            artifact_codeblock = "\n".join(
-                [
-                    f"{indentation_block}{line}"
-                    for line in self.raw_codeblock.split("\n")
-                    if len(line.strip(" ")) > 0
-                ]
-            )
-            args_string = ", ".join(sorted([v for v in self.input_variables]))
-        else:
-            assert self.pre_computed_artifact is not None
-            artifact_codeblock = (
-                f"{indentation_block}import lineapy\n{indentation_block}"
-            )
-            artifact_codeblock += f'{return_string}=lineapy.get("{self.pre_computed_artifact[0]}", {self.pre_computed_artifact[1]}).get_value()'
-            args_string = ""
+
+        artifact_codeblock = "\n".join(
+            [
+                f"{indentation_block}{line}"
+                for line in self._get_raw_codeblock().split("\n")
+                if len(line.strip(" ")) > 0
+            ]
+        )
+        args_string = ", ".join(sorted([v for v in self.input_variables]))
 
         return f"def get_{name}({args_string}):\n{artifact_codeblock}\n{indentation_block}return {return_string}"
 
-    def get_function_call_block(
-        self,
-        indentation=0,
-        keep_lineapy_save=False,
-        result_placeholder=None,
-        source_module="",
-    ) -> str:
+
+@dataclass
+class ArtifactNodeCollection(UserCodeNodeCollection):
+    """
+    ArtifactNodeCollection is a special subclass of UserCodeNodeCollection which return Artifacts.
+
+    If is_pre_computed is True, this means that this NodeCollection should use a precomputed
+    Artifact's value.
+    """
+
+    is_pre_computed: bool = False
+    pre_computed_artifact: Optional[LineaArtifactDef] = None
+
+    def get_function_definition(self, indentation=4) -> str:
         """
-        Return a codeblock to call the function with return variables of the graph segment
+        Return a codeblock to define the function of the graph segment.
 
-        :param int indentation: indentation size
-        :param bool keep_lineapy_save: whether do lineapy.save() after execution
-        :param Optional[str] result_placeholder: if not null, append the return result to the result_placeholder
-        :param str source_module: which module the function is coming from
-
-        The result_placeholder is a list to capture the artifact variables right
-        after calculation. Considering following code::
-
-            a = 1
-            lineapy.save(a,'a')
-            a+=1
-            b = a+1
-            lineapy.save(b,'b')
-            c = a+1
-            lineapy.save(c,'c')
-
-
-        we need to record the artifact a before it is mutated.
-
+        If self.is_pre_computed_artifact is True, will replace the calculation
+        block with lineapy.get().get_value()
         """
 
-        indentation_block = " " * indentation
-        return_string = ", ".join(self.return_variables)
-        args_string = ", ".join(sorted([v for v in self.input_variables]))
-        if self.is_pre_computed_artifact:
+        if not self.is_pre_computed:
+            return super().get_function_definition(indentation)
+        else:
+            assert self.pre_computed_artifact is not None
+            indentation_block = " " * indentation
+            name = self.safename
+            return_string = ", ".join([v for v in self.return_variables])
+            artifact_codeblock = (
+                f"{indentation_block}import lineapy\n{indentation_block}"
+            )
+            artifact_codeblock += f'{return_string}=lineapy.get("{self.pre_computed_artifact["artifact_name"]}", {self.pre_computed_artifact["version"]}).get_value()'
             args_string = ""
 
-        # handle calling the function from a module
-        if source_module != "":
-            source_module = f"{source_module}."
-        codeblock = f"{indentation_block}{return_string} = {source_module}get_{self.safename}({args_string})"
-        if (
-            keep_lineapy_save
-            and self.collection_type == NodeCollectionType.ARTIFACT
-        ):
-            codeblock += f"""\n{indentation_block}lineapy.save({self.return_variables[0]}, "{self.name}")"""
-        if result_placeholder is not None:
-            codeblock += f"""\n{indentation_block}{result_placeholder}["{self.name}"]=copy.deepcopy({self.return_variables[0]})"""
+            return f"def get_{name}({args_string}):\n{artifact_codeblock}\n{indentation_block}return {return_string}"
 
-        return codeblock
+
+class ImportNodeCollection(BaseNodeCollection):
+    """
+    ImportNodeCollection contains all the nodes used to import libraries in a Session.
+    """
 
     def get_import_block(self, indentation=0) -> str:
         """
         Return a code block for import statement of the graph segment
         """
-        if self.is_empty:
+        raw_codeblock = self._get_raw_codeblock()
+        if raw_codeblock == "":
             return ""
 
         indentation_block = " " * indentation
         import_codeblock = "\n".join(
             [
                 f"{indentation_block}{line}"
-                for line in self.raw_codeblock.split("\n")
+                for line in raw_codeblock.split("\n")
                 if len(line.strip(" ")) > 0
             ]
         )
@@ -247,15 +196,23 @@ class NodeCollection:
             import_codeblock += "\n" * 2
         return import_codeblock
 
+
+class InputVarNodeCollection(BaseNodeCollection):
+    """
+    InputVarNodeCollection contains all the nodes that are needed as input parameters
+    to the Session.
+    """
+
     def get_input_parameters_block(self, indentation=4) -> str:
         """
         Return a code block for input parameters of the graph segment
         """
-        if self.is_empty:
+        raw_codeblock = self._get_raw_codeblock()
+        if raw_codeblock == "":
             return ""
 
         indentation_block = " " * indentation
-        input_parameters_lines = self.raw_codeblock.rstrip("\n").split("\n")
+        input_parameters_lines = raw_codeblock.rstrip("\n").split("\n")
 
         if len(input_parameters_lines) > 1:
             input_parameters_codeblock = "\n" + "".join(
@@ -269,13 +226,26 @@ class NodeCollection:
         else:
             input_parameters_codeblock = ""
 
-        if self.pre_computed_artifact is not None:
-            logger.warning(
-                "Variables "
-                + ", ".join(self.input_variables)
-                + f" are dummy variables since they are only used in the calculation of artifacts {self.name}."
-                + "You can either edit the input_parameters or reuse_pre_computed parameters to remove this warning."
-            )
-            return ""
-
         return input_parameters_codeblock
+
+
+@dataclass
+class NodeInfo:
+    """
+    :assigned_variables: variables assigned at this node
+    :assigned_artifact: this node is pointing to some artifact
+    :dependent_variables: union of if any variable is assigned at predecessor node,
+     use the assigned variables. otherwise, use the dependent_variables
+    :tracked_variables: variables that this node is point to
+    :predecessors: predecessors of the node
+    :module_import: module name/alias that this node is point to
+    :artifact_name: this node belong to which artifact calculating block
+    """
+
+    assigned_variables: Set[str] = field(default_factory=set)
+    assigned_artifact: Optional[str] = field(default=None)
+    dependent_variables: Set[str] = field(default_factory=set)
+    predecessors: Set[LineaID] = field(default_factory=set)
+    tracked_variables: Set[str] = field(default_factory=set)
+    module_import: Set[str] = field(default_factory=set)
+    artifact_name: Optional[str] = field(default=None)

--- a/lineapy/graph_reader/node_collection.py
+++ b/lineapy/graph_reader/node_collection.py
@@ -181,15 +181,11 @@ class ImportNodeCollection(BaseNodeCollection):
     ImportNodeCollection contains all the nodes used to import libraries in a Session.
     """
 
-    def get_import_block(
-        self, graph: Graph, include_non_slice_as_comment=False, indentation=0
-    ) -> str:
+    def get_import_block(self, graph: Graph, indentation=0) -> str:
         """
         Return a code block for import statement of the graph segment
         """
-        raw_codeblock = self._get_raw_codeblock(
-            graph, include_non_slice_as_comment
-        )
+        raw_codeblock = self._get_raw_codeblock(graph)
         if raw_codeblock == "":
             return ""
 

--- a/lineapy/graph_reader/session_artifacts.py
+++ b/lineapy/graph_reader/session_artifacts.py
@@ -5,7 +5,10 @@ from typing import Dict, List, Optional, Set, Tuple, cast
 
 import networkx as nx
 
-from lineapy.api.models.linea_artifact import LineaArtifact
+from lineapy.api.models.linea_artifact import (
+    LineaArtifact,
+    get_lineaartifactdef,
+)
 from lineapy.data.graph import Graph
 from lineapy.data.types import (
     CallNode,
@@ -18,15 +21,15 @@ from lineapy.data.types import (
 from lineapy.db.db import RelationalLineaDB
 from lineapy.db.relational import ImportNodeORM
 from lineapy.graph_reader.node_collection import (
-    NodeCollection,
-    NodeCollectionType,
+    ArtifactNodeCollection,
+    ImportNodeCollection,
+    InputVarNodeCollection,
     NodeInfo,
+    UserCodeNodeCollection,
 )
 from lineapy.graph_reader.program_slice import get_slice_graph
-from lineapy.graph_reader.types import InputVariable
 from lineapy.graph_reader.utils import _is_import_node
 from lineapy.plugins.task import TaskGraph
-from lineapy.plugins.utils import load_plugin_template
 from lineapy.utils.logging_config import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -42,8 +45,8 @@ class SessionArtifacts:
     _session_id: LineaID
     graph: Graph
     db: RelationalLineaDB
-    artifact_nodecollections: List[NodeCollection]
-    import_nodecollection: NodeCollection
+    artifact_nodecollections: List[UserCodeNodeCollection]
+    import_nodecollection: ImportNodeCollection
     input_parameters_node: Dict[str, LineaID]
     node_context: Dict[LineaID, NodeInfo]
     target_artifacts: List[LineaArtifact]
@@ -71,8 +74,24 @@ class SessionArtifacts:
             self.db, self._session_id
         )
         self.include_non_slice_as_comment = include_non_slice_as_comment
+
+        def _get_subgraph_from_node_list(
+            session_graph: Graph, node_list: List[LineaID]
+        ) -> Graph:
+            """
+            Return the subgraph as LineaPy Graph from list of node id
+            """
+            nodes: List[Node] = []
+            for node_id in node_list:
+                node = session_graph.get_node(node_id)
+                if node is not None:
+                    nodes.append(node)
+
+            return self._session_graph.get_subgraph(nodes)
+
         # Only interested union of sliced graph of each artifacts
-        self.graph = self._get_subgraph_from_node_list(
+        self.graph = _get_subgraph_from_node_list(
+            self._session_graph,
             list(
                 set.union(
                     *[
@@ -80,7 +99,7 @@ class SessionArtifacts:
                         for art in target_artifacts
                     ]
                 )
-            )
+            ),
         )
         self.artifact_nodecollections = []
         self.node_context = OrderedDict()
@@ -91,7 +110,7 @@ class SessionArtifacts:
 
         # Retrive all artifacts within the subgraph of target artifacts
         self._retrive_all_session_artifacts()
-        # Add extra attributes(from predecessors) at session Liena nodes
+        # Add extra attributes(from predecessors) at session Linea nodes
         self._update_node_context()
         # Divide session graph into a set of non-overlapping NodeCollection
         self._slice_session_artifacts()
@@ -200,7 +219,7 @@ class SessionArtifacts:
     def _update_node_context(self):
         """
         Traverse every node within the session in topologically sorted order
-        and update node_context with following informations
+        and update node_context with following information.
 
         assigned_variables : variables assigned at this node
         assigned_artifact : this node is pointing to some artifact
@@ -323,18 +342,6 @@ class SessionArtifacts:
                     f"{var} has dependent variables: {dep_vars}."
                 )
 
-    def _get_subgraph_from_node_list(self, node_list: List[LineaID]) -> Graph:
-        """
-        Return the subgraph as LineaPy Graph from list of node id
-        """
-        nodes: List[Node] = []
-        for node_id in node_list:
-            node = self._session_graph.get_node(node_id)
-            if node is not None:
-                nodes.append(node)
-
-        return self._session_graph.get_subgraph(nodes)
-
     def _get_sliced_nodes(
         self, node_id: LineaID
     ) -> Tuple[Set[LineaID], Set[LineaID]]:
@@ -376,25 +383,8 @@ class SessionArtifacts:
         )
         return predecessor_nodes, predecessor_artifact
 
-    def _get_input_variable_sources(self, pred_nodes) -> Dict[str, Set[str]]:
-        # Get information about which input variable is originated from which artifact
-        input_variable_sources: Dict[str, Set[str]] = dict()
-        for pred_id in pred_nodes:
-            pred_variables = (
-                self.node_context[pred_id].assigned_variables
-                if len(self.node_context[pred_id].assigned_variables) > 0
-                else self.node_context[pred_id].tracked_variables
-            )
-            pred_art = self.node_context[pred_id].artifact_name
-            assert isinstance(pred_art, str)
-            if pred_art != "module_import":
-                input_variable_sources[pred_art] = input_variable_sources.get(
-                    pred_art, set()
-                ).union(pred_variables)
-        return input_variable_sources
-
     def _get_common_variables(
-        self, curr_nc: NodeCollection, pred_nc: NodeCollection
+        self, curr_nc: UserCodeNodeCollection, pred_nc: UserCodeNodeCollection
     ) -> Tuple[List[str], Set[LineaID]]:
         """
         Identify common variables for two NodeCollections.
@@ -402,7 +392,9 @@ class SessionArtifacts:
         assert isinstance(pred_nc.name, str)
         common_inner_variables = (
             pred_nc.all_variables - set(pred_nc.return_variables)
-        ).intersection(curr_nc.input_variable_sources[pred_nc.name])
+        ).intersection(
+            curr_nc.get_input_variable_sources(self.node_context)[pred_nc.name]
+        )
 
         common_nodes = set()
         if len(common_inner_variables) > 0:
@@ -413,9 +405,11 @@ class SessionArtifacts:
                 and self.node_context[n].assigned_artifact
                 != self.node_context[n].artifact_name
             ]
-            assert pred_nc.graph_segment is not None
+            pred_graph_segment = pred_nc._get_graph_segment()
+            assert pred_graph_segment is not None
             source_art_slice_variable_graph = get_slice_graph(
-                pred_nc.graph_segment, slice_variable_nodes
+                pred_graph_segment,
+                slice_variable_nodes,
             )
             common_nodes = set(source_art_slice_variable_graph.nx_graph.nodes)
         else:
@@ -453,39 +447,46 @@ class SessionArtifacts:
                     self.import_nodes
                 )
                 # Identify precedent artifacts(id and name)
-                pred_nodes, pred_artifact = self._get_predecessor_info(
+                pred_nodes, _ = self._get_predecessor_info(
                     art_nodes, self.import_nodes
-                )
-                # Identify input variables are coming from which artifacts
-                input_variable_sources = self._get_input_variable_sources(
-                    pred_nodes
                 )
                 # Check whether this artifact should be replaced by
                 # pre-computed value, None if no and (name, version) if yes
-                matched_pre_computed = (
-                    (
-                        n.assigned_artifact,
-                        self.reuse_pre_computed_artifacts[
-                            n.assigned_artifact
-                        ].version,
-                    )
-                    if n.assigned_artifact
+                if (
+                    n.assigned_artifact
                     in self.reuse_pre_computed_artifacts.keys()
-                    else None
-                )
-                nodecollectioninfo = NodeCollection(
-                    collection_type=NodeCollectionType.ARTIFACT,
-                    artifact_node_id=node_id,
-                    name=n.assigned_artifact,
-                    tracked_variables=n.tracked_variables,
-                    return_variables=list(n.tracked_variables),
-                    node_list=art_nodes,
-                    predecessor_nodes=pred_nodes,
-                    predecessor_artifact=pred_artifact,
-                    input_variable_sources=input_variable_sources,
-                    sliced_nodes=sliced_nodes,
-                    pre_computed_artifact=matched_pre_computed,
-                )
+                ):
+                    reuse_def = get_lineaartifactdef(
+                        (
+                            n.assigned_artifact,
+                            self.reuse_pre_computed_artifacts[
+                                n.assigned_artifact
+                            ].version,
+                        )
+                    )
+
+                    nodecollectioninfo: ArtifactNodeCollection = (
+                        ArtifactNodeCollection(
+                            name=n.assigned_artifact,
+                            node_list=art_nodes,
+                            graph=self.graph,
+                            tracked_variables=n.tracked_variables,
+                            return_variables=list(n.tracked_variables),
+                            predecessor_nodes=pred_nodes,
+                            is_pre_computed=True,
+                            pre_computed_artifact=reuse_def,
+                        )
+                    )
+                else:
+                    nodecollectioninfo = ArtifactNodeCollection(
+                        name=n.assigned_artifact,
+                        node_list=art_nodes,
+                        graph=self.graph,
+                        tracked_variables=n.tracked_variables,
+                        return_variables=list(n.tracked_variables),
+                        predecessor_nodes=pred_nodes,
+                        is_pre_computed=False,
+                    )
 
                 # Update node context to label the node is assigned to this artifact
                 for n_id in nodecollectioninfo.node_list:
@@ -500,7 +501,9 @@ class SessionArtifacts:
                 for (
                     source_artifact_name,
                     variables,
-                ) in input_variable_sources.items():
+                ) in nodecollectioninfo.get_input_variable_sources(
+                    self.node_context
+                ).items():
                     source_id, source_info = [
                         (i, context)
                         for i, context in enumerate(
@@ -523,34 +526,36 @@ class SessionArtifacts:
                     # calculation.
                     if len(common_inner_variables) > 0 and len(common_nodes):
 
-                        common_nodecollectioninfo = NodeCollection(
-                            collection_type=NodeCollectionType.COMMON_VARIABLE,
+                        common_nodecollectioninfo = UserCodeNodeCollection(
                             name=f"{'_'.join(common_inner_variables)}_for_artifact_{source_info.name}_and_downstream",
-                            return_variables=common_inner_variables,
                             node_list=common_nodes,
+                            graph=self.graph,
+                            return_variables=common_inner_variables,
                         )
-                        common_nodecollectioninfo._update_variable_info(
+                        common_nodecollectioninfo.update_variable_info(
                             self.node_context, self.input_parameters_node
-                        )
-                        common_nodecollectioninfo.update_raw_codeblock(
-                            self._session_graph,
-                            include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
 
                         remaining_nodes = source_info.node_list - common_nodes
-                        remaining_nodecollectioninfo = NodeCollection(
-                            collection_type=NodeCollectionType.ARTIFACT,
-                            name=source_info.name,
-                            return_variables=source_info.return_variables,
-                            node_list=remaining_nodes,
-                            pre_computed_artifact=source_info.pre_computed_artifact,
-                        )
-                        remaining_nodecollectioninfo._update_variable_info(
+                        if isinstance(source_info, ArtifactNodeCollection):
+                            remaining_nodecollectioninfo: UserCodeNodeCollection = ArtifactNodeCollection(
+                                name=source_info.name,
+                                node_list=remaining_nodes,
+                                graph=self.graph,
+                                return_variables=source_info.return_variables,
+                                is_pre_computed=source_info.is_pre_computed,
+                                pre_computed_artifact=source_info.pre_computed_artifact,
+                            )
+                        else:  # outputs a common variable, use base UserCodeNodeCollection instead.
+                            remaining_nodecollectioninfo = UserCodeNodeCollection(
+                                name=source_info.name,
+                                node_list=remaining_nodes,
+                                graph=self.graph,
+                                return_variables=source_info.return_variables,
+                            )
+
+                        remaining_nodecollectioninfo.update_variable_info(
                             self.node_context, self.input_parameters_node
-                        )
-                        remaining_nodecollectioninfo.update_raw_codeblock(
-                            self._session_graph,
-                            include_non_slice_as_comment=self.include_non_slice_as_comment,
                         )
 
                         self.artifact_nodecollections = (
@@ -563,40 +568,25 @@ class SessionArtifacts:
                         )
 
                 # Remove input parameter node
-                nodecollectioninfo._update_variable_info(
+                nodecollectioninfo.update_variable_info(
                     self.node_context, self.input_parameters_node
                 )
                 nodecollectioninfo.node_list = (
                     nodecollectioninfo.node_list
                     - set(self.input_parameters_node.values())
                 )
-                nodecollectioninfo.update_raw_codeblock(
-                    self._session_graph,
-                    include_non_slice_as_comment=self.include_non_slice_as_comment,
-                )
                 self.artifact_nodecollections.append(nodecollectioninfo)
 
         # NodeCollection for import
-        self.import_nodecollection = NodeCollection(
-            collection_type=NodeCollectionType.IMPORT,
-            node_list=self.import_nodes,
-        )
-        # TODO: dont comment unsliced code here as well since we dont care about imports
-        self.import_nodecollection.update_raw_codeblock(
-            self.graph, include_non_slice_as_comment=False
+        self.import_nodecollection = ImportNodeCollection(
+            name="", node_list=self.import_nodes, graph=self.graph
         )
 
         # NodeCollection for input parameters
-        self.input_parameters_nodecollection = NodeCollection(
-            collection_type=NodeCollectionType.INPUT_PARAMETERS,
+        self.input_parameters_nodecollection = InputVarNodeCollection(
+            name="",
             node_list=set(self.input_parameters_node.values()),
-        )
-        self.input_parameters_nodecollection._update_variable_info(
-            self.node_context, self.input_parameters_node
-        )
-        # TODO: change here to not include raw code since this is generated bits
-        self.input_parameters_nodecollection.update_raw_codeblock(
-            self.graph, include_non_slice_as_comment=False
+            graph=self.graph,
         )
 
     def _update_nodecollection_dependencies(self):
@@ -612,7 +602,7 @@ class SessionArtifacts:
         cache_nodes = [
             nc.name
             for nc in self.artifact_nodecollections
-            if nc.pre_computed_artifact is not None
+            if isinstance(nc, ArtifactNodeCollection) and nc.is_pre_computed
         ]
         # Determine input variables of a nodecollection are coming from output
         # variables of nodecollections to build the NodeCollection dependencies
@@ -668,142 +658,9 @@ class SessionArtifacts:
         Return the name of first artifact(topologically sorted).
         """
         for coll in self.artifact_nodecollections:
-            if coll.collection_type == NodeCollectionType.ARTIFACT:
+            if isinstance(coll, ArtifactNodeCollection):
                 return coll.safename
         return None
-
-    def get_session_module_imports(self, indentation=0) -> str:
-        """
-        Return all the import statement for the session.
-        """
-        return self.import_nodecollection.get_import_block(
-            indentation=indentation
-        )
-
-    def get_session_function_name(self) -> str:
-        """
-        Return the session function name: run_session_including_{first_artifact_name}
-        """
-        first_artifact_name = self._get_first_artifact_name()
-        if first_artifact_name is not None:
-            return f"run_session_including_{first_artifact_name}"
-        return ""
-
-    def get_session_function_body(
-        self, indentation, return_dict_name="artifacts"
-    ) -> str:
-        """
-        Return the args for the session function.
-        """
-        return "\n".join(
-            [
-                coll.get_function_call_block(
-                    indentation=indentation,
-                    keep_lineapy_save=False,
-                    result_placeholder=None
-                    if coll.collection_type != NodeCollectionType.ARTIFACT
-                    else return_dict_name,
-                )
-                for coll in self.artifact_nodecollections
-            ]
-        )
-
-    def get_session_input_parameters_lines(self, indentation=4) -> str:
-        """
-        Return lines of session code that are replaced by user selected input
-        parameters. These lines also serve as the default values of these
-        variables.
-        """
-        return self.input_parameters_nodecollection.get_input_parameters_block(
-            indentation=indentation
-        )
-
-    def get_session_input_parameters_spec(self) -> Dict[str, InputVariable]:
-        """
-        Return a dictionary with input parameters as key and InputVariable
-        class as value to generate code related to user input variables.
-        """
-        session_input_variables: Dict[str, InputVariable] = dict()
-        for line in self.get_session_input_parameters_lines().split("\n"):
-            variable_def = line.strip(" ").rstrip(",")
-            if variable_def.startswith("#"):
-                continue
-            if len(variable_def) > 0:
-                variable_name = variable_def.split("=")[0].strip(" ")
-                value = eval(variable_def.split("=")[1].strip(" "))
-                value_type = type(value)
-                if not (
-                    isinstance(value, int)
-                    or isinstance(value, float)
-                    or isinstance(value, str)
-                    or isinstance(value, bool)
-                ):
-                    raise ValueError(
-                        f"LineaPy only supports primitive types as input parameters for now. "
-                        f"{variable_name} in {variable_def} is a {value_type}."
-                    )
-                if ":" in variable_name:
-                    variable_name = variable_def.split(":")[0]
-                    session_input_variables[variable_name] = InputVariable(
-                        variable_name=variable_name,
-                        value=value,
-                        value_type=value_type,
-                    )
-                else:
-                    session_input_variables[variable_name] = InputVariable(
-                        variable_name=variable_name,
-                        value=value,
-                        value_type=value_type,
-                    )
-        return session_input_variables
-
-    def get_session_function_callblock(self) -> str:
-        """
-        Return the code to make the call to the session function as
-        `session_function_name(input_parameters)`.
-        """
-        session_function_name = self.get_session_function_name()
-        if session_function_name != "":
-            session_input_parameters = ", ".join(
-                self.get_session_input_parameters_spec().keys()
-            )
-            return f"{session_function_name}({session_input_parameters})"
-        else:
-            return ""
-
-    def get_session_artifact_function_definitions(
-        self, indentation=4
-    ) -> List[str]:
-        """
-        Return the definition of each targeted artifacts calculation
-        functions.
-        """
-        return [
-            coll.get_function_definition(indentation=indentation)
-            for coll in self.artifact_nodecollections
-        ]
-
-    def get_session_function(
-        self, indentation=4, return_dict_name="artifacts"
-    ) -> str:
-        """
-        Return the definition of the session function that executes the
-        calculation of all targeted artifacts.
-        """
-        indentation_block = " " * indentation
-        SESSION_FUNCTION_TEMPLATE = load_plugin_template(
-            "session_function.jinja"
-        )
-        session_function = SESSION_FUNCTION_TEMPLATE.render(
-            session_input_parameters_body=self.get_session_input_parameters_lines(),
-            indentation_block=indentation_block,
-            session_function_name=self.get_session_function_name(),
-            session_function_body=self.get_session_function_body(
-                indentation=indentation
-            ),
-            return_dict_name=return_dict_name,
-        )
-        return session_function
 
     def get_libraries(self) -> List[ImportNodeORM]:
         """

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -321,7 +321,7 @@ class BasePipelineWriter:
                     ),
                 }
                 for session_artifacts in self.session_artifacts_sorted
-                for node_collection in session_artifacts.artifact_nodecollections
+                for node_collection in session_artifacts.usercode_nodecollections
             }
         )
 
@@ -643,7 +643,7 @@ class AirflowPipelineWriter(BasePipelineWriter):
                     session_artifacts
                 )
             )
-            for nc in session_artifacts.artifact_nodecollections:
+            for nc in session_artifacts.usercode_nodecollections:
                 all_input_variables = sorted(list(nc.input_variables))
                 artifact_user_input_variables = [
                     var
@@ -718,7 +718,7 @@ def get_session_task_definition(
     function_call_block = f"artifacts = {pipeline_name}_module.{BaseSessionWriter().get_session_function_callblock(sa)}"
     return_artifacts_saving_block = [
         f"pickle.dump(artifacts['{nc.name}'],open('/tmp/{pipeline_name}/artifact_{nc.safename}.pickle','wb'))"
-        for nc in sa.artifact_nodecollections
+        for nc in sa.usercode_nodecollections
         if isinstance(nc, ArtifactNodeCollection)
     ]
 
@@ -772,7 +772,7 @@ class AirflowCodeGenerator:
         artifact_function_input_parameters = dict()
         for sa in self.artifact_collection.sort_session_artifacts():
             session_input_parameters = set(sa.input_parameters_node.keys())
-            for nc in sa.artifact_nodecollections:
+            for nc in sa.usercode_nodecollections:
                 user_input_variables = artifact_function_definitions[
                     nc.safename
                 ]["user_input_variables"]

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -12,8 +12,12 @@ from lineapy.graph_reader.artifact_collection import (
     ArtifactCollection,
     SessionArtifacts,
 )
-from lineapy.graph_reader.node_collection import NodeCollectionType
+from lineapy.graph_reader.node_collection import (
+    ArtifactNodeCollection,
+    UserCodeNodeCollection,
+)
 from lineapy.graph_reader.types import InputVariable
+from lineapy.plugins.session_writers import BaseSessionWriter
 from lineapy.plugins.task import (
     AirflowDagConfig,
     AirflowDagFlavor,
@@ -67,7 +71,6 @@ class BasePipelineWriter:
                 dependencies=dependencies
             )
         )
-
         # Create output directory folder(s) if nonexistent
         self.output_dir.mkdir(exist_ok=True, parents=True)
 
@@ -112,7 +115,7 @@ class BasePipelineWriter:
 
         module_imports = "\n".join(
             [
-                sa.get_session_module_imports()
+                BaseSessionWriter(sa).get_session_module_imports()
                 for sa in self.session_artifacts_sorted
             ]
         )
@@ -121,7 +124,9 @@ class BasePipelineWriter:
             list(
                 itertools.chain.from_iterable(
                     [
-                        sa.get_session_artifact_function_definitions(
+                        BaseSessionWriter(
+                            sa
+                        ).get_session_artifact_function_definitions(
                             indentation=indentation
                         )
                         for sa in self.session_artifacts_sorted
@@ -132,14 +137,16 @@ class BasePipelineWriter:
 
         session_functions = "\n".join(
             [
-                sa.get_session_function(indentation=indentation)
+                BaseSessionWriter(sa).get_session_function(
+                    indentation=indentation
+                )
                 for sa in self.session_artifacts_sorted
             ]
         )
 
         module_function_body = "\n".join(
             [
-                f"{indentation_block}{return_dict_name}.update({sa.get_session_function_callblock()})"
+                f"{indentation_block}{return_dict_name}.update({BaseSessionWriter(sa).get_session_function_callblock()})"
                 for sa in self.session_artifacts_sorted
             ]
         )
@@ -147,7 +154,9 @@ class BasePipelineWriter:
         module_input_parameters: List[InputVariable] = []
         for sa in self.session_artifacts_sorted:
             module_input_parameters += list(
-                sa.get_session_input_parameters_spec().values()
+                BaseSessionWriter(sa)
+                .get_session_input_parameters_spec()
+                .values()
             )
 
         module_input_parameters_list = [
@@ -283,7 +292,7 @@ class BasePipelineWriter:
         #             "input_variable_names": ["url1"],
         #             "return_variable_names": ["mod"],
         #             "output_name": "iris_model",
-        #             "_output_type": NodeCollectionType.ARTIFACT,
+        #             "_output_type": ArtifactNodeCollection,
         #             "dependent_output_names": ["url1_for_artifact_iris_model_and_downstream"],
         #         }
         #     }
@@ -299,7 +308,7 @@ class BasePipelineWriter:
                     ),
                     "return_variable_names": node_collection.return_variables,
                     "output_name": node_collection.safename,
-                    "_output_type": node_collection.collection_type,
+                    "_output_type": node_collection.__class__.__name__,
                     "dependent_output_names": nx.ancestors(
                         session_artifacts.nodecollection_dependencies.graph,
                         node_collection.safename,
@@ -328,7 +337,7 @@ class BasePipelineWriter:
             function_metadata["output_name"]
             for function_metadata in function_metadata_dict.values()
             if function_metadata["_output_type"]
-            == NodeCollectionType.COMMON_VARIABLE
+            == UserCodeNodeCollection.__name__
         ]
 
         # Format other components to be passed into file template
@@ -483,7 +492,9 @@ class AirflowPipelineWriter(BasePipelineWriter):
         task_functions = []
         task_definitions = []
         for sa in self.session_artifacts_sorted:
-            task_functions.append(sa.get_session_function_name())
+            task_functions.append(
+                BaseSessionWriter(sa).get_session_function_name()
+            )
             task_definitions.append(
                 get_session_task_definition(sa, self.pipeline_name)
             )
@@ -621,9 +632,9 @@ class AirflowPipelineWriter(BasePipelineWriter):
             self.artifact_collection.input_parameters
         )
         for session_artifacts in self.session_artifacts_sorted:
-            session_input_parameters_spec = (
-                session_artifacts.get_session_input_parameters_spec()
-            )
+            session_input_parameters_spec = BaseSessionWriter(
+                session_artifacts
+            ).get_session_input_parameters_spec()
             for nc in session_artifacts.artifact_nodecollections:
                 all_input_variables = sorted(list(nc.input_variables))
                 artifact_user_input_variables = [
@@ -643,8 +654,12 @@ class AirflowPipelineWriter(BasePipelineWriter):
                     for var in all_input_variables
                     if var not in artifact_user_input_variables
                 ]
-                function_call_block = nc.get_function_call_block(
-                    indentation=0, source_module=f"{self.pipeline_name}_module"
+                function_call_block = BaseSessionWriter(
+                    session_artifacts
+                ).get_function_call_block(
+                    nc,
+                    indentation=0,
+                    source_module=f"{self.pipeline_name}_module",
                 )
                 return_var_saving_block = [
                     f"pickle.dump({var},open('/tmp/{self.pipeline_name}/variable_{var}.pickle','wb'))"
@@ -682,7 +697,9 @@ def get_session_task_definition(
     Add serialization of output artifacts logic of the session function
     call_block and wrap them into a new function definition.
     """
-    session_input_parameters_spec = sa.get_session_input_parameters_spec()
+    session_input_parameters_spec = BaseSessionWriter(
+        sa
+    ).get_session_input_parameters_spec()
     session_input_variables = list(session_input_parameters_spec.keys())
     user_input_var_typing_block = [
         f"{var} = {session_input_parameters_spec[var].value_type}({var})"
@@ -690,16 +707,16 @@ def get_session_task_definition(
     ]
 
     input_var_loading_block: List[str] = []
-    function_call_block = f"artifacts = {pipeline_name}_module.{sa.get_session_function_callblock()}"
+    function_call_block = f"artifacts = {pipeline_name}_module.{BaseSessionWriter(sa).get_session_function_callblock()}"
     return_artifacts_saving_block = [
         f"pickle.dump(artifacts['{nc.name}'],open('/tmp/{pipeline_name}/artifact_{nc.safename}.pickle','wb'))"
         for nc in sa.artifact_nodecollections
-        if nc.collection_type == NodeCollectionType.ARTIFACT
+        if isinstance(nc, ArtifactNodeCollection)
     ]
 
     TASK_FUNCTION_TEMPLATE = load_plugin_template("task_function.jinja")
     return TASK_FUNCTION_TEMPLATE.render(
-        function_name=sa.get_session_function_name(),
+        function_name=BaseSessionWriter(sa).get_session_function_name(),
         user_input_variables=", ".join(session_input_variables),
         typing_blocks=user_input_var_typing_block,
         loading_blocks=input_var_loading_block,
@@ -716,7 +733,11 @@ class AirflowCodeGenerator:
     def get_params_args(self) -> str:
         input_parameters_dict = dict()
         for sa in self.artifact_collection.sort_session_artifacts():
-            for input_spec in sa.get_session_input_parameters_spec().values():
+            for input_spec in (
+                BaseSessionWriter(sa)
+                .get_session_input_parameters_spec()
+                .values()
+            ):
                 input_parameters_dict[
                     input_spec.variable_name
                 ] = input_spec.value
@@ -728,7 +749,7 @@ class AirflowCodeGenerator:
             session_input_parameters = list(sa.input_parameters_node.keys())
             if len(session_input_parameters) > 0:
                 session_function_input_parameters[
-                    sa.get_session_function_name()
+                    BaseSessionWriter(sa).get_session_function_name()
                 ] = "op_kwargs=" + str(
                     {
                         var: "{{ params." + var + " }}"

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -57,6 +57,7 @@ class BasePipelineWriter:
         output_dir: str = ".",
         generate_test: bool = False,
         dag_config: Optional[Union[AirflowDagConfig, DVCDagConfig]] = None,
+        include_non_slice_as_comment: Optional[bool] = False,
     ) -> None:
         self.artifact_collection = artifact_collection
         self.keep_lineapy_save = keep_lineapy_save
@@ -65,6 +66,7 @@ class BasePipelineWriter:
         self.generate_test = generate_test
         self.dag_config = dag_config or {}
         self.dependencies = dependencies
+        self.include_non_slice_as_comment = include_non_slice_as_comment
 
         self.session_artifacts_sorted = (
             self.artifact_collection.sort_session_artifacts(
@@ -115,7 +117,9 @@ class BasePipelineWriter:
 
         module_imports = "\n".join(
             [
-                BaseSessionWriter().get_session_module_imports(sa)
+                BaseSessionWriter().get_session_module_imports(
+                    sa, self.include_non_slice_as_comment
+                )
                 for sa in self.session_artifacts_sorted
             ]
         )
@@ -125,7 +129,9 @@ class BasePipelineWriter:
                 itertools.chain.from_iterable(
                     [
                         BaseSessionWriter().get_session_artifact_function_definitions(
-                            session_artifact=sa, indentation=indentation
+                            session_artifact=sa,
+                            include_non_slice_as_comment=self.include_non_slice_as_comment,
+                            indentation=indentation,
                         )
                         for sa in self.session_artifacts_sorted
                     ]
@@ -136,7 +142,9 @@ class BasePipelineWriter:
         session_functions = "\n".join(
             [
                 BaseSessionWriter().get_session_function(
-                    session_artifact=sa, indentation=indentation
+                    session_artifact=sa,
+                    include_non_slice_as_comment=self.include_non_slice_as_comment,
+                    indentation=indentation,
                 )
                 for sa in self.session_artifacts_sorted
             ]

--- a/lineapy/plugins/pipeline_writers.py
+++ b/lineapy/plugins/pipeline_writers.py
@@ -117,9 +117,7 @@ class BasePipelineWriter:
 
         module_imports = "\n".join(
             [
-                BaseSessionWriter().get_session_module_imports(
-                    sa, self.include_non_slice_as_comment
-                )
+                BaseSessionWriter().get_session_module_imports(sa)
                 for sa in self.session_artifacts_sorted
             ]
         )
@@ -143,7 +141,6 @@ class BasePipelineWriter:
             [
                 BaseSessionWriter().get_session_function(
                     session_artifact=sa,
-                    include_non_slice_as_comment=self.include_non_slice_as_comment,
                     indentation=indentation,
                 )
                 for sa in self.session_artifacts_sorted

--- a/lineapy/plugins/session_writers.py
+++ b/lineapy/plugins/session_writers.py
@@ -21,7 +21,6 @@ class BaseSessionWriter:
     def get_session_module_imports(
         self,
         session_artifact: SessionArtifacts,
-        include_non_slice_as_comment=False,
         indentation=0,
     ) -> str:
         """
@@ -30,7 +29,6 @@ class BaseSessionWriter:
 
         return session_artifact.import_nodecollection.get_import_block(
             graph=session_artifact.graph,
-            include_non_slice_as_comment=include_non_slice_as_comment,
             indentation=indentation,
         )
 
@@ -209,7 +207,6 @@ class BaseSessionWriter:
     def get_session_function(
         self,
         session_artifact,
-        include_non_slice_as_comment=False,
         indentation=4,
         return_dict_name="artifacts",
     ) -> str:

--- a/lineapy/plugins/session_writers.py
+++ b/lineapy/plugins/session_writers.py
@@ -109,7 +109,7 @@ class BaseSessionWriter:
                     keep_lineapy_save=False,
                     return_dict_name=return_dict_name,
                 )
-                for coll in session_artifact.artifact_nodecollections
+                for coll in session_artifact.usercode_nodecollections
             ]
         )
 
@@ -203,7 +203,7 @@ class BaseSessionWriter:
                 include_non_slice_as_comment=include_non_slice_as_comment,
                 indentation=indentation,
             )
-            for coll in session_artifact.artifact_nodecollections
+            for coll in session_artifact.usercode_nodecollections
         ]
 
     def get_session_function(

--- a/lineapy/plugins/session_writers.py
+++ b/lineapy/plugins/session_writers.py
@@ -19,13 +19,19 @@ class BaseSessionWriter:
         pass
 
     def get_session_module_imports(
-        self, session_artifact: SessionArtifacts, indentation=0
+        self,
+        session_artifact: SessionArtifacts,
+        include_non_slice_as_comment=False,
+        indentation=0,
     ) -> str:
         """
         Return all the import statement for the session.
         """
+
         return session_artifact.import_nodecollection.get_import_block(
-            indentation=indentation
+            graph=session_artifact.graph,
+            include_non_slice_as_comment=include_non_slice_as_comment,
+            indentation=indentation,
         )
 
     def get_session_function_name(
@@ -89,7 +95,7 @@ class BaseSessionWriter:
     def get_session_function_body(
         self,
         session_artifact: SessionArtifacts,
-        indentation,
+        indentation=0,
         return_dict_name="artifacts",
     ) -> str:
         """
@@ -108,7 +114,9 @@ class BaseSessionWriter:
         )
 
     def _get_session_input_parameters_lines(
-        self, session_artifact: SessionArtifacts, indentation=4
+        self,
+        session_artifact: SessionArtifacts,
+        indentation=4,
     ) -> str:
         """
         Return lines of session code that are replaced by user selected input
@@ -116,7 +124,8 @@ class BaseSessionWriter:
         variables.
         """
         return session_artifact.input_parameters_nodecollection.get_input_parameters_block(
-            indentation=indentation
+            graph=session_artifact.graph,
+            indentation=indentation,
         )
 
     def get_session_input_parameters_spec(
@@ -179,19 +188,30 @@ class BaseSessionWriter:
             return ""
 
     def get_session_artifact_function_definitions(
-        self, session_artifact: SessionArtifacts, indentation=4
+        self,
+        session_artifact: SessionArtifacts,
+        include_non_slice_as_comment=False,
+        indentation=4,
     ) -> List[str]:
         """
         Return the definition of each targeted artifacts calculation
         functions.
         """
         return [
-            coll.get_function_definition(indentation=indentation)
+            coll.get_function_definition(
+                graph=session_artifact.session_graph,
+                include_non_slice_as_comment=include_non_slice_as_comment,
+                indentation=indentation,
+            )
             for coll in session_artifact.artifact_nodecollections
         ]
 
     def get_session_function(
-        self, session_artifact, indentation=4, return_dict_name="artifacts"
+        self,
+        session_artifact,
+        include_non_slice_as_comment=False,
+        indentation=4,
+        return_dict_name="artifacts",
     ) -> str:
         """
         Return the definition of the session function that executes the
@@ -203,14 +223,15 @@ class BaseSessionWriter:
         )
         session_function = SESSION_FUNCTION_TEMPLATE.render(
             session_input_parameters_body=self._get_session_input_parameters_lines(
-                session_artifact=session_artifact
+                session_artifact=session_artifact,
             ),
             indentation_block=indentation_block,
             session_function_name=self.get_session_function_name(
-                session_artifact=session_artifact
+                session_artifact=session_artifact,
             ),
             session_function_body=self.get_session_function_body(
-                session_artifact=session_artifact, indentation=indentation
+                session_artifact=session_artifact,
+                indentation=indentation,
             ),
             return_dict_name=return_dict_name,
         )

--- a/lineapy/plugins/session_writers.py
+++ b/lineapy/plugins/session_writers.py
@@ -1,0 +1,196 @@
+from typing import Dict, List
+
+from lineapy.graph_reader.node_collection import (
+    ArtifactNodeCollection,
+    UserCodeNodeCollection,
+)
+from lineapy.graph_reader.session_artifacts import SessionArtifacts
+from lineapy.graph_reader.types import InputVariable
+from lineapy.plugins.utils import load_plugin_template
+
+
+class BaseSessionWriter:
+    """
+    BaseSessionWriter contains helper functions to turn the various components of a SessionArtifacts
+    object to runnable code.
+    """
+
+    def __init__(self, session_artifact: SessionArtifacts):
+        self.session_artifact = session_artifact
+
+    def get_session_module_imports(self, indentation=0) -> str:
+        """
+        Return all the import statement for the session.
+        """
+        return self.session_artifact.import_nodecollection.get_import_block(
+            indentation=indentation
+        )
+
+    def get_session_function_name(self) -> str:
+        """
+        Return the session function name: run_session_including_{first_artifact_name}
+        """
+        first_artifact_name = self.session_artifact._get_first_artifact_name()
+        if first_artifact_name is not None:
+            return f"run_session_including_{first_artifact_name}"
+        return ""
+
+    def get_function_call_block(
+        self,
+        coll: UserCodeNodeCollection,
+        indentation=0,
+        keep_lineapy_save=False,
+        return_dict_name=None,
+        source_module="",
+    ) -> str:
+        """
+        Return a codeblock to call the function with return variables of the graph segment
+        :param int indentation: indentation size
+        :param bool keep_lineapy_save: whether do lineapy.save() after execution
+        :param Optional[str] result_placeholder: if not null, append the return result to the result_placeholder
+        :param str source_module: which module the function is coming from
+        The result_placeholder is a list to capture the artifact variables right
+        after calculation. Considering following code::
+            a = 1
+            lineapy.save(a,'a')
+            a+=1
+            b = a+1
+            lineapy.save(b,'b')
+            c = a+1
+            lineapy.save(c,'c')
+        we need to record the artifact a before it is mutated.
+        """
+
+        indentation_block = " " * indentation
+        return_string = ", ".join(coll.return_variables)
+        args_string = ", ".join(sorted([v for v in coll.input_variables]))
+        if isinstance(coll, ArtifactNodeCollection) and coll.is_pre_computed:
+            args_string = ""
+
+        # handle calling the function from a module
+        if source_module != "":
+            source_module = f"{source_module}."
+        codeblock = f"{indentation_block}{return_string} = {source_module}get_{coll.safename}({args_string})"
+        if keep_lineapy_save and isinstance(coll, ArtifactNodeCollection):
+            codeblock += f"""\n{indentation_block}lineapy.save({coll.return_variables[0]}, "{coll.name}")"""
+
+        if (
+            isinstance(coll, ArtifactNodeCollection)
+            and return_dict_name is not None
+        ):
+            codeblock += f"""\n{indentation_block}{return_dict_name}["{coll.name}"]=copy.deepcopy({coll.return_variables[0]})"""
+
+        return codeblock
+
+    def get_session_function_body(
+        self, indentation, return_dict_name="artifacts"
+    ) -> str:
+        """
+        Return the args for the session function.
+        """
+        return "\n".join(
+            [
+                self.get_function_call_block(
+                    coll,
+                    indentation=indentation,
+                    keep_lineapy_save=False,
+                    return_dict_name=return_dict_name,
+                )
+                for coll in self.session_artifact.artifact_nodecollections
+            ]
+        )
+
+    def _get_session_input_parameters_lines(self, indentation=4) -> str:
+        """
+        Return lines of session code that are replaced by user selected input
+        parameters. These lines also serve as the default values of these
+        variables.
+        """
+        return self.session_artifact.input_parameters_nodecollection.get_input_parameters_block(
+            indentation=indentation
+        )
+
+    def get_session_input_parameters_spec(self) -> Dict[str, InputVariable]:
+        """
+        Return a dictionary with input parameters as key and InputVariable
+        class as value to generate code related to user input variables.
+        """
+        session_input_variables: Dict[str, InputVariable] = dict()
+        for line in self._get_session_input_parameters_lines().split("\n"):
+            variable_def = line.strip(" ").rstrip(",")
+            if len(variable_def) > 0:
+                variable_name = variable_def.split("=")[0].strip(" ")
+                value = eval(variable_def.split("=")[1].strip(" "))
+                value_type = type(value)
+                if not (
+                    isinstance(value, int)
+                    or isinstance(value, float)
+                    or isinstance(value, str)
+                    or isinstance(value, bool)
+                ):
+                    raise ValueError(
+                        f"LineaPy only supports primitive types as input parameters for now. "
+                        f"{variable_name} in {variable_def} is a {value_type}."
+                    )
+                if ":" in variable_name:
+                    variable_name = variable_def.split(":")[0]
+                    session_input_variables[variable_name] = InputVariable(
+                        variable_name=variable_name,
+                        value=value,
+                        value_type=value_type,
+                    )
+                else:
+                    session_input_variables[variable_name] = InputVariable(
+                        variable_name=variable_name,
+                        value=value,
+                        value_type=value_type,
+                    )
+        return session_input_variables
+
+    def get_session_function_callblock(self) -> str:
+        """
+        Return the code to make the call to the session function as
+        `session_function_name(input_parameters)`.
+        """
+        session_function_name = self.get_session_function_name()
+        if session_function_name != "":
+            session_input_parameters = ", ".join(
+                self.get_session_input_parameters_spec().keys()
+            )
+            return f"{session_function_name}({session_input_parameters})"
+        else:
+            return ""
+
+    def get_session_artifact_function_definitions(
+        self, indentation=4
+    ) -> List[str]:
+        """
+        Return the definition of each targeted artifacts calculation
+        functions.
+        """
+        return [
+            coll.get_function_definition(indentation=indentation)
+            for coll in self.session_artifact.artifact_nodecollections
+        ]
+
+    def get_session_function(
+        self, indentation=4, return_dict_name="artifacts"
+    ) -> str:
+        """
+        Return the definition of the session function that executes the
+        calculation of all targeted artifacts.
+        """
+        indentation_block = " " * indentation
+        SESSION_FUNCTION_TEMPLATE = load_plugin_template(
+            "session_function.jinja"
+        )
+        session_function = SESSION_FUNCTION_TEMPLATE.render(
+            session_input_parameters_body=self._get_session_input_parameters_lines(),
+            indentation_block=indentation_block,
+            session_function_name=self.get_session_function_name(),
+            session_function_body=self.get_session_function_body(
+                indentation=indentation
+            ),
+            return_dict_name=return_dict_name,
+        )
+        return session_function

--- a/tests/unit/graph_reader/test_artifact_collection.py
+++ b/tests/unit/graph_reader/test_artifact_collection.py
@@ -162,7 +162,7 @@ def test_two_sessions(
         moduletext = writer._compose_module()
         first_artifact_in_session = {}
         for sa in ac.session_artifacts.values():
-            for nodecollection in sa.artifact_nodecollections:
+            for nodecollection in sa.usercode_nodecollections:
                 art_name = sa._get_first_artifact_name()
                 assert isinstance(art_name, str)
                 first_artifact_in_session[nodecollection.name] = (

--- a/tests/unit/graph_reader/test_node_collection.py
+++ b/tests/unit/graph_reader/test_node_collection.py
@@ -29,13 +29,12 @@ def get_user_code_nodecollection(
     sliced_graph = get_slice_graph(session_graph, sink_node_id_list)
 
     nc = UserCodeNodeCollection(
-        set([node.id for node in sliced_graph.nodes]),
-        session_graph,
-        nc_name,
+        node_list=set([node.id for node in sliced_graph.nodes]),
+        name=nc_name,
         input_variables=set(input_variables),
         return_variables=return_variables,
     )
-    return nc
+    return nc, session_graph
 
 
 @pytest.mark.parametrize(
@@ -67,7 +66,7 @@ def test_fixture(
     input parameters
     """
 
-    nc = get_user_code_nodecollection(
+    nc, session_graph = get_user_code_nodecollection(
         input_code,
         execute,
         variable_sinks,
@@ -81,4 +80,6 @@ def test_fixture(
     expected_function_def = f"""def get_{nc_name}({expected_input_block}):
     p = "p"
     return {expected_return_block}"""
-    assert expected_function_def == nc.get_function_definition()
+    assert expected_function_def == nc.get_function_definition(
+        graph=session_graph
+    )

--- a/tests/unit/graph_reader/test_node_collection.py
+++ b/tests/unit/graph_reader/test_node_collection.py
@@ -1,0 +1,84 @@
+from typing import List, Set
+
+import pytest
+
+from lineapy.graph_reader.node_collection import UserCodeNodeCollection
+from lineapy.graph_reader.program_slice import get_slice_graph
+from lineapy.instrumentation.tracer import Tracer
+
+
+def get_user_code_nodecollection(
+    input_code,
+    execute,
+    variable_sinks: Set[str],
+    nc_name: str,
+    input_variables: List[str],
+    return_variables: List[str],
+):
+    tracer: Tracer = execute(input_code, snapshot=False)
+
+    session_graph = tracer.graph
+    session_id = tracer.tracer_context.session_context.id
+
+    session_vars = tracer.db.get_variables_for_session(session_id)
+
+    sink_node_id_list = [
+        node_id for node_id, var in session_vars if var in variable_sinks
+    ]
+
+    sliced_graph = get_slice_graph(session_graph, sink_node_id_list)
+
+    nc = UserCodeNodeCollection(
+        set([node.id for node in sliced_graph.nodes]),
+        session_graph,
+        nc_name,
+        input_variables=set(input_variables),
+        return_variables=return_variables,
+    )
+    return nc
+
+
+@pytest.mark.parametrize(
+    "input_code, variable_sinks, nc_name, input_variables, return_variables",
+    [
+        [
+            """
+a = 2
+p = "p"
+b = p*a
+""",
+            ["p"],
+            "test_nc",
+            ["a", "b", "c"],
+            ["y", "z"],
+        ],
+    ],
+)
+def test_fixture(
+    execute,
+    input_code,
+    variable_sinks,
+    nc_name,
+    input_variables,
+    return_variables,
+):
+    """
+    Test the module generated from ArtifactCollection can run with/without
+    input parameters
+    """
+
+    nc = get_user_code_nodecollection(
+        input_code,
+        execute,
+        variable_sinks,
+        nc_name,
+        input_variables,
+        return_variables,
+    )
+
+    expected_input_block = ", ".join(input_variables)
+    expected_return_block = ", ".join(return_variables)
+    expected_function_def = f"""def get_{nc_name}({expected_input_block}):
+    p = "p"
+    return {expected_return_block}"""
+    assert expected_function_def == nc.get_function_definition()


### PR DESCRIPTION
# Description

Refactor NodeCollection, breaking up single NodeCollection class and NodeCollectionType Enum into 
distinct classes with inheritance. 

Changes
- Breaks up NodeCollection into subclasses. BaseNodeCollection, which has subclasses UserCodeNodeCollection, ImportNodeCollection and InputVarNodeCollection.  UserCodeNodeCollection has a subclass for ArtifactNodeCollection. Artifact collections coming from re-use precomputed are unchanged, and defined by `is_pre_computed_artifact`.
- Remove unused parameters from these NodeCollections. For  ImportNodeCollection and InputVarNodeCollection, only a node_list inherited from BaseNodeCollection is necessary. 
- Remove `module_import`, `predecessor_artifact`, `sliced_nodes` and other unneeded parameters from dataclass. 
- Moved `get_input_variable_sources` to method of `UserCodeNodeCollection` instead of a function in SessionArtifacts. 
- Moved graph to be a parameter for a NodeCollection, removing the need to `update_graph` when NodeCollection is created. This allows `_get_subgraph_from_node_list` to be moved as a helper function in NodeCollection constructor. 
- Kept `get_function_definition` and other methods which require the use of a raw_codeblock generated from the NodeCollection nodes as methods of NodeCollection. 
- Move `get_function_call_block` to SessionWriters along with other utilities in SessionArtifacts to generate code from SessionsArtifacts. 
- Redo `matched_pre_computed` logic to be explicit if else condition instead of implicit None=non-reuse Artifact collection type. 
- Move writer methods from SessionArtifacts and NodeCollection to SessionWriter. These include `get_session_module_imports`, `get_session_function_name`, `get_session_function_body`, `get_session_input_parameters_lines`, `get_session_input_parameters_spec`, `get_session_function_callblock`, `get_session_artifact_function_definitions`, `get_session_function`, all of which return code which is defined by the SessionArtifact. 
- Move `include_non_slice_as_comment` to be a property of SessionWriters. 

Fixes # (issue)
LIN-640
LIN-667

## Type of change

Please delete options that are not relevant.

- [ X ] Refactor (non-breaking change which does not change functionality)

# How Has This Been Tested?
Existing pytest

Also added example test creating a UserNodeCollection, which can be used in the future to test other NodeCollection functionality. 