### PR TITLE
Fix resolution of ~ in output_dir

### DIFF
--- a/airflow-requirements.txt
+++ b/airflow-requirements.txt
@@ -1,4 +1,4 @@
 apache-airflow==2.2.4
 pandas
-sklearn
+scikit-learn==1.0.2
 SQLAlchemy==1.3.24

--- a/lineapy/plugins/base_pipeline_writer.py
+++ b/lineapy/plugins/base_pipeline_writer.py
@@ -47,7 +47,7 @@ class BasePipelineWriter:
         self.artifact_collection = artifact_collection
         self.keep_lineapy_save = keep_lineapy_save
         self.pipeline_name = slugify(pipeline_name)
-        self.output_dir = Path(output_dir)
+        self.output_dir = Path(output_dir).expanduser()
         self.generate_test = generate_test
         self.dag_config = dag_config or {}
         self.dependencies = dependencies


### PR DESCRIPTION
when output_dir="~", it should point to the user's home directory instead of the relative path that it resolves to right now.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
existing tests should not create a ~ folder in the project root or in tests/notebooks