### PR TITLE
LIN-724: Kubeflow Integration

### DIFF
--- a/lineapy/data/types.py
+++ b/lineapy/data/types.py
@@ -508,11 +508,15 @@ class PipelineType(Enum):
     - SCRIPT : the pipeline is wrapped as a python script
     - AIRFLOW : the pipeline is wrapped as an airflow dag
     - DVC : the pipeline is wrapped as a DVC
+
+    - KUBEFLOW : the pipeline is defined using Kubeflow's python SDK
     """
 
     SCRIPT = 1
     AIRFLOW = 2
     DVC = 3
+    # ARGO = 4
+    KUBEFLOW = 5
 
 
 FilePath = Union[str, Path]

--- a/lineapy/plugins/airflow_pipeline_writer.py
+++ b/lineapy/plugins/airflow_pipeline_writer.py
@@ -230,6 +230,7 @@ class AirflowPipelineWriter(BasePipelineWriter):
                 call_block=task_def.call_block,
                 post_call_block=task_def.post_call_block,
                 dumping_blocks=dumping_blocks,
+                include_imports_locally=False,
             )
             rendered_task_defs.append(task_def_rendered)
 

--- a/lineapy/plugins/jinja_templates/airflow_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/airflow_dockerfile.jinja
@@ -9,7 +9,8 @@ COPY ./{{ pipeline_name }}_requirements.txt ./
 RUN pip install -r ./{{ pipeline_name }}_requirements.txt
 
 WORKDIR /opt/airflow/dags
-COPY . .
+COPY ./{{ pipeline_name }}_module.py ./
+COPY ./{{ pipeline_name }}_dag.py ./
 
 WORKDIR /opt/airflow
 

--- a/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
@@ -1,0 +1,40 @@
+import kfp
+
+def add(a: float, b: float) -> float:
+  '''Calculates sum of two arguments'''
+  return a + b
+
+add_op = create_component_from_func(add)
+
+client = kfp.Client(host="http://localhost:3000")
+
+client.create_run_from_pipeline_func(
+    my_pipeline,
+    arguments={
+        'url': 'https://storage.googleapis.com/ml-pipeline-playground/iris-csv-files.tar.gz'
+    })
+
+
+@dsl.pipeline(
+  name='Addition pipeline',
+  description='An example pipeline that performs addition calculations.'
+)
+def add_pipeline(
+  a='1',
+  b='7',
+):
+  # Passes a pipeline parameter and a constant value to the `add_op` factory
+  # function.
+  first_add_task = add_op(a, 4)
+  # Passes an output reference from `first_add_task` and a pipeline parameter
+  # to the `add_op` factory function. For operations with a single return
+  # value, the output reference can be accessed as `task.output` or
+  # `task.outputs['output_name']`.
+  second_add_task = add_op(first_add_task.output, b)
+
+# Specify argument values for your pipeline run.
+arguments = {'a': '7', 'b': '8'}
+
+# Create a pipeline run, using the client you initialized in a prior step.
+client.create_run_from_pipeline_func(add_pipeline, arguments=arguments)
+Building Python function-based components 

--- a/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
@@ -1,40 +1,38 @@
+import {{ MODULE_NAME }}
+import pickle
+import pathlib
 import kfp
+from kfp.components import create_component_from_func
 
-def add(a: float, b: float) -> float:
-  '''Calculates sum of two arguments'''
-  return a + b
+{% for task_def in task_definitions %}
+{{ task_def }} 
+{% endfor %}
 
-add_op = create_component_from_func(add)
+{% for task_name, task_def in tasks.items() %}
+{{ task_name }} = create_component_from_func(task_{{ task_name }})
+{% endfor %}
 
-client = kfp.Client(host="http://localhost:3000")
+client = kfp.Client(host="{{ HOST_URL }}")
 
-client.create_run_from_pipeline_func(
-    my_pipeline,
-    arguments={
-        'url': 'https://storage.googleapis.com/ml-pipeline-playground/iris-csv-files.tar.gz'
-    })
-
-
-@dsl.pipeline(
-  name='Addition pipeline',
-  description='An example pipeline that performs addition calculations.'
+@kfp.dsl.pipeline(
+  name='{{ DAG_NAME }}_dag',
 )
-def add_pipeline(
-  a='1',
-  b='7',
-):
+def {{ DAG_NAME }}_pipeline({%- for var in dag_params.keys() %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %}):
   # Passes a pipeline parameter and a constant value to the `add_op` factory
   # function.
-  first_add_task = add_op(a, 4)
+  # first_add_task = add_op(a, 4)
   # Passes an output reference from `first_add_task` and a pipeline parameter
   # to the `add_op` factory function. For operations with a single return
   # value, the output reference can be accessed as `task.output` or
   # `task.outputs['output_name']`.
-  second_add_task = add_op(first_add_task.output, b)
+  # second_add_task = add_op(first_add_task.output, b)
+  {% for task_name, task_def in tasks.items() %}
+  {{ task_name }}({%- for var in task_def.user_input_variables %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %})
+  {% endfor %}
 
 # Specify argument values for your pipeline run.
-arguments = {'a': '7', 'b': '8'}
+# arguments = {'a': '7', 'b': '8'}
+pipeline_arguments = {{ dag_params }}
 
 # Create a pipeline run, using the client you initialized in a prior step.
-client.create_run_from_pipeline_func(add_pipeline, arguments=arguments)
-Building Python function-based components 
+client.create_run_from_pipeline_func({{ DAG_NAME }}_pipeline, arguments = pipeline_arguments)

--- a/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
@@ -1,6 +1,3 @@
-import {{ MODULE_NAME }}
-import pickle
-import pathlib
 import kfp
 from kfp.components import create_component_from_func
 
@@ -9,7 +6,7 @@ from kfp.components import create_component_from_func
 {% endfor %}
 
 {% for task_name, task_def in tasks.items() %}
-{{ task_name }} = create_component_from_func(task_{{ task_name }})
+{{ task_name }}_component = create_component_from_func(task_{{ task_name }}, base_image="{{ DAG_NAME }}:lineapy")
 {% endfor %}
 
 client = kfp.Client(host="{{ HOST_URL }}")
@@ -17,22 +14,15 @@ client = kfp.Client(host="{{ HOST_URL }}")
 @kfp.dsl.pipeline(
   name='{{ DAG_NAME }}_dag',
 )
-def {{ DAG_NAME }}_pipeline({%- for var in dag_params.keys() %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %}):
-  # Passes a pipeline parameter and a constant value to the `add_op` factory
-  # function.
-  # first_add_task = add_op(a, 4)
-  # Passes an output reference from `first_add_task` and a pipeline parameter
-  # to the `add_op` factory function. For operations with a single return
-  # value, the output reference can be accessed as `task.output` or
-  # `task.outputs['output_name']`.
-  # second_add_task = add_op(first_add_task.output, b)
+def {{ DAG_NAME }}({%- for var in dag_params.keys() %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %}):
   {% for task_name, task_def in tasks.items() %}
-  {{ task_name }}({%- for var in task_def.user_input_variables %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %})
-  {% endfor %}
+  task_{{ task_name }} = {{ task_name }}_component(
+    {%- for var in task_def.user_input_variables %}{{ var }}{{ ',' if not loop.last else '' }}{%- endfor %}{%- if task_def.loaded_input_variables|length > 0 and task_def.user_input_variables|length > 0 %},{%- endif %}{%- for var in task_def.loaded_input_variables %}{{ task_loading_blocks[var] }}{{ ',' if not loop.last else '' }}{%- endfor %}
+  )
+  {%- endfor %}
 
 # Specify argument values for your pipeline run.
-# arguments = {'a': '7', 'b': '8'}
 pipeline_arguments = {{ dag_params }}
 
 # Create a pipeline run, using the client you initialized in a prior step.
-client.create_run_from_pipeline_func({{ DAG_NAME }}_pipeline, arguments = pipeline_arguments)
+client.create_run_from_pipeline_func({{ DAG_NAME }}, arguments = pipeline_arguments)

--- a/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dag.jinja
@@ -21,6 +21,12 @@ def {{ DAG_NAME }}({%- for var in dag_params.keys() %}{{ var }}{{ ',' if not loo
   )
   {%- endfor %}
 
+  {% if task_dependencies is not none %}
+  {% for TASK_DEPENDENCIES in task_dependencies %}
+  {{TASK_DEPENDENCIES}}
+  {% endfor %}
+  {%endif %}
+
 # Specify argument values for your pipeline run.
 pipeline_arguments = {{ dag_params }}
 

--- a/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
@@ -17,7 +17,8 @@ RUN pip install kfp
 RUN pip install -r ./{{ pipeline_name }}_requirements.txt
 
 WORKDIR /home
-COPY . .
+COPY ./{{ pipeline_name }}_module.py ./
+COPY ./{{ pipeline_name }}_dag.py ./
 
 # Set environment variable so module file can be 
 # found by kubeflow components

--- a/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
@@ -1,0 +1,22 @@
+# Be sure to build this docker file with the following command
+# docker build -t {{ pipeline_name }} -f {{ pipeline_name }}_Dockerfile .
+
+FROM python:{{ python_version }}
+
+RUN mkdir /tmp/installers
+WORKDIR /tmp/installers
+
+# Copy all the requirements to run current DAG
+COPY ./{{ pipeline_name }}_requirements.txt ./
+
+# Install kubeflow python sdk
+RUN apt update
+RUN pip install kfp
+
+# Install required libs
+RUN pip install -r ./{{ pipeline_name }}_requirements.txt
+
+WORKDIR /home
+COPY . .
+
+ENTRYPOINT ["python", "{{ pipeline_name }}_module.py"]

--- a/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
@@ -1,5 +1,5 @@
 # Be sure to build this docker file with the following command
-# docker build -t {{ pipeline_name }} -f {{ pipeline_name }}_Dockerfile .
+# docker build -t data_housing_pipeline:lineapy -f data_housing_pipeline_Dockerfile .
 
 FROM python:{{ python_version }}
 
@@ -19,4 +19,10 @@ RUN pip install -r ./{{ pipeline_name }}_requirements.txt
 WORKDIR /home
 COPY . .
 
+# Set environment variable so module file can be 
+# found by kubeflow components
+ENV PYTHONPATH=/home:${PYTHON_PATH}
+
 ENTRYPOINT ["python", "{{ pipeline_name }}_module.py"]
+
+

--- a/lineapy/plugins/jinja_templates/script_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/script_dockerfile.jinja
@@ -10,6 +10,6 @@ COPY ./{{ pipeline_name }}_requirements.txt ./
 RUN pip install -r ./{{ pipeline_name }}_requirements.txt
 
 WORKDIR /home
-COPY . .
+COPY ./{{ pipeline_name }}_module.py ./
 
 ENTRYPOINT [ "python", "/home/{{ pipeline_name }}_module.py" ]

--- a/lineapy/plugins/jinja_templates/task/parameterizedpickle/task_parameterized_deser.jinja
+++ b/lineapy/plugins/jinja_templates/task/parameterizedpickle/task_parameterized_deser.jinja
@@ -1,0 +1,1 @@
+{{loaded_input_variable}} = pickle.load(open(variable_{{loaded_input_variable}}_path,'rb'))

--- a/lineapy/plugins/jinja_templates/task/parameterizedpickle/task_parameterized_ser.jinja
+++ b/lineapy/plugins/jinja_templates/task/parameterizedpickle/task_parameterized_ser.jinja
@@ -1,0 +1,1 @@
+pickle.dump({{return_variable}}, open(variable_{{return_variable}}_path,'wb'))

--- a/lineapy/plugins/jinja_templates/task/task_function.jinja
+++ b/lineapy/plugins/jinja_templates/task/task_function.jinja
@@ -1,4 +1,8 @@
 def task_{{function_name}}({{user_input_variables}}):
+{%- if include_imports_locally %}
+    import {{ MODULE_NAME }}
+    import pickle
+{%- endif %}
 {% for typing_block in typing_blocks %}
 {{typing_block | indent(4, True) }}
 {% endfor %}

--- a/lineapy/plugins/kubeflow_pipeline_writer.py
+++ b/lineapy/plugins/kubeflow_pipeline_writer.py
@@ -1,0 +1,81 @@
+import logging
+from enum import Enum
+from typing import Dict, TypedDict
+
+from lineapy.plugins.base_pipeline_writer import BasePipelineWriter
+from lineapy.plugins.task import DagTaskBreakdown, TaskDefinition
+from lineapy.plugins.taskgen import get_task_definitions
+from lineapy.plugins.utils import load_plugin_template
+from lineapy.utils.logging_config import configure_logging
+from lineapy.utils.utils import prettify
+
+logger = logging.getLogger(__name__)
+configure_logging()
+
+
+class KubeflowDagFlavor(Enum):
+    ComponentPerSession = 1
+    ComponentPerArtifact = 2
+
+
+KubeflowDagConfig = TypedDict(
+    "KubeflowDagConfig",
+    {
+        "dag_flavor": str,  # Not native to DVC config
+    },
+    total=False,
+)
+
+
+class KubeflowPipelineWriter(BasePipelineWriter):
+    def _write_dag(self) -> None:
+
+        # Check if the given DAG flavor is a supported/valid one
+        try:
+            dag_flavor = KubeflowDagFlavor[
+                self.dag_config.get("dag_flavor", "ComponentPerArtifact")
+            ]
+        except KeyError:
+            raise ValueError(
+                f'"{dag_flavor}" is an invalid kubeflow dag flavor.'
+            )
+
+        # Construct DAG text for the given flavor
+        full_code = self._write_operators(dag_flavor)
+
+        # Write out file
+        file = self.output_dir / f"{self.pipeline_name}_dag.py"
+        file.write_text(full_code)
+        logger.info(f"Generated DAG file: {file}")
+
+    def _write_operators(
+        self,
+        dag_flavor: KubeflowDagFlavor,
+    ) -> str:
+        """ """
+
+        DAG_TEMPLATE = load_plugin_template("kubeflow_dag.jinja")
+
+        if dag_flavor == KubeflowDagFlavor.ComponentPerSession:
+            task_breakdown = DagTaskBreakdown.TaskPerSession
+        elif dag_flavor == KubeflowDagFlavor.ComponentPerArtifact:
+            task_breakdown = DagTaskBreakdown.TaskPerArtifact
+
+        # Get task definitions based on dag_flavor
+        task_defs: Dict[str, TaskDefinition] = get_task_definitions(
+            self.artifact_collection,
+            pipeline_name=self.pipeline_name,
+            task_breakdown=task_breakdown,
+        )
+
+        task_names = list(task_defs.keys())
+
+        task_defs = {tn: task_defs[tn] for tn in task_names}
+
+        full_code = DAG_TEMPLATE.render()
+
+        return full_code
+
+    @property
+    def docker_template_name(self) -> str:
+        return "kubeflow_dockerfile.jinja"

--- a/lineapy/plugins/kubeflow_pipeline_writer.py
+++ b/lineapy/plugins/kubeflow_pipeline_writer.py
@@ -11,7 +11,7 @@ from lineapy.plugins.task import (
     TaskSerializer,
     render_task_io_serialize_blocks,
 )
-from lineapy.plugins.taskgen import get_task_definitions
+from lineapy.plugins.taskgen import get_task_graph
 from lineapy.plugins.utils import load_plugin_template
 from lineapy.utils.logging_config import configure_logging
 from lineapy.utils.utils import prettify
@@ -71,7 +71,7 @@ class KubeflowPipelineWriter(BasePipelineWriter):
             task_breakdown = DagTaskBreakdown.TaskPerArtifact
 
         # Get task definitions based on dag_flavor
-        task_defs: Dict[str, TaskDefinition] = get_task_definitions(
+        task_defs, _ = get_task_graph(
             self.artifact_collection,
             pipeline_name=self.pipeline_name,
             task_breakdown=task_breakdown,
@@ -155,7 +155,9 @@ class KubeflowPipelineWriter(BasePipelineWriter):
                 ),
                 typing_blocks=task_def.typing_blocks,
                 loading_blocks=loading_blocks,
+                pre_call_block="",
                 call_block=task_def.call_block,
+                post_call_block="",
                 dumping_blocks=dumping_blocks,
                 include_imports_locally=True,
             )

--- a/lineapy/plugins/pipeline_writer_factory.py
+++ b/lineapy/plugins/pipeline_writer_factory.py
@@ -2,6 +2,7 @@ from lineapy.data.types import PipelineType
 from lineapy.plugins.airflow_pipeline_writer import AirflowPipelineWriter
 from lineapy.plugins.base_pipeline_writer import BasePipelineWriter
 from lineapy.plugins.dvc_pipeline_writer import DVCPipelineWriter
+from lineapy.plugins.kubeflow_pipeline_writer import KubeflowPipelineWriter
 
 
 class PipelineWriterFactory:
@@ -16,5 +17,7 @@ class PipelineWriterFactory:
             return AirflowPipelineWriter(*args, **kwargs)
         elif pipeline_type == PipelineType.DVC:
             return DVCPipelineWriter(*args, **kwargs)
+        elif pipeline_type == PipelineType.KUBEFLOW:
+            return KubeflowPipelineWriter(*args, **kwargs)
         else:
             return BasePipelineWriter(*args, **kwargs)

--- a/lineapy/plugins/task.py
+++ b/lineapy/plugins/task.py
@@ -179,6 +179,7 @@ class TaskSerializer(Enum):
     """Enum to define what type of object serialization to use for inter task communication."""
 
     LocalPickle = 1
+    ParametrizedPickle = 2
     # TODO: lineapy.get and lineapy.save
 
 
@@ -202,6 +203,14 @@ def render_task_io_serialize_blocks(
         DESERIALIZER_TEMPLATE = load_plugin_template(
             "task/localpickle/task_local_pickle_deser.jinja"
         )
+    elif task_serialization == TaskSerializer.ParametrizedPickle:
+        SERIALIZER_TEMPLATE = load_plugin_template(
+            "task/parameterizedpickle/task_parameterized_ser.jinja"
+        )
+        DESERIALIZER_TEMPLATE = load_plugin_template(
+            "task/parameterizedpickle/task_parameterized_deser.jinja"
+        )
+
     # Add more renderable task serializers here
 
     for loaded_input_variable in taskdef.loaded_input_variables:

--- a/lineapy/plugins/task.py
+++ b/lineapy/plugins/task.py
@@ -178,7 +178,9 @@ class DagTaskBreakdown(Enum):
 class TaskSerializer(Enum):
     """Enum to define what type of object serialization to use for inter task communication."""
 
+    # Write to local pickle directory under /tmp/
     LocalPickle = 1
+    # Write to a pickle directory that can be parametrized
     ParametrizedPickle = 2
     # TODO: lineapy.get and lineapy.save
 

--- a/lineapy/plugins/taskgen.py
+++ b/lineapy/plugins/taskgen.py
@@ -252,3 +252,44 @@ def get_localpickle_teardown_task_definition(pipeline_name):
         return_vars=[],
         pipeline_name=pipeline_name,
     )
+
+
+def get_noop_setup_task_definition(pipeline_name):
+    """
+    Returns a TaskDefinition that no-ops so that users can write
+    their own setup tasks by replacing the setup call block.
+
+    This task should be used at the beginning of a pipeline.
+    """
+    return TaskDefinition(
+        function_name="dag_setup",
+        user_input_variables=[],
+        loaded_input_variables=[],
+        typing_blocks=[],
+        pre_call_block="",
+        call_block="pass",
+        post_call_block="",
+        return_vars=[],
+        pipeline_name=pipeline_name,
+    )
+
+
+def get_noop_teardown_task_definition(pipeline_name):
+    """
+    Returns a TaskDefinition that no-ops so that users can write
+    their own teardown tasks by replacing the teardown call block.
+
+    This task should be used at the end of a pipeline.
+
+    """
+    return TaskDefinition(
+        function_name="dag_teardown",
+        user_input_variables=[],
+        loaded_input_variables=[],
+        typing_blocks=[],
+        pre_call_block="",
+        call_block="pass",
+        post_call_block="",
+        return_vars=[],
+        pipeline_name=pipeline_name,
+    )

--- a/tests/unit/plugins/__snapshots__/test_writer.ambr
+++ b/tests/unit/plugins/__snapshots__/test_writer.ambr
@@ -1649,6 +1649,302 @@
       cmd: python dvc_pipeline_a_b0_singlestageallsessions_module.py
   '
 ---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_artifact]
+  '
+  def get_a0():
+      a0 = 0
+      a0 += 1
+      return a0
+  
+  
+  def get_b0():
+      b0 = 0
+      return b0
+  
+  
+  def run_session_including_a0():
+      # Given multiple artifacts, we need to save each right after
+      # its calculation to protect from any irrelevant downstream
+      # mutations (e.g., inside other artifact calculations)
+      import copy
+  
+      artifacts = dict()
+      a0 = get_a0()
+      artifacts["a0"] = copy.deepcopy(a0)
+      return artifacts
+  
+  
+  def run_session_including_b0():
+      # Given multiple artifacts, we need to save each right after
+      # its calculation to protect from any irrelevant downstream
+      # mutations (e.g., inside other artifact calculations)
+      import copy
+  
+      artifacts = dict()
+      b0 = get_b0()
+      artifacts["b0"] = copy.deepcopy(b0)
+      return artifacts
+  
+  
+  def run_all_sessions():
+      artifacts = dict()
+      artifacts.update(run_session_including_a0())
+      artifacts.update(run_session_including_b0())
+      return artifacts
+  
+  
+  if __name__ == "__main__":
+      # Edit this section to customize the behavior of artifacts
+      artifacts = run_all_sessions()
+      print(artifacts)
+  
+  '
+---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_artifact].1
+  ''
+---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_artifact].2
+  '
+  import kfp
+  from kfp.components import create_component_from_func
+  
+  
+  def task_a0(variable_a0_path: kfp.components.OutputPath(str)):
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_artifact_module
+  
+      a0 = kubeflow_pipeline_a0_b0_component_artifact_module.get_a0()
+  
+      pickle.dump(a0, open(variable_a0_path, "wb"))
+  
+  
+  def task_b0(variable_b0_path: kfp.components.OutputPath(str)):
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_artifact_module
+  
+      b0 = kubeflow_pipeline_a0_b0_component_artifact_module.get_b0()
+  
+      pickle.dump(b0, open(variable_b0_path, "wb"))
+  
+  
+  def task_setup():
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_artifact_module
+  
+      pass
+  
+  
+  def task_teardown():
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_artifact_module
+  
+      pass
+  
+  
+  a0_component = create_component_from_func(
+      task_a0, base_image="kubeflow_pipeline_a0_b0_component_artifact:lineapy"
+  )
+  
+  b0_component = create_component_from_func(
+      task_b0, base_image="kubeflow_pipeline_a0_b0_component_artifact:lineapy"
+  )
+  
+  setup_component = create_component_from_func(
+      task_setup, base_image="kubeflow_pipeline_a0_b0_component_artifact:lineapy"
+  )
+  
+  teardown_component = create_component_from_func(
+      task_teardown, base_image="kubeflow_pipeline_a0_b0_component_artifact:lineapy"
+  )
+  
+  
+  client = kfp.Client(host="http://localhost:3000")
+  
+  
+  @kfp.dsl.pipeline(
+      name="kubeflow_pipeline_a0_b0_component_artifact_dag",
+  )
+  def kubeflow_pipeline_a0_b0_component_artifact():
+  
+      task_a0 = a0_component()
+      task_b0 = b0_component()
+      task_setup = setup_component()
+      task_teardown = teardown_component()
+  
+      task_a0.after(task_setup)
+  
+      task_b0.after(task_setup)
+  
+      task_teardown.after(task_a0)
+  
+      task_teardown.after(task_b0)
+  
+  
+  # Specify argument values for your pipeline run.
+  pipeline_arguments = {}
+  
+  # Create a pipeline run, using the client you initialized in a prior step.
+  client.create_run_from_pipeline_func(
+      kubeflow_pipeline_a0_b0_component_artifact, arguments=pipeline_arguments
+  )
+  
+  '
+---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_session]
+  '
+  def get_a0():
+      a0 = 0
+      a0 += 1
+      return a0
+  
+  
+  def get_b0():
+      b0 = 0
+      return b0
+  
+  
+  def run_session_including_a0():
+      # Given multiple artifacts, we need to save each right after
+      # its calculation to protect from any irrelevant downstream
+      # mutations (e.g., inside other artifact calculations)
+      import copy
+  
+      artifacts = dict()
+      a0 = get_a0()
+      artifacts["a0"] = copy.deepcopy(a0)
+      return artifacts
+  
+  
+  def run_session_including_b0():
+      # Given multiple artifacts, we need to save each right after
+      # its calculation to protect from any irrelevant downstream
+      # mutations (e.g., inside other artifact calculations)
+      import copy
+  
+      artifacts = dict()
+      b0 = get_b0()
+      artifacts["b0"] = copy.deepcopy(b0)
+      return artifacts
+  
+  
+  def run_all_sessions():
+      artifacts = dict()
+      artifacts.update(run_session_including_a0())
+      artifacts.update(run_session_including_b0())
+      return artifacts
+  
+  
+  if __name__ == "__main__":
+      # Edit this section to customize the behavior of artifacts
+      artifacts = run_all_sessions()
+      print(artifacts)
+  
+  '
+---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_session].1
+  ''
+---
+# name: test_pipeline_generation[kubeflow_pipeline_a0_b0_component_session].2
+  '
+  import kfp
+  from kfp.components import create_component_from_func
+  
+  
+  def task_run_session_including_a0(variable_a0_path: kfp.components.OutputPath(str)):
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_session_module
+  
+      artifacts = (
+          kubeflow_pipeline_a0_b0_component_session_module.run_session_including_a0()
+      )
+  
+      pickle.dump(a0, open(variable_a0_path, "wb"))
+  
+  
+  def task_run_session_including_b0(variable_b0_path: kfp.components.OutputPath(str)):
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_session_module
+  
+      artifacts = (
+          kubeflow_pipeline_a0_b0_component_session_module.run_session_including_b0()
+      )
+  
+      pickle.dump(b0, open(variable_b0_path, "wb"))
+  
+  
+  def task_setup():
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_session_module
+  
+      pass
+  
+  
+  def task_teardown():
+      import pickle
+  
+      import kubeflow_pipeline_a0_b0_component_session_module
+  
+      pass
+  
+  
+  run_session_including_a0_component = create_component_from_func(
+      task_run_session_including_a0,
+      base_image="kubeflow_pipeline_a0_b0_component_session:lineapy",
+  )
+  
+  run_session_including_b0_component = create_component_from_func(
+      task_run_session_including_b0,
+      base_image="kubeflow_pipeline_a0_b0_component_session:lineapy",
+  )
+  
+  setup_component = create_component_from_func(
+      task_setup, base_image="kubeflow_pipeline_a0_b0_component_session:lineapy"
+  )
+  
+  teardown_component = create_component_from_func(
+      task_teardown, base_image="kubeflow_pipeline_a0_b0_component_session:lineapy"
+  )
+  
+  
+  client = kfp.Client(host="http://localhost:3000")
+  
+  
+  @kfp.dsl.pipeline(
+      name="kubeflow_pipeline_a0_b0_component_session_dag",
+  )
+  def kubeflow_pipeline_a0_b0_component_session():
+  
+      task_run_session_including_a0 = run_session_including_a0_component()
+      task_run_session_including_b0 = run_session_including_b0_component()
+      task_setup = setup_component()
+      task_teardown = teardown_component()
+  
+      task_run_session_including_a0.after(task_setup)
+  
+      task_run_session_including_b0.after(task_setup)
+  
+      task_teardown.after(task_run_session_including_a0)
+  
+      task_teardown.after(task_run_session_including_b0)
+  
+  
+  # Specify argument values for your pipeline run.
+  pipeline_arguments = {}
+  
+  # Create a pipeline run, using the client you initialized in a prior step.
+  client.create_run_from_pipeline_func(
+      kubeflow_pipeline_a0_b0_component_session, arguments=pipeline_arguments
+  )
+  
+  '
+---
 # name: test_pipeline_generation[script_pipeline_a0_b0]
   '
   def get_a0():

--- a/tests/unit/plugins/test_writer.py
+++ b/tests/unit/plugins/test_writer.py
@@ -193,6 +193,28 @@ def check_requirements_txt(t1: str, t2: str):
             [],
             id="dvc_pipeline_a_b0_single_stage_all_sessions",
         ),
+        pytest.param(
+            "simple",
+            "complex",
+            ["a0", "b0"],
+            "KUBEFLOW",
+            "kubeflow_pipeline_a0_b0_component_artifact",
+            {},
+            {"dag_flavor": "ComponentPerArtifact"},
+            [],
+            id="kubeflow_pipeline_a0_b0_component_artifact",
+        ),
+        pytest.param(
+            "simple",
+            "complex",
+            ["a0", "b0"],
+            "KUBEFLOW",
+            "kubeflow_pipeline_a0_b0_component_session",
+            {},
+            {"dag_flavor": "ComponentPerSession"},
+            [],
+            id="kubeflow_pipeline_a0_b0_component_session",
+        ),
     ],
 )
 def test_pipeline_generation(
@@ -246,7 +268,7 @@ def test_pipeline_generation(
 
     # Get list of files to compare
     file_endings = ["_module.py", "_requirements.txt"]
-    if framework == "AIRFLOW":
+    if framework in ["AIRFLOW", "KUBEFLOW"]:
         file_endings.append("_dag.py")
 
     file_names = [pipeline_name + file_suffix for file_suffix in file_endings]


### PR DESCRIPTION
# Description

Adds support for kubeflow pipelines. Setting `framework= KUBEFLOW` in `to_pipeline` now produces a dag file that can be run through the kubeflow pipeline sdk. 

Also adds task serialization that can be parametrized so that the save location can be specific through the task function signature. Kubeflow's `get_rendered_task_definitions` uses this by adding these locations as function parameters to `user_input_variables`. 

Fixes LIN-724

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Using housing example on local kubeflow setup.