### PR TITLE
[Hotfix] Use working link to dev branch until it is merged to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pip install lineapy
 ```
 
 If you want to run the latest version of LineaPy directly from the source, follow instructions
-[here](https://docs.lineapy.org/en/latest/development/start/setup.html#installation).
+[here](https://docs.lineapy.org/en/lin-680-produce-first-revamp-of-contributor-guide/development/start/setup.html#installation).
 
 LineaPy offers several extras to extend its core capabilities, such as support for PostgreSQL or Amazon S3.
 Learn more about these and other installation options [here](https://docs.lineapy.org/en/latest/fundamentals/setup.html#extras).


### PR DESCRIPTION
# Summary

README currently includes non-working link for installation from the source code (because the link points to contributor guide which is not yet in `main`). Until the dev branch (`LIN-680-produce-first-revamp-of-contributor-guide`) is merged to `main`, use a temporary working link (pointing to dev branch).

# Changes

- [x] Use a working link to dev branch until it is merged to `main`.

# Testing

NA

# Ticket(s)

NA