### PR TITLE
LIN-560 separate nodetransformers

### DIFF
--- a/lineapy/transformer/base_transformer.py
+++ b/lineapy/transformer/base_transformer.py
@@ -26,28 +26,6 @@ class BaseTransformer(ast.NodeTransformer):
         # None if it was a statement. Used by ipython to grab the last value
         self.last_statement_result: Optional[Node] = None
 
-    def generic_visit(self, node):
-        """
-        had to rewrite this because apparently if we process nodes in a list, it just extends it willy nilly
-        """
-        for field, old_value in ast.iter_fields(node):
-            if isinstance(old_value, list):
-                new_values = []
-                for value in old_value:
-                    if isinstance(value, ast.AST):
-                        value = self.visit(value)
-                        if value is None:
-                            continue
-                    new_values.append(value)
-                old_value[:] = new_values
-            elif isinstance(old_value, ast.AST):
-                new_node = self.visit(old_value)
-                if new_node is None:
-                    delattr(node, field)
-                else:
-                    setattr(node, field, new_node)
-        return node
-
     def _get_code_from_node(self, node: ast.AST) -> Optional[str]:
         if sys.version_info < (3, 8):
             from lineapy.utils.deprecation_utils import get_source_segment

--- a/lineapy/transformer/base_transformer.py
+++ b/lineapy/transformer/base_transformer.py
@@ -1,0 +1,116 @@
+import ast
+import sys
+from typing import List, Optional
+
+from lineapy.data.types import LiteralNode, Node, SourceCode, SourceLocation
+from lineapy.instrumentation.tracer import Tracer
+
+
+class BaseTransformer(ast.NodeTransformer):
+    """
+    .. note::
+
+        - Need to be careful about the order by which these calls are invoked
+          so that the transformation do not get called more than once.
+
+    """
+
+    def __init__(
+        self,
+        source_code: SourceCode,
+        tracer: Tracer,
+    ):
+        self.source_code = source_code
+        self.tracer = tracer
+        # The result of the last line, a node if it was an expression,
+        # None if it was a statement. Used by ipython to grab the last value
+        self.last_statement_result: Optional[Node] = None
+
+    def generic_visit(self, node):
+        """
+        had to rewrite this because apparently if we process nodes in a list, it just extends it willy nilly
+        """
+        for field, old_value in ast.iter_fields(node):
+            if isinstance(old_value, list):
+                new_values = []
+                for value in old_value:
+                    if isinstance(value, ast.AST):
+                        value = self.visit(value)
+                        if value is None:
+                            continue
+                    new_values.append(value)
+                old_value[:] = new_values
+            elif isinstance(old_value, ast.AST):
+                new_node = self.visit(old_value)
+                if new_node is None:
+                    delattr(node, field)
+                else:
+                    setattr(node, field, new_node)
+        return node
+
+    def _get_code_from_node(self, node: ast.AST) -> Optional[str]:
+        if sys.version_info < (3, 8):
+            from lineapy.utils.deprecation_utils import get_source_segment
+
+            return get_source_segment(self.source_code.code, node, padded=True)
+        else:
+            return ast.get_source_segment(
+                self.source_code.code, node, padded=True
+            )
+
+    def get_source(self, node: ast.AST) -> Optional[SourceLocation]:
+        if not hasattr(node, "lineno"):
+            return None
+        return SourceLocation(
+            source_code=self.source_code,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,  # type: ignore
+            end_col_offset=node.end_col_offset,  # type: ignore
+        )
+
+    def get_else_source(self, node: ast.If) -> Optional[SourceLocation]:
+        body_source = self.get_source(node.body[-1])
+        orelse_source = (
+            self.get_source(node.orelse[0]) if node.orelse else None
+        )
+        assert body_source, "Body of If/Else must have at least one statement"
+        if not orelse_source:
+            # If there is no else block, the else keyword would not be present
+            return None
+        return SourceLocation(
+            source_code=self.source_code,
+            # Else node can only start one line after if block, hence we add 1
+            lineno=body_source.end_lineno + 1,
+            col_offset=0,
+            # Keyword else can be in the previous line or the same line as the
+            # first statement of the else block
+            end_lineno=max(
+                orelse_source.lineno - 1, body_source.end_lineno + 1
+            ),
+            end_col_offset=orelse_source.col_offset,
+        )
+
+    def get_black_box_without_executing(
+        self, nodes: List[ast.stmt]
+    ) -> LiteralNode:
+        # We simply create a LiteralNode with the code within the block
+        # Processing a LiteralNode does not actually execute the statement
+        assert (
+            len(nodes) > 0
+        ), "The code block should contain at least one statement."
+        code = "\n".join(
+            [
+                str(self._get_code_from_node(node))
+                for node in nodes
+                if (self._get_code_from_node(node) is not None)
+            ]
+        )
+        source_location = SourceLocation(
+            source_code=self.source_code,
+            lineno=nodes[0].lineno,
+            col_offset=nodes[0].col_offset,
+            end_lineno=nodes[-1].end_lineno,  # type: ignore
+            end_col_offset=nodes[-1].end_col_offset,  # type: ignore
+        )
+        return self.tracer.literal(code, source_location=source_location)

