### PR TITLE
Platform 618 to pipeline returns pipeline object

### DIFF
--- a/.colab/01_using_artifacts.ipynb
+++ b/.colab/01_using_artifacts.ipynb
@@ -359,6 +359,8 @@
     }
    ],
    "source": [
+    "\n",
+    "\n",
     "# Plot petal length/width by iris type\n",
     "fig, ax = plt.subplots(1, 2, figsize=(10, 5))\n",
     "df.boxplot(\"petal.length\", \"variety\", ax=ax[0])\n",
@@ -985,9 +987,9 @@
  ],
  "metadata": {
   "colab": {
-    "collapsed_sections": [],
-    "name": "01_using_artifacts.ipynb",
-    "provenance": []
+   "collapsed_sections": [],
+   "name": "01_using_artifacts.ipynb",
+   "provenance": []
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ example using the [Iris dataset](https://en.wikipedia.org/wiki/Iris_flower_data_
 how to use LineaPy to 1) store a variable's history, 2) get its cleaned-up code,
 and 3) build an executable pipeline for the variable.
 
-The following development code fits a linear regression model to the Iris dataset:
+The following development code fits a linear regression model to the Iris dataset: 
 
 ```python
 import lineapy
@@ -191,6 +191,13 @@ mod.fit(
     X=df[["petal.width", "d_versicolor", "d_virginica"]],
     y=df["sepal.width"],
 )
+```
+
+Here, we've assumed you already have `pandas`, `matplotlib`, and `scikit-learn` installed in your environment. 
+If not, you can install these dependencies with the following code:
+
+```bash
+pip install pandas scikit-learn matplotlib
 ```
 
 Let's say you're happy with your above code, and you've decided to save the trained model. You can store the model as a LineaPy [artifact](https://docs.lineapy.org/latest/concepts/artifact/) with the following code:

--- a/docs/mkdocs/tutorials/01_using_artifacts.ipynb
+++ b/docs/mkdocs/tutorials/01_using_artifacts.ipynb
@@ -359,6 +359,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# Plot petal length/width by iris type\n",
     "fig, ax = plt.subplots(1, 2, figsize=(10, 5))\n",
     "df.boxplot(\"petal.length\", \"variety\", ax=ax[0])\n",
@@ -985,9 +987,9 @@
  ],
  "metadata": {
   "colab": {
-    "collapsed_sections": [],
-    "name": "01_using_artifacts.ipynb",
-    "provenance": []
+   "collapsed_sections": [],
+   "name": "01_using_artifacts.ipynb",
+   "provenance": []
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/tutorials/01_using_artifacts.ipynb
+++ b/examples/tutorials/01_using_artifacts.ipynb
@@ -359,6 +359,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# Plot petal length/width by iris type\n",
     "fig, ax = plt.subplots(1, 2, figsize=(10, 5))\n",
     "df.boxplot(\"petal.length\", \"variety\", ax=ax[0])\n",
@@ -985,9 +987,9 @@
  ],
  "metadata": {
   "colab": {
-    "collapsed_sections": [],
-    "name": "01_using_artifacts.ipynb",
-    "provenance": []
+   "collapsed_sections": [],
+   "name": "01_using_artifacts.ipynb",
+   "provenance": []
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/lineapy/api/api.py
+++ b/lineapy/api/api.py
@@ -5,7 +5,6 @@ User-facing APIs.
 import logging
 import warnings
 from datetime import datetime
-from pathlib import Path
 from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -384,7 +383,7 @@ def to_pipeline(
     generate_test: bool = False,
     pipeline_dag_config: Optional[Dict] = {},
     include_non_slice_as_comment: bool = False,
-) -> Path:
+) -> Pipeline:
     """
     Writes the pipeline job to a path on disk.
 
@@ -436,8 +435,8 @@ def to_pipeline(
 
     Returns
     -------
-    Path
-        Directory path where DAG and other pipeline files are saved.
+    Pipeline
+        Pipeline object
     """
     pipeline = Pipeline(
         artifacts=artifacts,
@@ -445,7 +444,7 @@ def to_pipeline(
         dependencies=dependencies,
     )
     pipeline.save()
-    return pipeline.export(
+    pipeline.export(
         framework=framework,
         output_dir=output_dir,
         input_parameters=input_parameters,
@@ -454,6 +453,7 @@ def to_pipeline(
         pipeline_dag_config=pipeline_dag_config,
         include_non_slice_as_comment=include_non_slice_as_comment,
     )
+    return pipeline
 
 
 def create_pipeline(

--- a/lineapy/api/models/pipeline.py
+++ b/lineapy/api/models/pipeline.py
@@ -51,6 +51,7 @@ class Pipeline:
 
         self.name = name or "_".join(artifact_safe_names)
         self.id = get_new_id()
+        self.output_dir = None
 
     def export(
         self,
@@ -107,6 +108,7 @@ class Pipeline:
             )
         )
 
+        self.output_dir = pipeline_writer.output_dir
         return pipeline_writer.output_dir
 
     def _get_artifact_collection(

--- a/tests/notebook/test_airflow.ipynb
+++ b/tests/notebook/test_airflow.ipynb
@@ -2,26 +2,10 @@
     "cells": [
         {
             "cell_type": "code",
-            "execution_count": 1,
-            "id": "3054022d-ea1b-4422-bd97-b323b72b0322",
-            "metadata": {
-                "tags": []
-            },
-            "outputs": [
-                {
-                    "ename": "RuntimeError",
-                    "evalue": "No context set. This could be because the LineaPy extension has not been loaded in your runtime environment. To load the extension, you need to launch your environment with the `lineapy` command, e.g., `lineapy jupyter notebook`. Or, to load the extension without relaunching the environment, execute `%load_ext lineapy` at the top of your session. Check https://docs.lineapy.org/latest/guides/setup/#running-lineapy#jupyter-and-ipython for more detailed instructions.",
-                    "output_type": "error",
-                    "traceback": [
-                        "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-                        "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-                        "\u001b[1;32m/home/veloce/Documents/lineapy/tests/notebook/test_airflow.ipynb Cell 1\u001b[0m in \u001b[0;36m<cell line: 8>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/veloce/Documents/lineapy/tests/notebook/test_airflow.ipynb#W0sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m y \u001b[39m=\u001b[39m \u001b[39m10\u001b[39m\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/veloce/Documents/lineapy/tests/notebook/test_airflow.ipynb#W0sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m z \u001b[39m=\u001b[39m [x]\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/veloce/Documents/lineapy/tests/notebook/test_airflow.ipynb#W0sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m art \u001b[39m=\u001b[39m lineapy\u001b[39m.\u001b[39;49msave(z, \u001b[39m\"\u001b[39;49m\u001b[39mz\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/veloce/Documents/lineapy/tests/notebook/test_airflow.ipynb#W0sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m pipeline_dir \u001b[39m=\u001b[39m lineapy\u001b[39m.\u001b[39mto_pipeline([art\u001b[39m.\u001b[39mname], framework\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mAIRFLOW\u001b[39m\u001b[39m'\u001b[39m, output_dir\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m~/airflow/dags\u001b[39m\u001b[39m\"\u001b[39m)\n",
-                        "File \u001b[0;32m~/Documents/lineapy/lineapy/api/api.py:89\u001b[0m, in \u001b[0;36msave\u001b[0;34m(reference, name, storage_backend, **kwargs)\u001b[0m\n\u001b[1;32m     53\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39msave\u001b[39m(\n\u001b[1;32m     54\u001b[0m     reference: \u001b[39mobject\u001b[39m,\n\u001b[1;32m     55\u001b[0m     name: \u001b[39mstr\u001b[39m,\n\u001b[1;32m     56\u001b[0m     storage_backend: Optional[ARTIFACT_STORAGE_BACKEND] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m     57\u001b[0m     \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs,\n\u001b[1;32m     58\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m LineaArtifact:\n\u001b[1;32m     59\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m     60\u001b[0m \u001b[39m    Publishes the object to the Linea DB.\u001b[39;00m\n\u001b[1;32m     61\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     87\u001b[0m \u001b[39m        information we have stored about the artifact (value, version), and other automation capabilities, such as :func:`to_pipeline`.\u001b[39;00m\n\u001b[1;32m     88\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 89\u001b[0m     execution_context \u001b[39m=\u001b[39m get_context()\n\u001b[1;32m     90\u001b[0m     executor \u001b[39m=\u001b[39m execution_context\u001b[39m.\u001b[39mexecutor\n\u001b[1;32m     91\u001b[0m     db \u001b[39m=\u001b[39m executor\u001b[39m.\u001b[39mdb\n",
-                        "File \u001b[0;32m~/Documents/lineapy/lineapy/execution/context.py:156\u001b[0m, in \u001b[0;36mget_context\u001b[0;34m()\u001b[0m\n\u001b[1;32m    154\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m _current_context:\n\u001b[1;32m    155\u001b[0m     track(ExceptionEvent(ErrorType\u001b[39m.\u001b[39mDATABASE, \u001b[39m\"\u001b[39m\u001b[39mNo context set\u001b[39m\u001b[39m\"\u001b[39m))\n\u001b[0;32m--> 156\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(NO_CONTEXT_ERROR_MESSAGE)\n\u001b[1;32m    158\u001b[0m \u001b[39mreturn\u001b[39;00m _current_context\n",
-                        "\u001b[0;31mRuntimeError\u001b[0m: No context set. This could be because the LineaPy extension has not been loaded in your runtime environment. To load the extension, you need to launch your environment with the `lineapy` command, e.g., `lineapy jupyter notebook`. Or, to load the extension without relaunching the environment, execute `%load_ext lineapy` at the top of your session. Check https://docs.lineapy.org/latest/guides/setup/#running-lineapy#jupyter-and-ipython for more detailed instructions."
-                    ]
-                }
-            ],
+            "execution_count": null,
+            "id": "489e7abe",
+            "metadata": {},
+            "outputs": [],
             "source": [
                 "# NBVAL_IGNORE_OUTPUT\n",
                 "import lineapy\n",
@@ -32,7 +16,8 @@
                 "\n",
                 "z = [x]\n",
                 "art = lineapy.save(z, \"z\")\n",
-                "pipeline_dir = lineapy.to_pipeline([art.name], framework='AIRFLOW', output_dir=\"~/airflow/dags\")"
+                "pipeline = lineapy.to_pipeline([art.name], framework='AIRFLOW', output_dir=\"~/airflow/dags\")\n",
+                "pipeline_dir = pipeline.output_dir"
             ]
         },
         {
@@ -87,7 +72,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.6"
+            "version": "3.8.10"
         },
         "vscode": {
             "interpreter": {

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -46,11 +46,11 @@ def airflow_py_module_path(run_cell, add_config):
     assert run_cell("import lineapy") is None
     assert run_cell("a = [1, 2, 3]\nres = lineapy.save(a, 'a')") is None
     if add_config:
-        to_pipeline_command = "lineapy.to_pipeline([res.name], framework='AIRFLOW', pipeline_name=res.name, output_dir='~/airflow/dags/', pipeline_dag_config={'retries': 1, 'schedule_interval': '*/30 * * * *'})"
+        to_pipeline_output = "lineapy.to_pipeline([res.name], framework='AIRFLOW', pipeline_name=res.name, output_dir='~/airflow/dags/', pipeline_dag_config={'retries': 1, 'schedule_interval': '*/30 * * * *'}).output_dir"
     else:
-        to_pipeline_command = "lineapy.to_pipeline([res.name], framework='AIRFLOW', pipeline_name=res.name, output_dir='~/airflow/dags/')"
+        to_pipeline_output = "lineapy.to_pipeline([res.name], framework='AIRFLOW', pipeline_name=res.name, output_dir='~/airflow/dags/').output_dir"
 
-    py_module_path = run_cell(to_pipeline_command)
+    py_module_path = run_cell(to_pipeline_output)
     yield py_module_path
     # cleanup since this tests creates files
     shutil.rmtree(py_module_path)


### PR DESCRIPTION
# Description

Make `to_pipeline` return `Pipeline` object

Fixes # (issue)

# How Has This Been Tested?

Fix existing `to_pipeline` related tests that rely on the `output_dif` and pass all of them.
