### PR TITLE
Pin SQLAlchemy<2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ VERSION = version("lineapy/utils/version.py")
 minimal_requirement = [
     "click>=8.0.0",
     "pydantic",
-    "SQLAlchemy>=1.4",
-    "SQLAlchemy<2.0.0",  # https://sqlalche.me/e/20/zlpr
+    "SQLAlchemy>=1.4, <2.0.0",  # https://sqlalche.me/e/20/zlpr
     "networkx",
     "rich",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ minimal_requirement = [
     "click>=8.0.0",
     "pydantic",
     "SQLAlchemy>=1.4",
+    "SQLAlchemy<2.0.0",  # https://sqlalche.me/e/20/zlpr
     "networkx",
     "rich",
     "pyyaml",


### PR DESCRIPTION
# Description

Pin SQLAlchemy<2.0.0. 

Lineapy install doesnt work with the latest version of sqlalchemy library (>= 2.0.0)
[https://docs.sqlalchemy.org/en/20/intro.html
](https://docs.sqlalchemy.org/en/20/intro.html)

[https://sqlalche.me/e/20/zlpr](https://sqlalche.me/e/20/zlpr)

```
sqlalchemy.exc.ArgumentError: Type annotation for "ArtifactORM.node" can't be correctly interpreted for Annotated 
Declarative Table form.  ORM annotations should normally make use of the ``Mapped[]`` generic type, or other ORM-
compatible generic type, as a container for the actual type, which indicates the intent that the attribute is mapped. Class 
variables that are not intended to be mapped by the ORM should use ClassVar[].  To allow Annotated Declarative to 
disregard legacy annotations which don't use Mapped[] to pass, set "__allow_unmapped__ = True" on the class or a 
superclass this class. (Background on this error at: https://sqlalche.me/e/20/zlpr) 
```


# How Has This Been Tested?

Test that lineapy runs on SQLAlchemy==1.4.44 (latest version before 2.0.0
Test that installing from source gives a version of SQLAlchemy < 2.0.0