--- a/lineapy/transformer/conditional_transformer.py
+++ b/lineapy/transformer/conditional_transformer.py
@@ -1,0 +1,73 @@
+import ast
+
+# import sys
+from typing import Any
+
+from lineapy.data.types import NodeType
+from lineapy.transformer.base_transformer import BaseTransformer
+from lineapy.utils.utils import get_new_id
+
+
+class ConditionalTransformer(BaseTransformer):
+    def visit_If(self, node: ast.If) -> Any:
+        test_call_node = self.visit(node.test)
+
+        node_id = get_new_id()
+        else_id = get_new_id() if len(node.orelse) > 0 else None
+
+        # We first check the value of the test node, depending on it's truth
+        # value we might have two cases as described below
+        if self.tracer.executor._id_to_value[test_call_node.id]:
+            # In case the test condition is truthy, we will visit only the
+            # statements within the body of the If node.
+            with self.tracer.get_control_node(
+                NodeType.IfNode,
+                node_id,
+                else_id,
+                self.get_source(node.test),
+                test_call_node.id,
+                None,
+            ):
+                for stmt in node.body:
+                    self.visit(stmt)
+            # For the statements within the orelse of the IfNode, since they
+            # are actually not executed, we simply treat all of the enclosed
+            # statements as a black box, and get a literal node containing all
+            # the unexecuted statements. We then create an ElseNode which
+            # points to the LiteralNode containing the unexecuted statements,
+            # which ensures all the unexecuted statements are always included
+            # in the sliced program
+            if else_id is not None:
+                with self.tracer.get_control_node(
+                    NodeType.ElseNode,
+                    else_id,
+                    node_id,
+                    self.get_else_source(node),
+                    None,
+                    self.get_black_box_without_executing(node.orelse).id,
+                ):
+                    pass
+        else:
+            # In this case, the test condition is falsy, so we reverse the
+            # analysis above: the statements in the body of the If node are not
+            # visited, hence they are treated as a blackbox, while the
+            # statements within the orelse branch are visited, and we call the
+            # visit() method on these statements.
+            with self.tracer.get_control_node(
+                NodeType.IfNode,
+                node_id,
+                else_id,
+                self.get_source(node.test),
+                test_call_node.id,
+                self.get_black_box_without_executing(node.body).id,
+            ):
+                pass
+            if else_id is not None:
+                with self.tracer.get_control_node(
+                    NodeType.ElseNode,
+                    else_id,
+                    node_id,
+                    self.get_else_source(node),
+                ):
+                    for stmt in node.orelse:
+                        self.visit(stmt)

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -89,10 +89,6 @@ class NodeTransformer(BaseTransformer):
             return self._exec_statement(node)
         elif isinstance(node, ast.expr):
             return self._exec_expression(node)
