### PR TITLE
LIN-735: Pin typing-extensions >= 4.0.0 for NotRequired type hint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ syrupy==1.4.5
 types-mock==4.0.15
 types-PyYAML==6.0.5
 types-requests==2.27.16
+typing-extensions==4.4.0

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ minimal_requirement = [
     "pandas",
     "alembic==1.8.0",
     "cloudpickle",
+    "typing-extensions>=4.0.0",
 ]
 
 graph_libs = [


### PR DESCRIPTION
# Description

Pin the version of typing-extensions >= 4.0.0
This is so that the user does not run into issue when installing lineapy out of the box. 

Version 4.0.0 was chosen on typing-extensions' release logs 
[which indicate 4.0.0 was the version where typing_extensions.NotRequired was added]. (https://github.com/python/typing_extensions/blob/673e5ceea32f77d90531d4d5e77a7694edba7fba/CHANGELOG.md)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally on a python 3.8 env 