### PR TITLE
LIN-734 Consolidate Getting Rendered Tasks

### DIFF
--- a/lineapy/plugins/airflow_pipeline_writer.py
+++ b/lineapy/plugins/airflow_pipeline_writer.py
@@ -9,7 +9,7 @@ from lineapy.plugins.task import (
     DagTaskBreakdown,
     TaskDefinition,
     TaskSerializer,
-    render_task_io_serialize_blocks,
+    render_task_definitions,
 )
 from lineapy.plugins.taskgen import (
     get_task_graph,
@@ -215,27 +215,10 @@ class AirflowPipelineWriter(BasePipelineWriter):
         """
         Returns rendered tasks for the pipeline tasks.
         """
-        TASK_FUNCTION_TEMPLATE = load_plugin_template(
-            "task/task_function.jinja"
+        rendered_task_defs: List[str] = render_task_definitions(
+            task_defs,
+            self.pipeline_name,
+            task_serialization=task_serialization,
         )
-        rendered_task_defs: List[str] = []
-        for task_name, task_def in task_defs.items():
-            loading_blocks, dumping_blocks = render_task_io_serialize_blocks(
-                task_def, task_serialization
-            )
-            task_def_rendered = TASK_FUNCTION_TEMPLATE.render(
-                function_name=task_name,
-                user_input_variables=", ".join(task_def.user_input_variables),
-                typing_blocks=task_def.typing_blocks,
-                loading_blocks=loading_blocks,
-                pre_call_block=task_def.pre_call_block,
-                call_block=task_def.call_block,
-                post_call_block=task_def.post_call_block,
-                dumping_blocks=dumping_blocks,
-                return_block="",
-                include_imports_locally=False,
-            )
-            rendered_task_defs.append(task_def_rendered)
 
-        # sort here to maintain deterministic behavior of writing
-        return sorted(rendered_task_defs)
+        return rendered_task_defs

--- a/lineapy/plugins/argo_pipeline_writer.py
+++ b/lineapy/plugins/argo_pipeline_writer.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from typing_extensions import TypedDict
 
@@ -10,7 +10,6 @@ from lineapy.plugins.task import (
     TaskDefinition,
     TaskSerializer,
     render_task_definitions,
-    render_task_io_serialize_blocks,
 )
 from lineapy.plugins.taskgen import (
     get_noop_setup_task_definition,

--- a/lineapy/plugins/argo_pipeline_writer.py
+++ b/lineapy/plugins/argo_pipeline_writer.py
@@ -9,6 +9,7 @@ from lineapy.plugins.task import (
     DagTaskBreakdown,
     TaskDefinition,
     TaskSerializer,
+    render_task_definitions,
     render_task_io_serialize_blocks,
 )
 from lineapy.plugins.taskgen import (
@@ -102,10 +103,8 @@ class ARGOPipelineWriter(BasePipelineWriter):
 
         task_defs = {tn: task_defs[tn] for tn in task_names}
 
-        (
-            rendered_task_defs,
-            task_loading_blocks,
-        ) = self.get_rendered_task_definitions(task_defs)
+        rendered_task_defs = self.get_rendered_task_definitions(task_defs)
+        task_loading_blocks = self.get_task_loading_blocks(task_defs)
 
         # Handle dependencies
         task_dependencies = reversed(
@@ -150,49 +149,37 @@ class ARGOPipelineWriter(BasePipelineWriter):
 
         return full_code
 
-    def get_rendered_task_definitions(
+    def get_task_loading_blocks(
         self,
         task_defs: Dict[str, TaskDefinition],
-    ) -> Tuple[List[str], Dict[str, str]]:
+    ) -> Dict[str, str]:
         """
-        Returns rendered tasks for the pipeline tasks along with a dictionary to lookup
-        previous task outputs.
+        Returns  a dictionary to lookup previous task outputs.
         The returned dictionary is used by the DAG to connect the right input files to
         output files for inter task communication.
         This method originates from:
         https://github.com/argoproj-labs/hera-workflows/blob/4efddc85bfce62455db758f4be47e3acc0342b4f/examples/k8s_sa.py#L12
         """
-        TASK_FUNCTION_TEMPLATE = load_plugin_template(
-            "task/task_function.jinja"
-        )
-        rendered_task_defs: List[str] = []
         task_loading_blocks: Dict[str, str] = {}
 
-        for task_name, task_def in task_defs.items():
-            loading_blocks, dumping_blocks = render_task_io_serialize_blocks(
-                task_def, TaskSerializer.TmpDirPickle
-            )
-
-            input_vars = task_def.user_input_variables
-
-            # this task will output variables to a file that other tasks can access
-
+        for _, task_def in task_defs.items():
             for return_variable in task_def.return_vars:
                 task_loading_blocks[return_variable] = return_variable
+        return task_loading_blocks
 
-            task_def_rendered = TASK_FUNCTION_TEMPLATE.render(
-                MODULE_NAME=self.pipeline_name + "_module",
-                function_name=task_name,
-                user_input_variables=", ".join(input_vars),
-                typing_blocks=task_def.typing_blocks,
-                loading_blocks=loading_blocks,
-                pre_call_block=task_def.pre_call_block or "",
-                call_block=task_def.call_block,
-                post_call_block=task_def.post_call_block or "",
-                dumping_blocks=dumping_blocks,
-                include_imports_locally=True,
-                return_block="",
-            )
-            rendered_task_defs.append(task_def_rendered)
+    def get_rendered_task_definitions(
+        self,
+        task_defs: Dict[str, TaskDefinition],
+    ) -> List[str]:
+        """
+        Returns rendered tasks for the pipeline tasks
+        """
 
-        return rendered_task_defs, task_loading_blocks
+        rendered_task_defs: List[str] = render_task_definitions(
+            task_defs,
+            self.pipeline_name,
+            task_serialization=TaskSerializer.TmpDirPickle,
+            include_imports_locally=True,
+        )
+
+        return rendered_task_defs

--- a/lineapy/plugins/dvc_pipeline_writer.py
+++ b/lineapy/plugins/dvc_pipeline_writer.py
@@ -149,13 +149,10 @@ class DVCPipelineWriter(BasePipelineWriter):
 
         # use index to keep track of which rendered task should be written
         # since they are returned in the same order as the keys in task_defs
-        index = 0
-        for task_name, task_def in task_defs.items():
-            python_operator_code = rendered_task_defs[index]
-
+        for index, (task_name, task_def) in enumerate(task_defs.items()):
             stage_code = STAGE_TEMPLATE.render(
                 MODULE_NAME=f"{self.pipeline_name}_module",
-                TASK_CODE=python_operator_code,
+                TASK_CODE=rendered_task_defs[index],
                 task_name=task_name,
                 # DVC tasks read each input variable and cannot rely on DAG to provide them
                 # provide a list here for the main function body
@@ -166,5 +163,3 @@ class DVCPipelineWriter(BasePipelineWriter):
             python_operator_file = self.output_dir / filename
             python_operator_file.write_text(prettify(stage_code))
             logger.info(f"Generated DAG file: {python_operator_file}")
-
-            index += 1

--- a/lineapy/plugins/dvc_pipeline_writer.py
+++ b/lineapy/plugins/dvc_pipeline_writer.py
@@ -11,7 +11,6 @@ from lineapy.plugins.task import (
     TaskDefinition,
     TaskSerializer,
     render_task_definitions,
-    render_task_io_serialize_blocks,
 )
 from lineapy.plugins.taskgen import get_task_graph
 from lineapy.plugins.utils import load_plugin_template

--- a/lineapy/plugins/kubeflow_pipeline_writer.py
+++ b/lineapy/plugins/kubeflow_pipeline_writer.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from typing_extensions import TypedDict
 
@@ -10,7 +10,6 @@ from lineapy.plugins.task import (
     TaskDefinition,
     TaskSerializer,
     render_task_definitions,
-    render_task_io_serialize_blocks,
 )
 from lineapy.plugins.taskgen import (
     get_noop_setup_task_definition,

--- a/lineapy/plugins/taskgen.py
+++ b/lineapy/plugins/taskgen.py
@@ -220,7 +220,7 @@ def get_tmpdirpickle_setup_task_definition(pipeline_name):
         pipeline_name=pipeline_name
     )
     return TaskDefinition(
-        function_name="dag_setup",
+        function_name="setup",
         user_input_variables=[],
         loaded_input_variables=[],
         typing_blocks=[],
@@ -246,7 +246,7 @@ def get_tmpdir_teardown_task_definition(pipeline_name):
         pipeline_name=pipeline_name
     )
     return TaskDefinition(
-        function_name="dag_teardown",
+        function_name="teardown",
         user_input_variables=[],
         loaded_input_variables=[],
         typing_blocks=[],
@@ -266,7 +266,7 @@ def get_noop_setup_task_definition(pipeline_name):
     This task should be used at the beginning of a pipeline.
     """
     return TaskDefinition(
-        function_name="dag_setup",
+        function_name="setup",
         user_input_variables=[],
         loaded_input_variables=[],
         typing_blocks=[],
@@ -287,7 +287,7 @@ def get_noop_teardown_task_definition(pipeline_name):
 
     """
     return TaskDefinition(
-        function_name="dag_teardown",
+        function_name="teardown",
         user_input_variables=[],
         loaded_input_variables=[],
         typing_blocks=[],

--- a/tests/unit/plugins/framework_specific/airflow/__snapshots__/test_writer_airflow.ambr
+++ b/tests/unit/plugins/framework_specific/airflow/__snapshots__/test_writer_airflow.ambr
@@ -630,21 +630,6 @@
   from airflow.utils.dates import days_ago
   
   
-  def task_a0():
-  
-      a0 = airflow_pipeline_a0_b0_dependencies_module.get_a0()
-  
-      if (
-          not pathlib.Path("/tmp")
-          .joinpath("airflow_pipeline_a0_b0_dependencies")
-          .exists()
-      ):
-          pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
-      pickle.dump(
-          a0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_a0.pickle", "wb")
-      )
-  
-  
   def task_b0():
   
       b0 = airflow_pipeline_a0_b0_dependencies_module.get_b0()
@@ -657,6 +642,21 @@
           pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
       pickle.dump(
           b0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_b0.pickle", "wb")
+      )
+  
+  
+  def task_a0():
+  
+      a0 = airflow_pipeline_a0_b0_dependencies_module.get_a0()
+  
+      if (
+          not pathlib.Path("/tmp")
+          .joinpath("airflow_pipeline_a0_b0_dependencies")
+          .exists()
+      ):
+          pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
+      pickle.dump(
+          a0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_a0.pickle", "wb")
       )
   
   
@@ -785,19 +785,6 @@
   from airflow.utils.dates import days_ago
   
   
-  def task_a():
-  
-      b0 = pickle.load(
-          open("/tmp/airflow_pipeline_a_b0_inputpar/variable_b0.pickle", "rb")
-      )
-  
-      a = airflow_pipeline_a_b0_inputpar_module.get_a(b0)
-  
-      if not pathlib.Path("/tmp").joinpath("airflow_pipeline_a_b0_inputpar").exists():
-          pathlib.Path("/tmp").joinpath("airflow_pipeline_a_b0_inputpar").mkdir()
-      pickle.dump(a, open("/tmp/airflow_pipeline_a_b0_inputpar/variable_a.pickle", "wb"))
-  
-  
   def task_b0(b0):
   
       b0 = int(b0)
@@ -809,6 +796,19 @@
       pickle.dump(
           b0, open("/tmp/airflow_pipeline_a_b0_inputpar/variable_b0.pickle", "wb")
       )
+  
+  
+  def task_a():
+  
+      b0 = pickle.load(
+          open("/tmp/airflow_pipeline_a_b0_inputpar/variable_b0.pickle", "rb")
+      )
+  
+      a = airflow_pipeline_a_b0_inputpar_module.get_a(b0)
+  
+      if not pathlib.Path("/tmp").joinpath("airflow_pipeline_a_b0_inputpar").exists():
+          pathlib.Path("/tmp").joinpath("airflow_pipeline_a_b0_inputpar").mkdir()
+      pickle.dump(a, open("/tmp/airflow_pipeline_a_b0_inputpar/variable_a.pickle", "wb"))
   
   
   def task_setup():
@@ -961,6 +961,21 @@
       )
   
   
+  def task_y():
+  
+      assets = pickle.load(
+          open("/tmp/airflow_pipeline_housing_multiple/variable_assets.pickle", "rb")
+      )
+  
+      y = airflow_pipeline_housing_multiple_module.get_y(assets)
+  
+      if not pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_multiple").exists():
+          pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_multiple").mkdir()
+      pickle.dump(
+          y, open("/tmp/airflow_pipeline_housing_multiple/variable_y.pickle", "wb")
+      )
+  
+  
   def task_p_value():
   
       assets = pickle.load(
@@ -996,21 +1011,6 @@
       )
       for f in pickle_files:
           f.unlink()
-  
-  
-  def task_y():
-  
-      assets = pickle.load(
-          open("/tmp/airflow_pipeline_housing_multiple/variable_assets.pickle", "rb")
-      )
-  
-      y = airflow_pipeline_housing_multiple_module.get_y(assets)
-  
-      if not pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_multiple").exists():
-          pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_multiple").mkdir()
-      pickle.dump(
-          y, open("/tmp/airflow_pipeline_housing_multiple/variable_y.pickle", "wb")
-      )
   
   
   default_dag_args = {
@@ -1287,6 +1287,27 @@
       )
   
   
+  def task_y():
+  
+      assets = pickle.load(
+          open(
+              "/tmp/airflow_pipeline_housing_w_dependencies/variable_assets.pickle", "rb"
+          )
+      )
+  
+      y = airflow_pipeline_housing_w_dependencies_module.get_y(assets)
+  
+      if (
+          not pathlib.Path("/tmp")
+          .joinpath("airflow_pipeline_housing_w_dependencies")
+          .exists()
+      ):
+          pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_w_dependencies").mkdir()
+      pickle.dump(
+          y, open("/tmp/airflow_pipeline_housing_w_dependencies/variable_y.pickle", "wb")
+      )
+  
+  
   def task_p_value():
   
       assets = pickle.load(
@@ -1330,27 +1351,6 @@
       )
       for f in pickle_files:
           f.unlink()
-  
-  
-  def task_y():
-  
-      assets = pickle.load(
-          open(
-              "/tmp/airflow_pipeline_housing_w_dependencies/variable_assets.pickle", "rb"
-          )
-      )
-  
-      y = airflow_pipeline_housing_w_dependencies_module.get_y(assets)
-  
-      if (
-          not pathlib.Path("/tmp")
-          .joinpath("airflow_pipeline_housing_w_dependencies")
-          .exists()
-      ):
-          pathlib.Path("/tmp").joinpath("airflow_pipeline_housing_w_dependencies").mkdir()
-      pickle.dump(
-          y, open("/tmp/airflow_pipeline_housing_w_dependencies/variable_y.pickle", "wb")
-      )
   
   
   default_dag_args = {
@@ -2081,23 +2081,6 @@
   from airflow.utils.dates import days_ago
   
   
-  def task_run_session_including_a0():
-  
-      artifacts = airflow_pipeline_a0_b0_dependencies_module.run_session_including_a0()
-  
-      a0 = artifacts["a0"]
-  
-      if (
-          not pathlib.Path("/tmp")
-          .joinpath("airflow_pipeline_a0_b0_dependencies")
-          .exists()
-      ):
-          pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
-      pickle.dump(
-          a0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_a0.pickle", "wb")
-      )
-  
-  
   def task_run_session_including_b0():
   
       artifacts = airflow_pipeline_a0_b0_dependencies_module.run_session_including_b0()
@@ -2112,6 +2095,23 @@
           pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
       pickle.dump(
           b0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_b0.pickle", "wb")
+      )
+  
+  
+  def task_run_session_including_a0():
+  
+      artifacts = airflow_pipeline_a0_b0_dependencies_module.run_session_including_a0()
+  
+      a0 = artifacts["a0"]
+  
+      if (
+          not pathlib.Path("/tmp")
+          .joinpath("airflow_pipeline_a0_b0_dependencies")
+          .exists()
+      ):
+          pathlib.Path("/tmp").joinpath("airflow_pipeline_a0_b0_dependencies").mkdir()
+      pickle.dump(
+          a0, open("/tmp/airflow_pipeline_a0_b0_dependencies/variable_a0.pickle", "wb")
       )
   
   


### PR DESCRIPTION
# Description

Consolidate get_rendered_task_definitions to helper function in task.py

* Add `render_task_definitions` helper function which takes in generator functions for each code block (or else takes defaults) and renders the task template including generating the `task_serialization` block. 
* Change all pipeline integration frameworks to use this.

Fixes LIN-734

## Type of change

Please delete options that are not relevant.

- [X] Non-Breaking Refactor 

# How Has This Been Tested?

Assert that snapshot tests did not change. 
(Airflow tests have their tasks re-organized in a different order due the removal of a sort, but the file generated is still the same, 