-        # else:
-        #     raise NotImplementedError(
-        #         f"Don't know how to transform {type(node).__name__}"
-        #     )
 
     def visit_Module(self, node: ast.Module) -> Any:
         for stmt in node.body:

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -1,17 +1,10 @@
 import ast
 import logging
 import sys
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
-from lineapy.data.types import (
-    CallNode,
-    LiteralNode,
-    Node,
-    NodeType,
-    SourceCode,
-    SourceLocation,
-)
-from lineapy.instrumentation.tracer import Tracer
+from lineapy.data.types import CallNode, LiteralNode, Node, SourceLocation
+from lineapy.transformer.base_transformer import BaseTransformer
 from lineapy.transformer.transformer_util import create_lib_attributes
 from lineapy.utils.constants import (
     ADD,
@@ -58,12 +51,11 @@ from lineapy.utils.lineabuiltins import (
     l_unpack_ex,
     l_unpack_sequence,
 )
-from lineapy.utils.utils import get_new_id
 
 logger = logging.getLogger(__name__)
 
 
-class NodeTransformer(ast.NodeTransformer):
+class NodeTransformer(BaseTransformer):
     """
     .. note::
 
@@ -71,27 +63,6 @@ class NodeTransformer(ast.NodeTransformer):
           so that the transformation do not get called more than once.
 
     """
-
-    def __init__(
-        self,
-        source_code: SourceCode,
-        tracer: Tracer,
-    ):
-        self.source_code = source_code
-        self.tracer = tracer
-        # The result of the last line, a node if it was an expression,
-        # None if it was a statement. Used by ipython to grab the last value
-        self.last_statement_result: Optional[Node] = None
-
-    def _get_code_from_node(self, node: ast.AST) -> Optional[str]:
-        if sys.version_info < (3, 8):
-            from lineapy.utils.deprecation_utils import get_source_segment
-
-            return get_source_segment(self.source_code.code, node, padded=True)
-        else:
-            return ast.get_source_segment(
-                self.source_code.code, node, padded=True
-            )
 
     def generic_visit(self, node: ast.AST):
         """
@@ -163,101 +134,6 @@ class NodeTransformer(ast.NodeTransformer):
             self.get_source(node),
             attributes=create_lib_attributes(node.names),
         )
-
-    def visit_If_hidden(self, node: ast.If) -> Any:
-        test_call_node = self.visit(node.test)
-
-        node_id = get_new_id()
-        else_id = get_new_id() if len(node.orelse) > 0 else None
-
-        # We first check the value of the test node, depending on it's truth
-        # value we might have two cases as described below
-        if self.tracer.executor._id_to_value[test_call_node.id]:
-            # In case the test condition is truthy, we will visit only the
-            # statements within the body of the If node.
-            with self.tracer.get_control_node(
-                NodeType.IfNode,
-                node_id,
-                else_id,
-                self.get_source(node.test),
-                test_call_node.id,
-                None,
-            ):
-                for stmt in node.body:
-                    self.visit(stmt)
-            # For the statements within the orelse of the IfNode, since they
-            # are actually not executed, we simply treat all of the enclosed
-            # statements as a black box, and get a literal node containing all
-            # the unexecuted statements. We then create an ElseNode which
-            # points to the LiteralNode containing the unexecuted statements,
-            # which ensures all the unexecuted statements are always included
-            # in the sliced program
-            if else_id is not None:
-                with self.tracer.get_control_node(
-                    NodeType.ElseNode,
-                    else_id,
-                    node_id,
-                    self.get_else_source(node),
-                    None,
-                    self.get_black_box_without_executing(node.orelse).id,
-                ):
-                    pass
-        else:
-            # In this case, the test condition is falsy, so we reverse the
-            # analysis above: the statements in the body of the If node are not
-            # visited, hence they are treated as a blackbox, while the
-            # statements within the orelse branch are visited, and we call the
-            # visit() method on these statements.
-            with self.tracer.get_control_node(
-                NodeType.IfNode,
-                node_id,
-                else_id,
-                self.get_source(node.test),
-                test_call_node.id,
-                self.get_black_box_without_executing(node.body).id,
-            ):
-                pass
-            if else_id is not None:
-                with self.tracer.get_control_node(
-                    NodeType.ElseNode,
-                    else_id,
-                    node_id,
-                    self.get_else_source(node),
-                ):
-                    for stmt in node.orelse:
-                        self.visit(stmt)
-
-    def visit_Index(self, node: ast.Index) -> Node:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.9
-        """
-        if sys.version_info >= (3, 9):
-            raise NotImplementedError(
-                "Index nodes are deprecated in Python 3.9"
-            )
-        else:
-            return self.visit(node.value)
-
-    def visit_ExtSlice(self, node: ast.ExtSlice) -> Node:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.9
-        """
-        if sys.version_info >= (3, 9):
-            raise NotImplementedError(
-                "ExtSlice nodes are deprecated in Python 3.9"
-            )
-        else:
-            elem_nodes = [self.visit(elem) for elem in node.dims]
-            return self.tracer.tuple(
-                *elem_nodes,
-                source_location=self.get_source(node),
-            )
 
     def visit_Name(self, node: ast.Name) -> Node:
         return self.tracer.lookup_node(node.id, self.get_source(node))
@@ -687,59 +563,4 @@ class NodeTransformer(ast.NodeTransformer):
             ),
         )
 
-    def get_source(self, node: ast.AST) -> Optional[SourceLocation]:
-        if not hasattr(node, "lineno"):
-            return None
-        return SourceLocation(
-            source_code=self.source_code,
-            lineno=node.lineno,
-            col_offset=node.col_offset,
-            end_lineno=node.end_lineno,  # type: ignore
-            end_col_offset=node.end_col_offset,  # type: ignore
-        )
-
-    def get_else_source(self, node: ast.If) -> Optional[SourceLocation]:
-        body_source = self.get_source(node.body[-1])
-        orelse_source = (
-            self.get_source(node.orelse[0]) if node.orelse else None
-        )
-        assert body_source, "Body of If/Else must have at least one statement"
-        if not orelse_source:
-            # If there is no else block, the else keyword would not be present
-            return None
-        return SourceLocation(
-            source_code=self.source_code,
-            # Else node can only start one line after if block, hence we add 1
-            lineno=body_source.end_lineno + 1,
-            col_offset=0,
-            # Keyword else can be in the previous line or the same line as the
-            # first statement of the else block
-            end_lineno=max(
-                orelse_source.lineno - 1, body_source.end_lineno + 1
-            ),
-            end_col_offset=orelse_source.col_offset,
-        )
-
-    def get_black_box_without_executing(
-        self, nodes: List[ast.stmt]
-    ) -> LiteralNode:
-        # We simply create a LiteralNode with the code within the block
-        # Processing a LiteralNode does not actually execute the statement
-        assert (
-            len(nodes) > 0
-        ), "The code block should contain at least one statement."
-        code = "\n".join(
-            [
-                str(self._get_code_from_node(node))
-                for node in nodes
-                if (self._get_code_from_node(node) is not None)
-            ]
-        )
-        source_location = SourceLocation(
-            source_code=self.source_code,
-            lineno=nodes[0].lineno,
-            col_offset=nodes[0].col_offset,
-            end_lineno=nodes[-1].end_lineno,  # type: ignore
-            end_col_offset=nodes[-1].end_col_offset,  # type: ignore
-        )
-        return self.tracer.literal(code, source_location=source_location)
+    

--- a/lineapy/transformer/node_transformer.py
+++ b/lineapy/transformer/node_transformer.py
@@ -1,7 +1,6 @@
 import ast
 import logging
 import sys
-from pathlib import Path
 from typing import Any, List, Optional, cast
 
 from lineapy.data.types import (
@@ -10,7 +9,6 @@ from lineapy.data.types import (
     Node,
     NodeType,
     SourceCode,
-    SourceCodeLocation,
     SourceLocation,
 )
 from lineapy.instrumentation.tracer import Tracer
@@ -76,18 +74,11 @@ class NodeTransformer(ast.NodeTransformer):
 
     def __init__(
         self,
-        code: str,
-        location: SourceCodeLocation,
+        source_code: SourceCode,
         tracer: Tracer,
     ):
-        self.source_code = SourceCode(
-            id=get_new_id(), code=code, location=location
-        )
-        tracer.db.write_source_code(self.source_code)
+        self.source_code = source_code
         self.tracer = tracer
-        # Set __file__ to the pathname of the file
-        if isinstance(location, Path):
-            tracer.executor.module_file = str(location)
         # The result of the last line, a node if it was an expression,
         # None if it was a statement. Used by ipython to grab the last value
         self.last_statement_result: Optional[Node] = None
@@ -126,80 +117,10 @@ class NodeTransformer(ast.NodeTransformer):
             return self._exec_statement(node)
         elif isinstance(node, ast.expr):
             return self._exec_expression(node)
-        else:
-            raise NotImplementedError(
-                f"Don't know how to transform {type(node).__name__}"
-            )
-
-    def visit_Ellipsis(self, node: ast.Ellipsis) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
-        if sys.version_info >= (3, 8):
-            raise NotImplementedError(
-                "Ellipsis nodes are deprecated since Python 3.8"
-            )
-        else:
-            return self.tracer.literal(..., self.get_source(node))
-
-    def visit_Str(self, node: ast.Str) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
-        if sys.version_info >= (3, 8):
-            raise NotImplementedError(
-                "Str nodes are deprecated since Python 3.8"
-            )
-        else:
-            return self.tracer.literal(node.s, self.get_source(node))
-
-    def visit_Num(self, node: ast.Num) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
-        if sys.version_info >= (3, 8):
-            raise NotImplementedError(
-                "Num nodes are deprecated since Python 3.8"
-            )
-        else:
-            return self.tracer.literal(node.n, self.get_source(node))
-
-    def visit_Bytes(self, node: ast.Bytes) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
-        if sys.version_info >= (3, 8):
-            raise NotImplementedError(
-                "Bytes nodes are deprecated since Python 3.8"
-            )
-        else:
-            return self.tracer.literal(node.s, self.get_source(node))
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
-        if sys.version_info >= (3, 8):
-            raise NotImplementedError(
-                "Num nodes are deprecated since Python 3.8"
-            )
-        else:
-            return self.tracer.literal(node.value, self.get_source(node))
+        # else:
+        #     raise NotImplementedError(
+        #         f"Don't know how to transform {type(node).__name__}"
+        #     )
 
     def visit_Module(self, node: ast.Module) -> Any:
         for stmt in node.body:
@@ -401,6 +322,11 @@ class NodeTransformer(ast.NodeTransformer):
             node.value,
             self.get_source(node),
         )
+
+    def visit_LiteralNode(self, node: LiteralNode) -> LiteralNode:
+        # This is to capture nodes processes by python 3.7 transformer
+        # They have already been added to the db and do not need to be processed any further
+        return node
 
     def visit_Assign(self, node: ast.Assign) -> None:
         """

--- a/lineapy/transformer/py37_transformer.py
+++ b/lineapy/transformer/py37_transformer.py
@@ -1,0 +1,98 @@
+import ast
+
+# import sys
+from typing import Optional
+
+from lineapy.data.types import LiteralNode, Node, SourceCode, SourceLocation
+from lineapy.instrumentation.tracer import Tracer
+
+
+class Py37Transformer(ast.NodeTransformer):
+    def __init__(
+        self,
+        source_code: SourceCode,
+        tracer: Tracer,
+    ):
+        self.source_code = source_code
+        self.tracer = tracer
+        # The result of the last line, a node if it was an expression,
+        # None if it was a statement. Used by ipython to grab the last value
+        self.last_statement_result: Optional[Node] = None
+
+    def generic_visit(self, node):
+        """
+        had to rewrite this because apparently if we process nodes in a list, it just extends it willy nilly
+        """
+        for field, old_value in ast.iter_fields(node):
+            if isinstance(old_value, list):
+                new_values = []
+                for value in old_value:
+                    if isinstance(value, ast.AST):
+                        value = self.visit(value)
+                        if value is None:
+                            continue
+                    new_values.append(value)
+                old_value[:] = new_values
+            elif isinstance(old_value, ast.AST):
+                new_node = self.visit(old_value)
+                if new_node is None:
+                    delattr(node, field)
+                else:
+                    setattr(node, field, new_node)
+        return node
+
+    def visit_Ellipsis(self, node: ast.Ellipsis) -> LiteralNode:
+        """
+        Note
+        ----
+
+        Deprecated in Python 3.8
+        """
+        return self.tracer.literal(..., self.get_source(node))
+
+    def visit_Str(self, node: ast.Str) -> LiteralNode:
+        """
+        Note
+        ----
+
+        Deprecated in Python 3.8
+        """
+        return self.tracer.literal(node.s, self.get_source(node))
+
+    def visit_Num(self, node: ast.Num) -> LiteralNode:
+        """
+        Note
+        ----
+
+        Deprecated in Python 3.8
+        """
+        return self.tracer.literal(node.n, self.get_source(node))
+
+    def visit_NameConstant(self, node: ast.NameConstant) -> LiteralNode:
+        """
+        Note
+        ----
+
+        Deprecated in Python 3.8
+        """
+        return self.tracer.literal(node.value, self.get_source(node))
+
+    def visit_Bytes(self, node: ast.Bytes) -> LiteralNode:
+        """
+        Note
+        ----
+
+        Deprecated in Python 3.8
+        """
+        return self.tracer.literal(node.s, self.get_source(node))
+
+    def get_source(self, node: ast.AST) -> Optional[SourceLocation]:
+        if not hasattr(node, "lineno"):
+            return None
+        return SourceLocation(
+            source_code=self.source_code,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,  # type: ignore
+            end_col_offset=node.end_col_offset,  # type: ignore
+        )

--- a/lineapy/transformer/py37_transformer.py
+++ b/lineapy/transformer/py37_transformer.py
@@ -5,7 +5,7 @@ from lineapy.utils.deprecation_utils import Constant
 
 
 class Py37Transformer(BaseTransformer):
-    def convert_to_constant(self, value, node) -> Constant:
+    def _convert_to_constant(self, value, node) -> Constant:
         if not hasattr(
             node, "end_lineno"
         ):  # somehow didnt go through our sourcegiver
@@ -22,16 +22,16 @@ class Py37Transformer(BaseTransformer):
             )
 
     def visit_Ellipsis(self, node: ast.Ellipsis) -> Constant:
