### PR TITLE
LIN-729 add new user properties in every request

### DIFF
--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -12,8 +12,10 @@ import json
 import logging
 import os
 import sys
+import time
 import uuid
 from functools import lru_cache
+from pathlib import Path
 
 import requests
 from IPython import get_ipython
@@ -80,8 +82,33 @@ def _api_key() -> str:
 
 
 @lru_cache(maxsize=1)
-def _session_id() -> str:
-    return str(uuid.uuid4())  # uuid that marks current python session
+def _user_id() -> str:
+    return str(
+        uuid.uuid3(uuid.NAMESPACE_X500, str(Path("~").expanduser().resolve()))
+    )  # recognize users based on their home dir
+
+
+@lru_cache(maxsize=1)
+def _device_id() -> str:
+    # This is an attempt to get mac address for the current device however, it has limitations.
+    # This thread goes over the different issues in detail.
+    # https://stackoverflow.com/questions/36235807/fixed-identifier-for-a-machine-uuid-getnode
+    # For now though, this works as our goal is to simply tie a device to a semi-stable id
+    # instead of a constantly changing random number. NOTE: getnode can and does return random
+    # numbers as well however the only case discussed when that happens is in android where it
+    # does not have permissions to access macids. This should not be a case we need to deal with
+    # so going with this until we see weirdness
+
+    return str(
+        uuid.uuid3(uuid.NAMESPACE_X500, str(uuid.getnode()))
+    )  # hash the device mac id
+
+
+@lru_cache(maxsize=1)
+def _session_id() -> int:
+    return (
+        time.time_ns() // 1000000
+    )  # session id is recommended to be time in ms since epoch
 
 
 @lru_cache(maxsize=1)
@@ -94,7 +121,9 @@ def _send_amplitude_event(event_type: str, event_properties: dict):
     events = [
         {
             "event_type": event_type,
-            "user_id": _session_id(),
+            "user_id": _user_id(),
+            "device_id": _device_id(),
+            "session_id": _session_id(),
             "event_properties": event_properties,
         }
     ]

--- a/tests/unit/utils/test_usage_tracking.py
+++ b/tests/unit/utils/test_usage_tracking.py
@@ -1,7 +1,15 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from lineapy.utils.analytics.event_schemas import SaveEvent
-from lineapy.utils.analytics.usage_tracking import track
+from lineapy.utils.analytics.usage_tracking import (
+    _amplitude_url,
+    _api_key,
+    _device_id,
+    _send_amplitude_event,
+    _session_id,
+    _user_id,
+    track,
+)
 
 
 @patch("lineapy.utils.analytics.usage_tracking.requests.post")
@@ -45,4 +53,43 @@ def test_send_usage_failure(mock_do_not_track, mock_post, mock_logger):
     assert mock_post.called
     mock_logger.debug.assert_called_with(
         "Tracking Error: something went wrong"
+    )
+
+
+@patch("lineapy.utils.analytics.usage_tracking.requests.post")
+def test_send_amplitude_event_adds_userdata(mock_post):
+    _send_amplitude_event("TestEvent", {})
+    expected_event_data = [
+        {
+            # calling the functions generating the ids should work
+            # because the results are cached with maxsize 1
+            # testing if user_id/device_id etc return the right thing
+            # is moot because we'll be testing uuid and pathlib module
+            "event_type": "TestEvent",
+            "user_id": _user_id(),
+            "device_id": _device_id(),
+            "session_id": _session_id(),
+            "event_properties": {},
+        }
+    ]
+    mock_post.assert_called_with(
+        _amplitude_url(),
+        json={
+            "api_key": _api_key(),
+            "events": expected_event_data,
+        },
+        headers=ANY,
+        timeout=ANY,
+    )
+
+    # calling a second time should not change any of the properties.
+    _send_amplitude_event("TestEvent", {})
+    mock_post.assert_called_with(
+        _amplitude_url(),
+        json={
+            "api_key": _api_key(),
+            "events": expected_event_data,
+        },
+        headers=ANY,
+        timeout=ANY,
     )


### PR DESCRIPTION
# Description

This PR adds properties that ties a user's session to the events we see in amplitude. This will help us trace the user journeys much better and get feedback on which features are popular or where exceptions occur for a user.

Fixes LIN-729

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
new test added