### PR TITLE
LIN-729 persist device ids.

### DIFF
--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -96,12 +96,20 @@ def _device_id() -> str:
     # For now though, this works as our goal is to simply tie a device to a semi-stable id
     # instead of a constantly changing random number. NOTE: getnode can and does return random
     # numbers as well however the only case discussed when that happens is in android where it
-    # does not have permissions to access macids. This should not be a case we need to deal with
-    # so going with this until we see weirdness
+    # does not have permissions to access macids. This seems to happen in more cases as we have
+    # observed more device ids for the same user than we expected. To fix this, we'll persist
+    # an id to the .lineapy folder for future use. This might give us a bit more stability 
 
-    return str(
-        uuid.uuid3(uuid.NAMESPACE_X500, str(uuid.getnode()))
-    )  # hash the device mac id
+    device_id = ""
+    with open(options.safe_get("dev_id"), "w+") as f:
+        device_id = f.read()
+        if not device_id:
+            device_id = str(
+                uuid.uuid3(uuid.NAMESPACE_X500, str(uuid.getnode()))
+            )  # hash the device mac id
+            f.write(device_id)
+
+    return device_id
 
 
 @lru_cache(maxsize=1)
@@ -165,4 +173,5 @@ def tag(tag_name: str):
     # Put this line at the top of demo notebooks:
     # lineapy.tag("demo_name") # change "demo_name" with actual demo name.
 
+    track(TagEvent(tag_name))
     track(TagEvent(tag_name))

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -174,4 +174,3 @@ def tag(tag_name: str):
     # lineapy.tag("demo_name") # change "demo_name" with actual demo name.
 
     track(TagEvent(tag_name))
-    track(TagEvent(tag_name))

--- a/lineapy/utils/analytics/usage_tracking.py
+++ b/lineapy/utils/analytics/usage_tracking.py
@@ -98,7 +98,7 @@ def _device_id() -> str:
     # numbers as well however the only case discussed when that happens is in android where it
     # does not have permissions to access macids. This seems to happen in more cases as we have
     # observed more device ids for the same user than we expected. To fix this, we'll persist
-    # an id to the .lineapy folder for future use. This might give us a bit more stability 
+    # an id to the .lineapy folder for future use. This might give us a bit more stability
 
     device_id = ""
     with open(options.safe_get("dev_id"), "w+") as f:

--- a/lineapy/utils/config.py
+++ b/lineapy/utils/config.py
@@ -20,6 +20,7 @@ except ImportError:
 
 LINEAPY_FOLDER_NAME = ".lineapy"
 LOG_FILE_NAME = "lineapy.log"
+DEVICE_ID_FILE_NAME = ".devid"
 CONFIG_FILE_NAME = "lineapy_config.json"
 FILE_PICKLER_BASEDIR = "linea_pickles"
 DB_FILE_NAME = "db.sqlite"
@@ -92,6 +93,7 @@ class lineapy_config:
         self.do_not_track = do_not_track
         self.logging_level = logging_level
         self.logging_file = logging_file
+        self.dev_id = None
         self.mlflow_registry_uri = mlflow_registry_uri
         self.mlflow_tracking_uri = mlflow_tracking_uri
         self.default_ml_models_storage_backend = (
@@ -288,6 +290,19 @@ class lineapy_config:
                 )
             return safe_get_folder("customized_annotation_folder")
 
+        elif name == "dev_id":
+            if self.dev_id is None:
+                dev_id_file = Path(safe_get_folder("home_dir")).joinpath(
+                    DEVICE_ID_FILE_NAME
+                )
+                self.set(
+                    "dev_id",
+                    dev_id_file,
+                    verbose=False,
+                )
+            else:
+                dev_id_file = logging_file = Path(str(self.dev_id))
+            return dev_id_file
         else:
             return self.get(name)
 

--- a/tests/unit/utils/test_usage_tracking.py
+++ b/tests/unit/utils/test_usage_tracking.py
@@ -100,8 +100,9 @@ def test_send_amplitude_event_adds_userdata(mock_post):
 
 @pytest.mark.folder(options.safe_get("home_dir"))
 def test_device_id_persisted(move_folder):
+    devid_path = options.safe_get("dev_id")
     # should not need to remove the old file since move folder is creating a new one for us
     # call the device id function.
     new_dev_id = _device_id()
-    with open(options.safe_get("dev_id"), "r") as f:
+    with open(devid_path, "r") as f:
         assert f.read() == new_dev_id

--- a/tests/unit/utils/test_usage_tracking.py
+++ b/tests/unit/utils/test_usage_tracking.py
@@ -1,5 +1,7 @@
 from unittest.mock import ANY, patch
 
+import pytest
+
 from lineapy.utils.analytics.event_schemas import SaveEvent
 from lineapy.utils.analytics.usage_tracking import (
     _amplitude_url,
@@ -10,6 +12,7 @@ from lineapy.utils.analytics.usage_tracking import (
     _user_id,
     track,
 )
+from lineapy.utils.config import options
 
 
 @patch("lineapy.utils.analytics.usage_tracking.requests.post")
@@ -93,3 +96,13 @@ def test_send_amplitude_event_adds_userdata(mock_post):
         headers=ANY,
         timeout=ANY,
     )
+
+
+@pytest.mark.folder(options.safe_get("home_dir"))
+def test_device_id_persisted(move_folder):
+    devid_path = options.safe_get("dev_id")
+    # should not need to remove the old file since move folder is creating a new one for us
+    # call the device id function.
+    new_dev_id = _device_id()
+    with open(devid_path, "r") as f:
+        assert f.read() == new_dev_id

--- a/tests/unit/utils/test_usage_tracking.py
+++ b/tests/unit/utils/test_usage_tracking.py
@@ -100,9 +100,8 @@ def test_send_amplitude_event_adds_userdata(mock_post):
 
 @pytest.mark.folder(options.safe_get("home_dir"))
 def test_device_id_persisted(move_folder):
-    devid_path = options.safe_get("dev_id")
     # should not need to remove the old file since move folder is creating a new one for us
     # call the device id function.
     new_dev_id = _device_id()
-    with open(devid_path, "r") as f:
+    with open(options.safe_get("dev_id"), "r") as f:
         assert f.read() == new_dev_id


### PR DESCRIPTION
# Description

persist device id so that we dont keep getting new random numbers (a situation that can happen with uuid.getnode())

Fixes LIN-729

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
New test added to ensure that device id gets persisted to the lineapy folder.