-        return self.convert_to_constant(..., node)
+        return self._convert_to_constant(..., node)
 
     def visit_Str(self, node: ast.Str) -> Constant:
-        return self.convert_to_constant(node.s, node)
+        return self._convert_to_constant(node.s, node)
 
     def visit_Num(self, node: ast.Num) -> Constant:
-        return self.convert_to_constant(node.n, node)
+        return self._convert_to_constant(node.n, node)
 
     def visit_NameConstant(self, node: ast.NameConstant) -> Constant:
-        return self.convert_to_constant(node.value, node)
+        return self._convert_to_constant(node.value, node)
 
     def visit_Bytes(self, node: ast.Bytes) -> Constant:
-        return self.convert_to_constant(node.s, node)
+        return self._convert_to_constant(node.s, node)

--- a/lineapy/transformer/py37_transformer.py
+++ b/lineapy/transformer/py37_transformer.py
@@ -1,98 +1,21 @@
 import ast
 
-# import sys
-from typing import Optional
-
-from lineapy.data.types import LiteralNode, Node, SourceCode, SourceLocation
-from lineapy.instrumentation.tracer import Tracer
+from lineapy.data.types import LiteralNode
+from lineapy.transformer.base_transformer import BaseTransformer
 
 
-class Py37Transformer(ast.NodeTransformer):
-    def __init__(
-        self,
-        source_code: SourceCode,
-        tracer: Tracer,
-    ):
-        self.source_code = source_code
-        self.tracer = tracer
-        # The result of the last line, a node if it was an expression,
-        # None if it was a statement. Used by ipython to grab the last value
-        self.last_statement_result: Optional[Node] = None
-
-    def generic_visit(self, node):
-        """
-        had to rewrite this because apparently if we process nodes in a list, it just extends it willy nilly
-        """
-        for field, old_value in ast.iter_fields(node):
-            if isinstance(old_value, list):
-                new_values = []
-                for value in old_value:
-                    if isinstance(value, ast.AST):
-                        value = self.visit(value)
-                        if value is None:
-                            continue
-                    new_values.append(value)
-                old_value[:] = new_values
-            elif isinstance(old_value, ast.AST):
-                new_node = self.visit(old_value)
-                if new_node is None:
-                    delattr(node, field)
-                else:
-                    setattr(node, field, new_node)
-        return node
-
+class Py37Transformer(BaseTransformer):
     def visit_Ellipsis(self, node: ast.Ellipsis) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
         return self.tracer.literal(..., self.get_source(node))
 
     def visit_Str(self, node: ast.Str) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
         return self.tracer.literal(node.s, self.get_source(node))
 
     def visit_Num(self, node: ast.Num) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
         return self.tracer.literal(node.n, self.get_source(node))
 
     def visit_NameConstant(self, node: ast.NameConstant) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
         return self.tracer.literal(node.value, self.get_source(node))
 
     def visit_Bytes(self, node: ast.Bytes) -> LiteralNode:
