### PR TITLE
Change instructions to use psycopg2-binary

### DIFF
--- a/docs/source/guide/manage_artifacts/storage_location/postgres.rst
+++ b/docs/source/guide/manage_artifacts/storage_location/postgres.rst
@@ -55,7 +55,7 @@ is a Python package called ``psycopg2``, which can be installed as follows:
 
 .. code:: bash
 
-    $ pip install psycopg2
+    $ pip install psycopg2-binary
 
 Connect LineaPy with PostgreSQL
 -------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pdbpp==0.10.3
 pg==0.1
 Pillow==9.1.1
 pre-commit==2.18.1
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
 pydantic==1.9.0
 pytest==6.2.5
 pytest-alembic==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ typing_libs = [
 ]
 
 postgres_libs = [
-    "psycopg2",
+    "psycopg2-binary",
 ]
 
 s3_libs = ["boto3", "s3fs", "botocore"]

--- a/tests/tools/requirements_txt_gen.py
+++ b/tests/tools/requirements_txt_gen.py
@@ -86,7 +86,7 @@ DEV_REQUIRES = [
     # DBs
     ##
     "pg",
-    "psycopg2",
+    "psycopg2-binary",
     "pytest-xdist",
     "sphinx-autobuild",
 ]


### PR DESCRIPTION
# Description

Change instructions to use psycopg2-binary

Fixes #839 

# How Has This Been Tested?

Reinstalled lineapy in a new venv from setup
``pip install -r requirements.txt `` and ensure no errors and that DB connection works.