### PR TITLE
LIN-740: Reset configurations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,8 @@ class ExecuteFixture:
                     f"lineapy.{save.__name__}({artifact}, {repr(artifact)})\n"
                 )
 
+        # Saving old env variables to reset after test is executed
+        old_os_environ = dict(os.environ)
         # These temp filenames are unique per test function.
         # If `execute` is called twice in a test, it will overwrite the
         # previous paths
@@ -246,6 +248,13 @@ class ExecuteFixture:
         os.chdir(self.tmp_path)
         new_executor.execute_graph(tracer.graph)
         os.chdir(current_working_dir)
+
+        # Reset environment variables to state before the user code was executed
+        # so as to not affect subsequently executed tests.
+        for key in os.environ.keys():
+            del os.environ[key]
+        for key in old_os_environ:
+            os.environ[key] = old_os_environ[key]
 
         return tracer
 

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -45,6 +45,8 @@ try:
     deleted_clf = lineapy.get('clf', version=art.version)
 except:
     deleted_clf = None
+lineapy.options.set('mlflow_tracking_uri',None)
+lineapy.options.set('mlflow_registry_uri',None)
 """
     res = execute(code, snapshot=False)
 

--- a/tests/unit/utils/test_config_mlflow.py
+++ b/tests/unit/utils/test_config_mlflow.py
@@ -37,3 +37,7 @@ def test_mlflow_console_config():
     clean_lineapy_env_var()
     for k, v in existing_lineapy_env.items():
         os.environ[k] = v
+
+    # Reset MLFlow options to not affect subsequent tests
+    options.set("mlflow_tracking_uri", None)
+    options.set("default_ml_models_storage_backend", None)


### PR DESCRIPTION
Some MLflow tests require setting some configuration flags using  which are not reset by default, which leads to subsequent tests failing due to unexpected configuration. Hence, for such tests, we reset the  as well as the env variables to tackle the bug.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (LIN-740)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally using `pytest`