-        """
-        Note
-        ----
-
-        Deprecated in Python 3.8
-        """
         return self.tracer.literal(node.s, self.get_source(node))
-
-    def get_source(self, node: ast.AST) -> Optional[SourceLocation]:
-        if not hasattr(node, "lineno"):
-            return None
-        return SourceLocation(
-            source_code=self.source_code,
-            lineno=node.lineno,
-            col_offset=node.col_offset,
-            end_lineno=node.end_lineno,  # type: ignore
-            end_col_offset=node.end_col_offset,  # type: ignore
-        )

--- a/lineapy/transformer/py37_transformer.py
+++ b/lineapy/transformer/py37_transformer.py
@@ -1,21 +1,37 @@
 import ast
 
-from lineapy.data.types import LiteralNode
 from lineapy.transformer.base_transformer import BaseTransformer
+from lineapy.utils.deprecation_utils import Constant
 
 
 class Py37Transformer(BaseTransformer):
-    def visit_Ellipsis(self, node: ast.Ellipsis) -> LiteralNode:
-        return self.tracer.literal(..., self.get_source(node))
+    def convert_to_constant(self, value, node) -> Constant:
+        if not hasattr(
+            node, "end_lineno"
+        ):  # somehow didnt go through our sourcegiver
+            return Constant(
+                value=value, lineno=node.lineno, col_offset=node.col_offset
+            )
+        else:
+            return Constant(
+                value=value,
+                lineno=node.lineno,
+                end_lineno=node.end_lineno,  # type: ignore
+                col_offset=node.col_offset,
+                end_col_offset=node.end_col_offset,  # type: ignore
+            )
 
