### PR TITLE
LIN-737: Fix argo tests requiring /home/runner

### DIFF
--- a/lineapy/plugins/argo_pipeline_writer.py
+++ b/lineapy/plugins/argo_pipeline_writer.py
@@ -139,7 +139,7 @@ class ARGOPipelineWriter(BasePipelineWriter):
                 "image_pull_policy", "Never"
             ),
             SERVICE_ACCOUNT=self.dag_config.get("service_account", "argo"),
-            KUBE_CONFIG=kube_config,
+            KUBE_CONFIG_PATH_CODE_BLOCK=kube_config,
             TOKEN=self.dag_config.get("token", "None"),
             dag_params=input_parameters_dict,
             task_definitions=rendered_task_defs,

--- a/lineapy/plugins/jinja_templates/argo_dag.jinja
+++ b/lineapy/plugins/jinja_templates/argo_dag.jinja
@@ -49,7 +49,7 @@ def get_sa_token(
 ws = WorkflowService(
     host = "{{ HOST }}",
     verify_ssl = {{ VERIFY_SSL }},
-    token = get_sa_token("{{SERVICE_ACCOUNT}}", "{{NAMESPACE}}", {{KUBE_CONFIG}}),
+    token = get_sa_token("{{SERVICE_ACCOUNT}}", "{{NAMESPACE}}", {{KUBE_CONFIG_PATH_CODE_BLOCK}}),
     namespace = "{{ NAMESPACE }}",
 )
 

--- a/lineapy/plugins/jinja_templates/argo_dag.jinja
+++ b/lineapy/plugins/jinja_templates/argo_dag.jinja
@@ -49,7 +49,7 @@ def get_sa_token(
 ws = WorkflowService(
     host = "{{ HOST }}",
     verify_ssl = {{ VERIFY_SSL }},
-    token = get_sa_token("{{SERVICE_ACCOUNT}}", "{{NAMESPACE}}", "{{KUBE_CONFIG}}"),
+    token = get_sa_token("{{SERVICE_ACCOUNT}}", "{{NAMESPACE}}", {{KUBE_CONFIG}}),
     namespace = "{{ NAMESPACE }}",
 )
 

--- a/lineapy/plugins/jinja_templates/argo_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/argo_dockerfile.jinja
@@ -1,3 +1,6 @@
+# Be sure to build this docker file with the following command
+# docker build -t {{ pipeline_name }}:lineapy -f {{ pipeline_name }}_Dockerfile .
+
 FROM python:{{ python_version }}
 
 RUN mkdir /tmp/installers

--- a/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
+++ b/lineapy/plugins/jinja_templates/kubeflow_dockerfile.jinja
@@ -1,5 +1,5 @@
 # Be sure to build this docker file with the following command
-# docker build -t data_housing_pipeline:lineapy -f data_housing_pipeline_Dockerfile .
+# docker build -t {{ pipeline_name }}:lineapy -f {{ pipeline_name }}_Dockerfile .
 
 FROM python:{{ python_version }}
 

--- a/tests/unit/plugins/__snapshots__/test_writer.ambr
+++ b/tests/unit/plugins/__snapshots__/test_writer.ambr
@@ -1842,13 +1842,13 @@
   ws = WorkflowService(
       host="https://localhost:2746",
       verify_ssl=False,
-      token=get_sa_token("argo", "argo", "/home/runner/.kube/config"),
+      token=get_sa_token("argo", "argo", os.path.expanduser("~/.kube/config")),
       namespace="argo",
   )
   
   with Workflow("argo-pipeline-a0-b0", service=ws) as w:
   
-      set_global_task_image("argo_pipeline:latest")
+      set_global_task_image("argo_pipeline_a0_b0:lineapy")
   
       run_session_including_a0 = Task(
           "run-session-including-a0",


### PR DESCRIPTION
# Description

Argo tests at this time snapshot the user home directory, which means the snapshot tests must be manually updated to pass on github actions.

This PR moves the path expansion to the dag file itself, meaning the generated DAG will not depend on the users home directory. 

Also added and fixed hints for how to use the Dockerfile for argo. 

Fixes LIN-737

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally with housing example, both providing and not providing a kube config
`        "kube_config": "/Users/andrewcui/.kube/config",` 
