### PR TITLE
LIN-712 use cloudpickle

### DIFF
--- a/lineapy/api/artifact_serializer.py
+++ b/lineapy/api/artifact_serializer.py
@@ -3,8 +3,7 @@ import types
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pandas.io.pickle import to_pickle
-
+from lineapy.api.api_utils import to_pickle
 from lineapy.data.types import ARTIFACT_STORAGE_BACKEND, LineaID
 from lineapy.exceptions.db_exceptions import ArtifactSaveException
 from lineapy.plugins.serializers.mlflow_io import try_write_to_mlflow

--- a/lineapy/api/models/linea_artifact.py
+++ b/lineapy/api/models/linea_artifact.py
@@ -5,7 +5,7 @@ from typing import Optional, Set, Tuple, Union
 
 from IPython.display import display
 
-from lineapy.api.api_utils import _read_pickle, de_lineate_code
+from lineapy.api.api_utils import de_lineate_code, read_pickle
 from lineapy.data.graph import Graph
 from lineapy.data.types import (
     ARTIFACT_STORAGE_BACKEND,
@@ -119,7 +119,7 @@ class LineaArtifact:
                 return read_mlflow(metadata["mlflow"])
 
             # read from lineapy
-            return _read_pickle(saved_filepath)
+            return read_pickle(saved_filepath)
 
     @lru_cache(maxsize=None)
     def _get_storage_path(self) -> Optional[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ astpretty==2.1.0
 asttokens==2.0.5
 black==22.3.0
 click==8.1.2
+cloudpickle==2.2.0
 coveralls==3.3.1
 fastparquet==0.8.0
 flake8==4.0.1
@@ -24,7 +25,7 @@ pdbpp==0.10.3
 pg==0.1
 Pillow==9.1.1
 pre-commit==2.18.1
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5
 pydantic==1.9.0
 pytest==6.2.5
 pytest-alembic==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ minimal_requirement = [
     "fsspec",
     "pandas",
     "alembic==1.8.0",
+    "cloudpickle",
 ]
 
 graph_libs = [

--- a/tests/tools/requirements_txt_gen.py
+++ b/tests/tools/requirements_txt_gen.py
@@ -27,6 +27,7 @@ INSTALL_REQUIRES = [
     "nbconvert",
     "requests",
     "alembic==1.8.0",
+    "cloudpickle",
 ]
 
 


### PR DESCRIPTION
# Description

Start using cloudpickle. In general, cloudpickle supports more use cases but specifically it works around the constraint of the pickle class that requires class objects to be registered in globals().  This will let linea keep hijacking the default globals and work with a separate copy in executor.

Fixes LIN-712

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
All existing tests.