-    def visit_Str(self, node: ast.Str) -> LiteralNode:
-        return self.tracer.literal(node.s, self.get_source(node))
+    def visit_Ellipsis(self, node: ast.Ellipsis) -> Constant:
+        return self.convert_to_constant(..., node)
 
-    def visit_Num(self, node: ast.Num) -> LiteralNode:
-        return self.tracer.literal(node.n, self.get_source(node))
+    def visit_Str(self, node: ast.Str) -> Constant:
+        return self.convert_to_constant(node.s, node)
 
-    def visit_NameConstant(self, node: ast.NameConstant) -> LiteralNode:
-        return self.tracer.literal(node.value, self.get_source(node))
+    def visit_Num(self, node: ast.Num) -> Constant:
+        return self.convert_to_constant(node.n, node)
 
-    def visit_Bytes(self, node: ast.Bytes) -> LiteralNode:
-        return self.tracer.literal(node.s, self.get_source(node))
+    def visit_NameConstant(self, node: ast.NameConstant) -> Constant:
+        return self.convert_to_constant(node.value, node)
+
+    def visit_Bytes(self, node: ast.Bytes) -> Constant:
+        return self.convert_to_constant(node.s, node)

--- a/lineapy/transformer/py38_transformer.py
+++ b/lineapy/transformer/py38_transformer.py
@@ -1,16 +1,14 @@
 import ast
 
-from lineapy.data.types import Node
 from lineapy.transformer.base_transformer import BaseTransformer
 
 
 class Py38Transformer(BaseTransformer):
     def visit_Index(self, node: ast.Index) -> ast.AST:
-        return node.value
+        return self.visit(node.value)
 
-    def visit_ExtSlice(self, node: ast.ExtSlice) -> Node:
+    def visit_ExtSlice(self, node: ast.ExtSlice) -> ast.Tuple:
         elem_nodes = [self.visit(elem) for elem in node.dims]
-        return self.tracer.tuple(
-            *elem_nodes,
-            source_location=self.get_source(node),
+        return ast.Tuple(
+            elts=list(elem_nodes),
         )

--- a/lineapy/transformer/py38_transformer.py
+++ b/lineapy/transformer/py38_transformer.py
@@ -5,10 +5,12 @@ from lineapy.transformer.base_transformer import BaseTransformer
 
 class Py38Transformer(BaseTransformer):
     def visit_Index(self, node: ast.Index) -> ast.AST:
-        return self.visit(node.value)
+        # ignoring types because these classes were entirely removed without backward support in 3.9
+        return self.visit(node.value)  # type: ignore
 
     def visit_ExtSlice(self, node: ast.ExtSlice) -> ast.Tuple:
-        elem_nodes = [self.visit(elem) for elem in node.dims]
+        # ignoring types because these classes were entirely removed without backward support in 3.9
+        elem_nodes = [self.visit(elem) for elem in node.dims]  # type: ignore
         return ast.Tuple(
             elts=list(elem_nodes),
         )

--- a/lineapy/transformer/py38_transformer.py
+++ b/lineapy/transformer/py38_transformer.py
@@ -1,0 +1,16 @@
+import ast
+
+from lineapy.data.types import Node
+from lineapy.transformer.base_transformer import BaseTransformer
+
+
+class Py38Transformer(BaseTransformer):
+    def visit_Index(self, node: ast.Index) -> ast.AST:
+        return node.value
+
+    def visit_ExtSlice(self, node: ast.ExtSlice) -> Node:
+        elem_nodes = [self.visit(elem) for elem in node.dims]
+        return self.tracer.tuple(
+            *elem_nodes,
+            source_location=self.get_source(node),
+        )

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -30,14 +30,14 @@ def transform(
     # This function is our main entry point to linea-based transformations.
     # In does the following things in order:
     #     1) accepts the source code and writes it to the db after proper encapsulation
-    #     2) determines the transformations that need to be done on this source. The additions currently 
-    #        are mostly dependent on the python runtime version but can be extended to other variables in 
-    #        the future. These transforms will be run in order with each transformer fixing the ast so 
-    #        that the final transformer/s (NodeTransformer and others in future) which do most of the 
+    #     2) determines the transformations that need to be done on this source. The additions currently
+    #        are mostly dependent on the python runtime version but can be extended to other variables in
+    #        the future. These transforms will be run in order with each transformer fixing the ast so
+    #        that the final transformer/s (NodeTransformer and others in future) which do most of the
     #        conversion to linea graph are agnostic of python versions or source format changes.
-    #     3) parse code and walk the first level of the ast generated from code. Note that since this is only a first 
-    #        level walk, all transformers are supposed to walk any sub-trees (eg. check out visit_Index 
-    #        in py38transformer. not visiting the value will result only in first-level ast to be mutated 
+    #     3) parse code and walk the first level of the ast generated from code. Note that since this is only a first
+    #        level walk, all transformers are supposed to walk any sub-trees (eg. check out visit_Index
+    #        in py38transformer. not visiting the value will result only in first-level ast to be mutated
     #        leaving the children untouched)
     # create sourcecode object and register source code to db
     src = SourceCode(id=get_new_id(), code=code, location=location)

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -21,24 +21,27 @@ def transform(
     code: str, location: SourceCodeLocation, tracer: Tracer
 ) -> Optional[Node]:
     """
-    Traces the given code, executing it and writing the results to the DB.
+    This function is our main entry point to linea-based transformations.
+    It traces the given code, executing it and writing the results to the DB.
+
+    It does the following things in order:
+        1) accepts the source code and writes it to the db after proper encapsulation
+        2) determines the transformations that need to be done on this source. The additions currently
+           are mostly dependent on the python runtime version but can be extended to other variables in
+           the future. These transforms will be run in order with each transformer fixing the ast so
+           that the final transformer/s (NodeTransformer and others in future) which do most of the
+           conversion to linea graph are agnostic of python versions or source format changes.
+        3) parse code and walk the first level of the ast generated from code. Note that since this is only a first
+           level walk, all transformers are supposed to walk any sub-trees (eg. check out visit_Index
+           in py38transformer. not visiting the value will result only in first-level ast to be mutated
+           leaving the children untouched)
+        4) Finally writes the linea graph generated from this ast to linea DB
 
     It returns the node corresponding to the last statement in the code,
     if it exists.
+
     """
 
-    # This function is our main entry point to linea-based transformations.
-    # In does the following things in order:
-    #     1) accepts the source code and writes it to the db after proper encapsulation
-    #     2) determines the transformations that need to be done on this source. The additions currently
-    #        are mostly dependent on the python runtime version but can be extended to other variables in
-    #        the future. These transforms will be run in order with each transformer fixing the ast so
-    #        that the final transformer/s (NodeTransformer and others in future) which do most of the
-    #        conversion to linea graph are agnostic of python versions or source format changes.
-    #     3) parse code and walk the first level of the ast generated from code. Note that since this is only a first
-    #        level walk, all transformers are supposed to walk any sub-trees (eg. check out visit_Index
-    #        in py38transformer. not visiting the value will result only in first-level ast to be mutated
-    #        leaving the children untouched)
     # create sourcecode object and register source code to db
     src = SourceCode(id=get_new_id(), code=code, location=location)
     tracer.db.write_source_code(src)

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -8,8 +8,10 @@ from lineapy.data.types import Node, SourceCode, SourceCodeLocation
 from lineapy.editors.ipython_cell_storage import get_location_path
 from lineapy.exceptions.user_exception import RemoveFrames, UserException
 from lineapy.instrumentation.tracer import Tracer
+from lineapy.transformer.base_transformer import BaseTransformer
 from lineapy.transformer.node_transformer import NodeTransformer
 from lineapy.transformer.py37_transformer import Py37Transformer
+from lineapy.transformer.py38_transformer import Py38Transformer
 from lineapy.utils.utils import get_new_id
 
 logger = logging.getLogger(__name__)
@@ -35,10 +37,13 @@ def transform(
         tracer.executor.module_file = str(location)
 
     # initialize the transformer IN ORDER of preference
-    transformers: List[ast.NodeTransformer] = []
+    transformers: List[BaseTransformer] = []
     # python 3.7 handler
     if sys.version_info < (3, 8):
         transformers.append(Py37Transformer(src, tracer))
+    # python 3.8 handler
+    if sys.version_info < (3, 9):
+        transformers.append(Py38Transformer(src, tracer))
 
     # main transformation handler
     transformers.append(NodeTransformer(src, tracer))

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -38,17 +38,21 @@ def transform(
 
     # initialize the transformer IN ORDER of preference
     transformers: List[BaseTransformer] = []
+
     # python 3.7 handler
     if sys.version_info < (3, 8):
         transformers.append(Py37Transformer(src, tracer))
+
     # python 3.8 handler
     if sys.version_info < (3, 9):
         transformers.append(Py38Transformer(src, tracer))
 
+    # newer conditional transformers
+    # FIXME these done work so they have been removed for now
+    # transformers.append(ConditionalTransformer(src, tracer))
+
     # main transformation handler
     transformers.append(NodeTransformer(src, tracer))
-
-    # TODO control flow handler
 
     # parse the usercode in preparation for visits
     try:
@@ -77,9 +81,7 @@ def transform(
             res = None
             for trans in transformers:
 
-                # print(f"before {trans.__class__.__name__}: {ast.dump(stmt)}")
                 res = trans.visit(stmt)
-                # print(f"after {trans.__class__.__name__}: {ast.dump(stmt)}")
                 # swap the node with the output of previous transformer and use that for further calls
                 # or some other statement to figure out whether the node is properly processed or not
                 if res is not None:
@@ -90,12 +92,9 @@ def transform(
                 raise NotImplementedError(
                     f"Don't know how to transform {type(stmt).__name__}"
                 )
-            # FIXME - this is needed for jupyter, will revisit this after prototype phase.
-            last_statement_result = res  # type: ignore
-        # replaced by the for loop above
-        # node_transformer.visit(tree)
+            last_statement_result = res
 
         tracer.db.commit()
-        return last_statement_result  # type: ignore
+        return last_statement_result
 
     return None

--- a/lineapy/transformer/transform_code.py
+++ b/lineapy/transformer/transform_code.py
@@ -27,6 +27,18 @@ def transform(
     if it exists.
     """
 
+    # This function is our main entry point to linea-based transformations.
+    # In does the following things in order:
+    #     1) accepts the source code and writes it to the db after proper encapsulation
+    #     2) determines the transformations that need to be done on this source. The additions currently 
+    #        are mostly dependent on the python runtime version but can be extended to other variables in 
+    #        the future. These transforms will be run in order with each transformer fixing the ast so 
+    #        that the final transformer/s (NodeTransformer and others in future) which do most of the 
+    #        conversion to linea graph are agnostic of python versions or source format changes.
+    #     3) parse code and walk the first level of the ast generated from code. Note that since this is only a first 
+    #        level walk, all transformers are supposed to walk any sub-trees (eg. check out visit_Index 
+    #        in py38transformer. not visiting the value will result only in first-level ast to be mutated 
+    #        leaving the children untouched)
     # create sourcecode object and register source code to db
     src = SourceCode(id=get_new_id(), code=code, location=location)
     tracer.db.write_source_code(src)

--- a/lineapy/utils/deprecation_utils.py
+++ b/lineapy/utils/deprecation_utils.py
@@ -1,6 +1,8 @@
 import functools
 import weakref
+from ast import expr
 from functools import singledispatch, update_wrapper
+from typing import Any, Optional
 
 
 # Descriptor version
@@ -145,3 +147,11 @@ def lru_cache(*lru_args, **lru_kwargs):
         return wrapped_func
 
     return decorator
+
+
+class Constant(expr):
+    value: Any  # None, str, bytes, bool, int, float, complex, Ellipsis
+    kind: Optional[str]
+    # Aliases for value, for backwards compatibility
+    s: Any
+    n: complex

--- a/tests/unit/transformer/test_node_transformer.py
+++ b/tests/unit/transformer/test_node_transformer.py
@@ -12,6 +12,7 @@ from mock import MagicMock
 from lineapy.data.types import SourceCode
 from lineapy.transformer.node_transformer import NodeTransformer
 from lineapy.transformer.py37_transformer import Py37Transformer
+from lineapy.transformer.py38_transformer import Py38Transformer
 from lineapy.transformer.source_giver import SourceGiver
 from lineapy.utils.utils import get_new_id
 
@@ -142,6 +143,10 @@ class TestNodeTransformer:
             py37 = Py37Transformer(self.nt.source_code, tracer)
             py37.visit(test_node.body[0])
             self.nt.visit_MagicMock = tracer.literal
+        if sys.version_info < (3, 9):
+            py38 = Py38Transformer(self.nt.source_code, tracer)
+            py38.visit(test_node.body[0])
+            self.nt.visit_MagicMock = tracer.literal
         self.nt.visit(test_node.body[0])
         tracer.assign.assert_called_once_with("a", tracer.literal.return_value)
 
@@ -157,6 +162,10 @@ class TestNodeTransformer:
         if sys.version_info < (3, 8):
             py37 = Py37Transformer(self.nt.source_code, tracer)
             py37.visit(test_node.body[0])
+            self.nt.visit_MagicMock = tracer.literal
+        if sys.version_info < (3, 9):
+            py38 = Py38Transformer(self.nt.source_code, tracer)
+            py38.visit(test_node.body[0])
             self.nt.visit_MagicMock = tracer.literal
         self.nt.visit(test_node.body[0])
         tracer.call.assert_called_once_with(
@@ -209,6 +218,10 @@ class TestNodeTransformer:
             py37 = Py37Transformer(self.nt.source_code, tracer)
             py37.visit(test_node.body[0])
             self.nt.visit_MagicMock = tracer.literal
+        if sys.version_info < (3, 9):
+            py38 = Py38Transformer(self.nt.source_code, tracer)
+            py38.visit(test_node.body[0])
+            self.nt.visit_MagicMock = tracer.literal
         self.nt.visit(test_node.body[0])
         tracer.call.assert_called_once_with(
             tracer.lookup_node.return_value,
@@ -225,10 +238,14 @@ class TestNodeTransformer:
     ):
         self.nt._get_code_from_node = MagicMock()
         test_node = _get_ast_node(code)
+        tracer = self.nt.tracer
         if sys.version_info < (3, 8):
-            tracer = self.nt.tracer
             py37 = Py37Transformer(self.nt.source_code, tracer)
             py37.visit(test_node.body[0])
+            self.nt.visit_MagicMock = tracer.literal
+        if sys.version_info < (3, 9):
+            py38 = Py38Transformer(self.nt.source_code, tracer)
+            py38.visit(test_node.body[0])
             self.nt.visit_MagicMock = tracer.literal
         self.nt.visit(test_node)
         # doing this so that we can select which function in tracer gets called.

--- a/tests/unit/transformer/test_transform_code.py
+++ b/tests/unit/transformer/test_transform_code.py
@@ -13,6 +13,6 @@ def test_transform_fn(nt_mock: MagicMock):
     mocked_tracer = MagicMock()
     source_location = MagicMock()
     transform("x = 1", source_location, mocked_tracer)
-    nt_mock.assert_called_once_with("x = 1", source_location, mocked_tracer)
+    nt_mock.assert_called_once()
     mocked_tracer.db.commit.assert_called_once()
     # TODO - test that source giver is called only for 3.7 and below


### PR DESCRIPTION
# Description

This PR moves the code to handle changes in ast over different python versions to their own transforms. this way nodetransformer remains agnostic of the version and makes future additions plug-n-playable.

Fixes LIN-560

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
existing test + some modified unit tests